### PR TITLE
First Support for VE-Direct Hex messages

### DIFF
--- a/lib/VeDirectFrameHandler/VeDirectChargerController.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectChargerController.cpp
@@ -1,0 +1,14 @@
+#include <Arduino.h>
+#include "VeDirectChargerController.h"
+
+/*
+ * setBatteryCurrentLimit
+ * This function sets battery current limit. Don't call it in a loop because 
+ * Victron is writing battery current limit in non volatile memory.
+ */
+void VeDirectChargerController::setBatteryCurrentLimit(uint16_t batteryCurrentLimit)
+{
+	//uint16_t veBatCurrentLimit = batteryCurrentLimit * 10;
+	sendHexCommand(SET,BATTERY_MAXIMUM_CURRENT,DEFAULT_FLAG0, batteryCurrentLimit * 10);
+	_msgOut->printf("[Victron Charger] Set Victron batteryMaximumCurrent to %dA.\r\n",batteryCurrentLimit);
+}

--- a/lib/VeDirectFrameHandler/VeDirectChargerController.h
+++ b/lib/VeDirectFrameHandler/VeDirectChargerController.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <Arduino.h>
+#include "VeDirectFrameHandler.h"
+
+class VeDirectChargerController : public VeDirectFrameHandler {
+public:
+    void setBatteryCurrentLimit(uint16_t batteryCurrentLimit);
+};

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
@@ -19,6 +19,32 @@
 #define VE_MAX_VALUE_LEN 33 // VE.Direct Protocol: max value size is 33 including /0
 #define VE_MAX_HEX_LEN 100 // Maximum size of hex frame - max payload 34 byte (=68 char) + safe buffer
 
+
+// hex commands
+enum VeDirectHexCommand {
+    ENTER_BOOT = 0x00,
+    PING = 0x01,
+    APP_VERSION = 0x02,
+    PRODUCT_ID = 0x04,
+    RESTART = 0x06,
+    GET = 0x07,
+    SET = 0x08,
+    ASYNC = 0x0A
+};
+
+// hex ids
+enum VeDirectHexId {
+    BATTERY_MAXIMUM_CURRENT = 0xEDF0,
+    CHARGER_MAXIMUM_CURRENT = 0xEDDF,
+    CHARGER_CURRENT = 0xEDD7,
+    CHARGER_VOLTAGE = 0xEDD5,
+    CHARGER_ERROR_CODE = 0xEDDA,
+};
+
+enum VeDirectFlag {
+    DEFAULT_FLAG0 = 0x00,
+};
+
 class VeDirectFrameHandler {
 public:
     VeDirectFrameHandler();
@@ -30,7 +56,6 @@ protected:
     bool _verboseLogging;
     Print* _msgOut;
     uint32_t _lastUpdate;
-
     typedef struct {
         uint16_t PID = 0;               // product id
         char SER[VE_MAX_VALUE_LEN];     // serial number
@@ -42,6 +67,7 @@ protected:
         String getPidAsString() const;  // product id as string
     } veStruct;
 
+    void sendHexCommand(VeDirectHexCommand cmd, VeDirectHexId id, VeDirectFlag flag, uint16_t value);
     bool textRxEvent(std::string const& who, char* name, char* value, veStruct& frame);
     bool isDataValid(veStruct const& frame) const;      // return true if data valid and not outdated
 
@@ -55,13 +81,14 @@ private:
     virtual void textRxEvent(char *, char *) = 0;
     virtual void frameValidEvent() = 0;
     int hexRxEvent(uint8_t);
-
+    
     std::unique_ptr<HardwareSerial> _vedirectSerial;
     int _state;                                // current state
     int _prevState;                            // previous state
     uint8_t _checksum;                         // checksum value
     char * _textPointer;                       // pointer to the private buffer we're writing to, name or value
-    int _hexSize;                               // length of hex buffer
+    int _hexSize;                              // length of hex buffer
+    char _hexBuffer[VE_MAX_HEX_LEN] = { };	   // buffer for received hex frames
     char _name[VE_MAX_VALUE_LEN];              // buffer for the field name
     char _value[VE_MAX_VALUE_LEN];             // buffer for the field value
     std::array<uint8_t, 512> _debugBuffer;

--- a/lib/VeDirectFrameHandler/VeDirectMpptController.h
+++ b/lib/VeDirectFrameHandler/VeDirectMpptController.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Arduino.h>
-#include "VeDirectFrameHandler.h"
+#include "VeDirectChargerController.h"
 
 template<typename T, size_t WINDOW_SIZE>
 class MovingAverage {
@@ -35,7 +35,7 @@ private:
     size_t _count;
 };
 
-class VeDirectMpptController : public VeDirectFrameHandler {
+class VeDirectMpptController : public VeDirectChargerController {
 public:
     VeDirectMpptController() = default;
 


### PR DESCRIPTION
This is some initial base work for both https://github.com/helgeerbe/OpenDTU-OnBattery/issues/470 and https://github.com/helgeerbe/OpenDTU-OnBattery/issues/436 to make further development of the two issues independent. 

It does two things:

1. Initial support for sending VE-Direct Hex commands (thanks to @Jamo523). Also received Hex messages are checked for a valid checksum, but not yet further handled.
2. An additional class VeDirectChargerController is introduced which is the new base class for VeDirectMpptController. The idea is to include all code here which is shared between a MPPT charger and a Victron AC Charger. It did not yet add this new class to this PR yet as its is mostly empty for now.