### PR TITLE
TaskScheduler tasks with limited lifespans

### DIFF
--- a/include/Battery.h
+++ b/include/Battery.h
@@ -14,7 +14,6 @@ class BatteryProvider {
         virtual bool init(bool verboseLogging) = 0;
 
         virtual void deinit() = 0;
-        virtual void loop() = 0;
         virtual std::shared_ptr<BatteryStats> getStats() const = 0;
 };
 
@@ -25,11 +24,10 @@ class BatteryClass {
 
         std::shared_ptr<BatteryStats const> getStats() const;
     private:
-        void loop();
+        void mqttPublish();
 
-        Task _loopTask;
+        Task _mqttPublishTask;
 
-        uint32_t _lastMqttPublish = 0;
         mutable std::mutex _mutex;
         std::unique_ptr<BatteryProvider> _upProvider = nullptr;
 };

--- a/include/JkBmsController.h
+++ b/include/JkBmsController.h
@@ -2,7 +2,7 @@
 
 #include <memory>
 #include <vector>
-#include <frozen/string.h>
+#include <TaskSchedulerDeclarations.h>
 
 #include "Battery.h"
 #include "JkBmsSerialMessage.h"
@@ -17,7 +17,6 @@ class Controller : public BatteryProvider {
 
         bool init(bool verboseLogging) final;
         void deinit() final;
-        void loop() final;
         std::shared_ptr<BatteryStats> getStats() const final { return _stats; }
 
     private:
@@ -31,9 +30,8 @@ class Controller : public BatteryProvider {
             FrameCompleted
         };
 
-        frozen::string const& getStatusText(Status status);
-        void announceStatus(Status status);
-        void sendRequest(uint8_t pollInterval);
+        void send();
+        void receive();
         void rxData(uint8_t inbyte);
         void reset();
         void frameComplete();
@@ -60,12 +58,11 @@ class Controller : public BatteryProvider {
             _readState = state;
         }
 
+        Task _sendTask;
+        Task _receiveTask;
         bool _verboseLogging = true;
         int8_t _rxEnablePin = -1;
         int8_t _txEnablePin = -1;
-        Status _lastStatus = Status::Initializing;
-        uint32_t _lastStatusPrinted = 0;
-        uint32_t _lastRequest = 0;
         uint16_t _frameLength = 0;
         uint8_t _protocolVersion = -1;
         SerialResponse::tData _buffer = {};

--- a/include/MqttBattery.h
+++ b/include/MqttBattery.h
@@ -9,7 +9,6 @@ class MqttBattery : public BatteryProvider {
 
         bool init(bool verboseLogging) final;
         void deinit() final;
-        void loop() final { return; } // this class is event-driven
         std::shared_ptr<BatteryStats> getStats() const final { return _stats; }
 
     private:

--- a/include/PylontechCanReceiver.h
+++ b/include/PylontechCanReceiver.h
@@ -3,6 +3,7 @@
 
 #include "Configuration.h"
 #include "Battery.h"
+#include <TaskSchedulerDeclarations.h>
 #include <espMqttClient.h>
 #include <driver/twai.h>
 #include <Arduino.h>
@@ -12,10 +13,10 @@ class PylontechCanReceiver : public BatteryProvider {
 public:
     bool init(bool verboseLogging) final;
     void deinit() final;
-    void loop() final;
     std::shared_ptr<BatteryStats> getStats() const final { return _stats; }
 
 private:
+    void loop();
     uint16_t readUnsignedInt16(uint8_t *data);
     int16_t readSignedInt16(uint8_t *data);
     float scaleValue(int16_t value, float factor);
@@ -23,6 +24,7 @@ private:
 
     void dummyData();
 
+    Task _loopTask;
     bool _verboseLogging = true;
     std::shared_ptr<PylontechBatteryStats> _stats =
         std::make_shared<PylontechBatteryStats>();

--- a/include/VictronSmartShunt.h
+++ b/include/VictronSmartShunt.h
@@ -7,10 +7,12 @@ class VictronSmartShunt : public BatteryProvider {
 public:
     bool init(bool verboseLogging) final;
     void deinit() final { }
-    void loop() final;
     std::shared_ptr<BatteryStats> getStats() const final { return _stats; }
 
 private:
+    void loop();
+
+    Task _loopTask;
     std::shared_ptr<VictronSmartShuntStats> _stats =
         std::make_shared<VictronSmartShuntStats>();
 };

--- a/src/PylontechCanReceiver.cpp
+++ b/src/PylontechCanReceiver.cpp
@@ -3,6 +3,7 @@
 #include "Configuration.h"
 #include "MessageOutput.h"
 #include "PinMapping.h"
+#include "Scheduler.h"
 #include <driver/twai.h>
 #include <ctime>
 
@@ -62,6 +63,11 @@ bool PylontechCanReceiver::init(bool verboseLogging)
             return false;
             break;
     }
+
+    scheduler.addTask(_loopTask);
+    _loopTask.setCallback(std::bind(&PylontechCanReceiver::loop, this));
+    _loopTask.setIterations(TASK_FOREVER);
+    _loopTask.enable();
 
     return true;
 }

--- a/src/VictronSmartShunt.cpp
+++ b/src/VictronSmartShunt.cpp
@@ -2,6 +2,7 @@
 #include "VictronSmartShunt.h"
 #include "Configuration.h"
 #include "PinMapping.h"
+#include "Scheduler.h"
 #include "MessageOutput.h"
 
 
@@ -22,6 +23,13 @@ bool VictronSmartShunt::init(bool verboseLogging)
     auto rx = static_cast<gpio_num_t>(pin.battery_rx);
 
     VeDirectShunt.init(rx, tx, &MessageOutput, verboseLogging);
+
+    scheduler.addTask(_loopTask);
+    _loopTask.setCallback(std::bind(&VictronSmartShunt::loop, this));
+    _loopTask.setIterations(TASK_FOREVER);
+    _loopTask.setInterval(100 * TASK_MILLISECOND);
+    _loopTask.enable();
+
     return true;
 }
 


### PR DESCRIPTION
@tbnobody This might have information that could be helpful to the upstream project and I would appreciate your opinion on this matter.

This is an attempt to use TaskScheduler tasks with a particular interval. In general, this works. In this case, the `BatteryClass` MQTT publish task works as expected: It is executed in the expected interval.

I would really like to extend this approach to all classes that need to execute work regularly. In particular, this would allow for simplifications based on the knowledge that a particular function is executed at a particular interval. See the changes in the `JkBms::Controller` class, where a sender and receiver task are supposed to be used and where the receiver task is only enabled when needed, allowing for a better overall approach to tackle some of the problems that arise if the loop task was executed with high frequency.

Unfortunately, the `JkBms::Controller` tasks don't even execute once. I don't yet understand why that is. The difference here is that the task instances are constructed "dynamically", i.e., once the main loop is executing. The idea is that only the specific battery provider that is needed is constructed at all, and some may need no task, another needs one, another needs two.

What I do understand is that even though I made @tbnobody define `_TASK_THREAD_SAFE` for the TaskScheduler library, the whole library is really **not at all** thread-safe. This is something that I realized after I actually looked at the code. In particular, adding a task to the scheduler while a scheduler pass is active is simply unsupported. Adding does not lead to serious problems, I guess, but deleting a task whose instance then is freed definitely does: There is no guarantee whatsoever that TaskScheduler does not try to load/execute a task in the chain that was previously deleted. If the task was also freed, this leads to a memory access violation:

```
0x420418c7: Scheduler::execute() at /home/schlimmchen/Documents/OpenDTU-OnBattery/.pio/libdeps/opendtufusionv2/TaskScheduler/src/TaskScheduler.h:1401
 (inlined by) Scheduler::execute() at /home/schlimmchen/Documents/OpenDTU-OnBattery/.pio/libdeps/opendtufusionv2/TaskScheduler/src/TaskScheduler.h:1339
0x42041972: loop() at /home/schlimmchen/Documents/OpenDTU-OnBattery/src/main.cpp:191
0x42069ee5: loopTask(void*) at /home/schlimmchen/.platformio/packages/framework-arduinoespressif32/cores/esp32/main.cpp:50
```

I am confident that the whole TaskScheduler is not made to handle task objects with limited lifespan. And that is very disappointing.

Ideas:
1. Find or create and maintain a fork of TaskScheduler that actually is thread-safe and which does support tasks with limited lifetimes.
2. Create some sort of shim, like "DynamicTaskScheduler", for OpenDTU(-OnBattery) which allows class instances to die freely that somehow use a task, and which performs cleanup (removing the task from the TaskScheduler chain) **outside** of the scheduler pass once the task is no longer needed. This could use some sort of reference counting, like attaching the task instance to a `std::shared_ptr` and once there is only once reference (in the DynamicTaskScheduler), the task ist deleted from the chain and is freed.
3. Create static instances of a task.

Assessment:
1. I would love to go this route. The TaskScheduler has a lot of potential, but it needs some more love. Real thread-safety and allowing tasks to die would unlock some of the potential. However, I am unsure if it is doable with a reasonable amount of work and whether or not @helgeerbe and/or @tbnobody would even have interest in those features.
2. This sounds doable, but also sounds like **a lot** of overhead.
3. Not really an option. At least not an attractive one. Dying classes that use static tasks still need to make sure to disable the task in their constructor. They also would need to set a new static do-nothing callback method, simply because they do not know whether or not the task will be executed once more or not. At least not if the respective class instance dies in the context of another thread, like when a web app request changes the settings of the Battery interface.

Thank you very much if you made it through this wall of text :see_no_evil: @helgeerbe What's your feeling about this? The changeset of this PR might give you an idea of the potential that I am talking about.