### PR TITLE
[DPL] Overscaling: Support for HMT inverters

### DIFF
--- a/lib/Hoymiles/src/inverters/HERF_1CH.cpp
+++ b/lib/Hoymiles/src/inverters/HERF_1CH.cpp
@@ -29,6 +29,10 @@ static const byteAssign_t byteAssignment[] = {
     { TYPE_INV, CH0, FLD_EFF, UNIT_PCT, CALC_TOTAL_EFF, 0, CMD_CALC, false, 3 }
 };
 
+static const channelMetaData_t channelMetaData[] = {
+    { CH0, MPPT_A }
+};
+
 HERF_1CH::HERF_1CH(HoymilesRadio* radio, const uint64_t serial)
     : HM_Abstract(radio, serial) {};
 
@@ -52,4 +56,14 @@ const byteAssign_t* HERF_1CH::getByteAssignment() const
 uint8_t HERF_1CH::getByteAssignmentSize() const
 {
     return sizeof(byteAssignment) / sizeof(byteAssignment[0]);
+}
+
+const channelMetaData_t* HERF_1CH::getChannelMetaData() const
+{
+    return channelMetaData;
+}
+
+uint8_t HERF_1CH::getChannelMetaDataSize() const
+{
+    return sizeof(channelMetaData) / sizeof(channelMetaData[0]);
 }

--- a/lib/Hoymiles/src/inverters/HERF_1CH.h
+++ b/lib/Hoymiles/src/inverters/HERF_1CH.h
@@ -10,4 +10,6 @@ public:
     String typeName() const;
     const byteAssign_t* getByteAssignment() const;
     uint8_t getByteAssignmentSize() const;
+    const channelMetaData_t* getChannelMetaData() const;
+    uint8_t getChannelMetaDataSize() const;
 };

--- a/lib/Hoymiles/src/inverters/HERF_2CH.cpp
+++ b/lib/Hoymiles/src/inverters/HERF_2CH.cpp
@@ -36,6 +36,11 @@ static const byteAssign_t byteAssignment[] = {
     { TYPE_INV, CH0, FLD_EFF, UNIT_PCT, CALC_TOTAL_EFF, 0, CMD_CALC, false, 3 }
 };
 
+static const channelMetaData_t channelMetaData[] = {
+    { CH0, MPPT_A },
+    { CH1, MPPT_B }
+};
+
 HERF_2CH::HERF_2CH(HoymilesRadio* radio, const uint64_t serial)
     : HM_Abstract(radio, serial) {};
 
@@ -59,4 +64,14 @@ const byteAssign_t* HERF_2CH::getByteAssignment() const
 uint8_t HERF_2CH::getByteAssignmentSize() const
 {
     return sizeof(byteAssignment) / sizeof(byteAssignment[0]);
+}
+
+const channelMetaData_t* HERF_2CH::getChannelMetaData() const
+{
+    return channelMetaData;
+}
+
+uint8_t HERF_2CH::getChannelMetaDataSize() const
+{
+    return sizeof(channelMetaData) / sizeof(channelMetaData[0]);
 }

--- a/lib/Hoymiles/src/inverters/HERF_2CH.h
+++ b/lib/Hoymiles/src/inverters/HERF_2CH.h
@@ -10,4 +10,6 @@ public:
     String typeName() const;
     const byteAssign_t* getByteAssignment() const;
     uint8_t getByteAssignmentSize() const;
+    const channelMetaData_t* getChannelMetaData() const;
+    uint8_t getChannelMetaDataSize() const;
 };

--- a/lib/Hoymiles/src/inverters/HMS_1CH.cpp
+++ b/lib/Hoymiles/src/inverters/HMS_1CH.cpp
@@ -28,6 +28,10 @@ static const byteAssign_t byteAssignment[] = {
     { TYPE_INV, CH0, FLD_EFF, UNIT_PCT, CALC_TOTAL_EFF, 0, CMD_CALC, false, 3 }
 };
 
+static const channelMetaData_t channelMetaData[] = {
+    { CH0, MPPT_A }
+};
+
 HMS_1CH::HMS_1CH(HoymilesRadio* radio, const uint64_t serial)
     : HMS_Abstract(radio, serial) {};
 
@@ -51,4 +55,14 @@ const byteAssign_t* HMS_1CH::getByteAssignment() const
 uint8_t HMS_1CH::getByteAssignmentSize() const
 {
     return sizeof(byteAssignment) / sizeof(byteAssignment[0]);
+}
+
+const channelMetaData_t* HMS_1CH::getChannelMetaData() const
+{
+    return channelMetaData;
+}
+
+uint8_t HMS_1CH::getChannelMetaDataSize() const
+{
+    return sizeof(channelMetaData) / sizeof(channelMetaData[0]);
 }

--- a/lib/Hoymiles/src/inverters/HMS_1CH.h
+++ b/lib/Hoymiles/src/inverters/HMS_1CH.h
@@ -11,4 +11,6 @@ public:
     String typeName() const;
     const byteAssign_t* getByteAssignment() const;
     uint8_t getByteAssignmentSize() const;
+    const channelMetaData_t* getChannelMetaData() const;
+    uint8_t getChannelMetaDataSize() const;
 };

--- a/lib/Hoymiles/src/inverters/HMS_1CHv2.cpp
+++ b/lib/Hoymiles/src/inverters/HMS_1CHv2.cpp
@@ -28,6 +28,10 @@ static const byteAssign_t byteAssignment[] = {
     { TYPE_INV, CH0, FLD_EFF, UNIT_PCT, CALC_TOTAL_EFF, 0, CMD_CALC, false, 3 }
 };
 
+static const channelMetaData_t channelMetaData[] = {
+    { CH0, MPPT_A }
+};
+
 HMS_1CHv2::HMS_1CHv2(HoymilesRadio* radio, const uint64_t serial)
     : HMS_Abstract(radio, serial) {};
 
@@ -51,4 +55,14 @@ const byteAssign_t* HMS_1CHv2::getByteAssignment() const
 uint8_t HMS_1CHv2::getByteAssignmentSize() const
 {
     return sizeof(byteAssignment) / sizeof(byteAssignment[0]);
+}
+
+const channelMetaData_t* HMS_1CHv2::getChannelMetaData() const
+{
+    return channelMetaData;
+}
+
+uint8_t HMS_1CHv2::getChannelMetaDataSize() const
+{
+    return sizeof(channelMetaData) / sizeof(channelMetaData[0]);
 }

--- a/lib/Hoymiles/src/inverters/HMS_1CHv2.h
+++ b/lib/Hoymiles/src/inverters/HMS_1CHv2.h
@@ -11,4 +11,6 @@ public:
     String typeName() const;
     const byteAssign_t* getByteAssignment() const;
     uint8_t getByteAssignmentSize() const;
+    const channelMetaData_t* getChannelMetaData() const;
+    uint8_t getChannelMetaDataSize() const;
 };

--- a/lib/Hoymiles/src/inverters/HMS_2CH.cpp
+++ b/lib/Hoymiles/src/inverters/HMS_2CH.cpp
@@ -35,6 +35,11 @@ static const byteAssign_t byteAssignment[] = {
     { TYPE_INV, CH0, FLD_EFF, UNIT_PCT, CALC_TOTAL_EFF, 0, CMD_CALC, false, 3 }
 };
 
+static const channelMetaData_t channelMetaData[] = {
+    { CH0, MPPT_A },
+    { CH1, MPPT_B }
+};
+
 HMS_2CH::HMS_2CH(HoymilesRadio* radio, const uint64_t serial)
     : HMS_Abstract(radio, serial) {};
 
@@ -58,4 +63,14 @@ const byteAssign_t* HMS_2CH::getByteAssignment() const
 uint8_t HMS_2CH::getByteAssignmentSize() const
 {
     return sizeof(byteAssignment) / sizeof(byteAssignment[0]);
+}
+
+const channelMetaData_t* HMS_2CH::getChannelMetaData() const
+{
+    return channelMetaData;
+}
+
+uint8_t HMS_2CH::getChannelMetaDataSize() const
+{
+    return sizeof(channelMetaData) / sizeof(channelMetaData[0]);
 }

--- a/lib/Hoymiles/src/inverters/HMS_2CH.h
+++ b/lib/Hoymiles/src/inverters/HMS_2CH.h
@@ -11,4 +11,6 @@ public:
     String typeName() const;
     const byteAssign_t* getByteAssignment() const;
     uint8_t getByteAssignmentSize() const;
+    const channelMetaData_t* getChannelMetaData() const;
+    uint8_t getChannelMetaDataSize() const;
 };

--- a/lib/Hoymiles/src/inverters/HMS_4CH.cpp
+++ b/lib/Hoymiles/src/inverters/HMS_4CH.cpp
@@ -49,6 +49,13 @@ static const byteAssign_t byteAssignment[] = {
     { TYPE_INV, CH0, FLD_EFF, UNIT_PCT, CALC_TOTAL_EFF, 0, CMD_CALC, false, 3 }
 };
 
+static const channelMetaData_t channelMetaData[] = {
+    { CH0, MPPT_A },
+    { CH1, MPPT_B },
+    { CH2, MPPT_C },
+    { CH3, MPPT_D }
+};
+
 HMS_4CH::HMS_4CH(HoymilesRadio* radio, const uint64_t serial)
     : HMS_Abstract(radio, serial) {};
 
@@ -72,4 +79,14 @@ const byteAssign_t* HMS_4CH::getByteAssignment() const
 uint8_t HMS_4CH::getByteAssignmentSize() const
 {
     return sizeof(byteAssignment) / sizeof(byteAssignment[0]);
+}
+
+const channelMetaData_t* HMS_4CH::getChannelMetaData() const
+{
+    return channelMetaData;
+}
+
+uint8_t HMS_4CH::getChannelMetaDataSize() const
+{
+    return sizeof(channelMetaData) / sizeof(channelMetaData[0]);
 }

--- a/lib/Hoymiles/src/inverters/HMS_4CH.h
+++ b/lib/Hoymiles/src/inverters/HMS_4CH.h
@@ -10,4 +10,6 @@ public:
     String typeName() const;
     const byteAssign_t* getByteAssignment() const;
     uint8_t getByteAssignmentSize() const;
+    const channelMetaData_t* getChannelMetaData() const;
+    uint8_t getChannelMetaDataSize() const;
 };

--- a/lib/Hoymiles/src/inverters/HMT_4CH.cpp
+++ b/lib/Hoymiles/src/inverters/HMT_4CH.cpp
@@ -58,6 +58,13 @@ static const byteAssign_t byteAssignment[] = {
     { TYPE_INV, CH0, FLD_EFF, UNIT_PCT, CALC_TOTAL_EFF, 0, CMD_CALC, false, 3 }
 };
 
+static const channelMetaData_t channelMetaData[] = {
+    { CH0, MPPT_A },
+    { CH1, MPPT_A },
+    { CH2, MPPT_B },
+    { CH3, MPPT_B }
+};
+
 HMT_4CH::HMT_4CH(HoymilesRadio* radio, const uint64_t serial)
     : HMT_Abstract(radio, serial) {};
 
@@ -81,4 +88,14 @@ const byteAssign_t* HMT_4CH::getByteAssignment() const
 uint8_t HMT_4CH::getByteAssignmentSize() const
 {
     return sizeof(byteAssignment) / sizeof(byteAssignment[0]);
+}
+
+const channelMetaData_t* HMT_4CH::getChannelMetaData() const
+{
+    return channelMetaData;
+}
+
+uint8_t HMT_4CH::getChannelMetaDataSize() const
+{
+    return sizeof(channelMetaData) / sizeof(channelMetaData[0]);
 }

--- a/lib/Hoymiles/src/inverters/HMT_4CH.h
+++ b/lib/Hoymiles/src/inverters/HMT_4CH.h
@@ -10,4 +10,6 @@ public:
     String typeName() const;
     const byteAssign_t* getByteAssignment() const;
     uint8_t getByteAssignmentSize() const;
+    const channelMetaData_t* getChannelMetaData() const;
+    uint8_t getChannelMetaDataSize() const;
 };

--- a/lib/Hoymiles/src/inverters/HMT_6CH.cpp
+++ b/lib/Hoymiles/src/inverters/HMT_6CH.cpp
@@ -72,6 +72,15 @@ static const byteAssign_t byteAssignment[] = {
     { TYPE_INV, CH0, FLD_EFF, UNIT_PCT, CALC_TOTAL_EFF, 0, CMD_CALC, false, 3 }
 };
 
+static const channelMetaData_t channelMetaData[] = {
+    { CH0, MPPT_A },
+    { CH1, MPPT_A },
+    { CH2, MPPT_B },
+    { CH3, MPPT_B },
+    { CH4, MPPT_C },
+    { CH5, MPPT_C }
+};
+
 HMT_6CH::HMT_6CH(HoymilesRadio* radio, const uint64_t serial)
     : HMT_Abstract(radio, serial) {};
 
@@ -95,4 +104,14 @@ const byteAssign_t* HMT_6CH::getByteAssignment() const
 uint8_t HMT_6CH::getByteAssignmentSize() const
 {
     return sizeof(byteAssignment) / sizeof(byteAssignment[0]);
+}
+
+const channelMetaData_t* HMT_6CH::getChannelMetaData() const
+{
+    return channelMetaData;
+}
+
+uint8_t HMT_6CH::getChannelMetaDataSize() const
+{
+    return sizeof(channelMetaData) / sizeof(channelMetaData[0]);
 }

--- a/lib/Hoymiles/src/inverters/HMT_6CH.h
+++ b/lib/Hoymiles/src/inverters/HMT_6CH.h
@@ -10,4 +10,6 @@ public:
     String typeName() const;
     const byteAssign_t* getByteAssignment() const;
     uint8_t getByteAssignmentSize() const;
+    const channelMetaData_t* getChannelMetaData() const;
+    uint8_t getChannelMetaDataSize() const;
 };

--- a/lib/Hoymiles/src/inverters/HM_1CH.cpp
+++ b/lib/Hoymiles/src/inverters/HM_1CH.cpp
@@ -28,6 +28,10 @@ static const byteAssign_t byteAssignment[] = {
     { TYPE_INV, CH0, FLD_EFF, UNIT_PCT, CALC_TOTAL_EFF, 0, CMD_CALC, false, 3 }
 };
 
+static const channelMetaData_t channelMetaData[] = {
+    { CH0, MPPT_A }
+};
+
 HM_1CH::HM_1CH(HoymilesRadio* radio, const uint64_t serial)
     : HM_Abstract(radio, serial) {};
 
@@ -64,4 +68,14 @@ const byteAssign_t* HM_1CH::getByteAssignment() const
 uint8_t HM_1CH::getByteAssignmentSize() const
 {
     return sizeof(byteAssignment) / sizeof(byteAssignment[0]);
+}
+
+const channelMetaData_t* HM_1CH::getChannelMetaData() const
+{
+    return channelMetaData;
+}
+
+uint8_t HM_1CH::getChannelMetaDataSize() const
+{
+    return sizeof(channelMetaData) / sizeof(channelMetaData[0]);
 }

--- a/lib/Hoymiles/src/inverters/HM_1CH.h
+++ b/lib/Hoymiles/src/inverters/HM_1CH.h
@@ -11,4 +11,6 @@ public:
     String typeName() const;
     const byteAssign_t* getByteAssignment() const;
     uint8_t getByteAssignmentSize() const;
+    const channelMetaData_t* getChannelMetaData() const;
+    uint8_t getChannelMetaDataSize() const;
 };

--- a/lib/Hoymiles/src/inverters/HM_2CH.cpp
+++ b/lib/Hoymiles/src/inverters/HM_2CH.cpp
@@ -36,6 +36,11 @@ static const byteAssign_t byteAssignment[] = {
     { TYPE_INV, CH0, FLD_EFF, UNIT_PCT, CALC_TOTAL_EFF, 0, CMD_CALC, false, 3 }
 };
 
+static const channelMetaData_t channelMetaData[] = {
+    { CH0, MPPT_A },
+    { CH1, MPPT_B }
+};
+
 HM_2CH::HM_2CH(HoymilesRadio* radio, const uint64_t serial)
     : HM_Abstract(radio, serial) {};
 
@@ -72,4 +77,14 @@ const byteAssign_t* HM_2CH::getByteAssignment() const
 uint8_t HM_2CH::getByteAssignmentSize() const
 {
     return sizeof(byteAssignment) / sizeof(byteAssignment[0]);
+}
+
+const channelMetaData_t* HM_2CH::getChannelMetaData() const
+{
+    return channelMetaData;
+}
+
+uint8_t HM_2CH::getChannelMetaDataSize() const
+{
+    return sizeof(channelMetaData) / sizeof(channelMetaData[0]);
 }

--- a/lib/Hoymiles/src/inverters/HM_2CH.h
+++ b/lib/Hoymiles/src/inverters/HM_2CH.h
@@ -10,4 +10,6 @@ public:
     String typeName() const;
     const byteAssign_t* getByteAssignment() const;
     uint8_t getByteAssignmentSize() const;
+    const channelMetaData_t* getChannelMetaData() const;
+    uint8_t getChannelMetaDataSize() const;
 };

--- a/lib/Hoymiles/src/inverters/HM_4CH.cpp
+++ b/lib/Hoymiles/src/inverters/HM_4CH.cpp
@@ -49,6 +49,13 @@ static const byteAssign_t byteAssignment[] = {
     { TYPE_INV, CH0, FLD_EFF, UNIT_PCT, CALC_TOTAL_EFF, 0, CMD_CALC, false, 3 }
 };
 
+static const channelMetaData_t channelMetaData[] = {
+    { CH0, MPPT_A },
+    { CH1, MPPT_A },
+    { CH2, MPPT_B },
+    { CH3, MPPT_B }
+};
+
 HM_4CH::HM_4CH(HoymilesRadio* radio, const uint64_t serial)
     : HM_Abstract(radio, serial) {};
 
@@ -85,4 +92,14 @@ const byteAssign_t* HM_4CH::getByteAssignment() const
 uint8_t HM_4CH::getByteAssignmentSize() const
 {
     return sizeof(byteAssignment) / sizeof(byteAssignment[0]);
+}
+
+const channelMetaData_t* HM_4CH::getChannelMetaData() const
+{
+    return channelMetaData;
+}
+
+uint8_t HM_4CH::getChannelMetaDataSize() const
+{
+    return sizeof(channelMetaData) / sizeof(channelMetaData[0]);
 }

--- a/lib/Hoymiles/src/inverters/HM_4CH.h
+++ b/lib/Hoymiles/src/inverters/HM_4CH.h
@@ -10,4 +10,6 @@ public:
     String typeName() const;
     const byteAssign_t* getByteAssignment() const;
     uint8_t getByteAssignmentSize() const;
+    const channelMetaData_t* getChannelMetaData() const;
+    uint8_t getChannelMetaDataSize() const;
 };

--- a/lib/Hoymiles/src/inverters/InverterAbstract.cpp
+++ b/lib/Hoymiles/src/inverters/InverterAbstract.cpp
@@ -299,7 +299,7 @@ void InverterAbstract::resetRadioStats()
     RadioStats = {};
 }
 
-std::vector<ChannelNum_t> InverterAbstract::getChannels() const
+std::vector<ChannelNum_t> InverterAbstract::getChannelsDC() const
 {
     std::vector<ChannelNum_t> l;
     for (uint8_t i = 0; i < getChannelMetaDataSize(); i++) {
@@ -320,7 +320,7 @@ std::vector<MpptNum_t> InverterAbstract::getMppts() const
     return l;
 }
 
-std::vector<ChannelNum_t> InverterAbstract::getChannelsByMppt(const MpptNum_t mppt) const
+std::vector<ChannelNum_t> InverterAbstract::getChannelsDCByMppt(const MpptNum_t mppt) const
 {
     std::vector<ChannelNum_t> l;
     for (uint8_t i = 0; i < getChannelMetaDataSize(); i++) {

--- a/lib/Hoymiles/src/inverters/InverterAbstract.cpp
+++ b/lib/Hoymiles/src/inverters/InverterAbstract.cpp
@@ -298,3 +298,35 @@ void InverterAbstract::resetRadioStats()
 {
     RadioStats = {};
 }
+
+std::vector<ChannelNum_t> InverterAbstract::getChannels() const
+{
+    std::vector<ChannelNum_t> l;
+    for (uint8_t i = 0; i < getChannelMetaDataSize(); i++) {
+        l.push_back(getChannelMetaData()[i].ch);
+    }
+    return l;
+}
+
+std::vector<MpptNum_t> InverterAbstract::getMppts() const
+{
+    std::vector<MpptNum_t> l;
+    for (uint8_t i = 0; i < getChannelMetaDataSize(); i++) {
+        auto m = getChannelMetaData()[i].mppt;
+        if (l.end() == std::find(l.begin(), l.end(), m)){
+            l.push_back(m);
+        }
+    }
+    return l;
+}
+
+std::vector<ChannelNum_t> InverterAbstract::getChannelsByMppt(const MpptNum_t mppt) const
+{
+    std::vector<ChannelNum_t> l;
+    for (uint8_t i = 0; i < getChannelMetaDataSize(); i++) {
+        if (getChannelMetaData()[i].mppt == mppt) {
+            l.push_back(getChannelMetaData()[i].ch);
+        }
+    }
+    return l;
+}

--- a/lib/Hoymiles/src/inverters/InverterAbstract.h
+++ b/lib/Hoymiles/src/inverters/InverterAbstract.h
@@ -24,6 +24,20 @@ enum {
     FRAGMENT_OK = 0
 };
 
+enum MpptNum_t {
+    MPPT_A = 0,
+    MPPT_B,
+    MPPT_C,
+    MPPT_D,
+    MPPT_CNT
+};
+
+// additional meta data per input channel
+typedef struct {
+    ChannelNum_t ch; // channel 0 - 5
+    MpptNum_t mppt; // mppt a - d (0 - 3)
+} channelMetaData_t;
+
 #define MAX_RF_FRAGMENT_COUNT 13
 
 class CommandAbstract;
@@ -39,6 +53,9 @@ public:
     virtual String typeName() const = 0;
     virtual const byteAssign_t* getByteAssignment() const = 0;
     virtual uint8_t getByteAssignmentSize() const = 0;
+
+    virtual const channelMetaData_t* getChannelMetaData() const = 0;
+    virtual uint8_t getChannelMetaDataSize() const = 0;
 
     bool isProducing();
     bool isReachable();
@@ -111,6 +128,10 @@ public:
     PowerCommandParser* PowerCommand();
     StatisticsParser* Statistics();
     SystemConfigParaParser* SystemConfigPara();
+
+    std::vector<MpptNum_t> getMppts() const;
+    std::vector<ChannelNum_t> getChannels() const;
+    std::vector<ChannelNum_t> getChannelsByMppt(const MpptNum_t mppt) const;
 
 protected:
     HoymilesRadio* _radio;

--- a/lib/Hoymiles/src/inverters/InverterAbstract.h
+++ b/lib/Hoymiles/src/inverters/InverterAbstract.h
@@ -130,8 +130,8 @@ public:
     SystemConfigParaParser* SystemConfigPara();
 
     std::vector<MpptNum_t> getMppts() const;
-    std::vector<ChannelNum_t> getChannels() const;
-    std::vector<ChannelNum_t> getChannelsByMppt(const MpptNum_t mppt) const;
+    std::vector<ChannelNum_t> getChannelsDC() const;
+    std::vector<ChannelNum_t> getChannelsDCByMppt(const MpptNum_t mppt) const;
 
 protected:
     HoymilesRadio* _radio;

--- a/src/PowerLimiterInverter.cpp
+++ b/src/PowerLimiterInverter.cpp
@@ -3,7 +3,6 @@
 #include "PowerLimiterInverter.h"
 #include "PowerLimiterBatteryInverter.h"
 #include "PowerLimiterSolarInverter.h"
-#include "inverters/HMS_4CH.h"
 
 std::unique_ptr<PowerLimiterInverter> PowerLimiterInverter::create(
         bool verboseLogging, PowerLimiterInverterConfig const& config)

--- a/src/PowerLimiterSolarInverter.cpp
+++ b/src/PowerLimiterSolarInverter.cpp
@@ -73,16 +73,13 @@ uint16_t PowerLimiterSolarInverter::scaleLimit(uint16_t expectedOutputWatts)
     if (!isProducing()) { return expectedOutputWatts; }
 
     auto pStats = _spInverter->Statistics();
-    std::list<ChannelNum_t> dcChnls = pStats->getChannelsByType(TYPE_DC);
+    std::vector<ChannelNum_t> dcChnls = _spInverter->getChannels();
+    std::vector<MpptNum_t> dcMppts = _spInverter->getMppts();
     size_t dcTotalChnls = dcChnls.size();
+    size_t dcTotalMppts = dcMppts.size();
 
-    // according to the upstream projects README (table with supported devs),
-    // every 2 channel inverter has 2 MPPTs. then there are the HM*S* 4 channel
-    // models which have 4 MPPTs. all others have a different number of MPPTs
-    // than inputs. those are not supported by the current scaling mechanism.
-    bool supported = dcTotalChnls == 2;
-    supported |= dcTotalChnls == 4 && HMS_4CH::isValidSerial(getSerial());
-    if (!supported) { return expectedOutputWatts; }
+    // if there is only one MPPT available, there is nothing we can do
+    if (dcTotalMppts <= 1) { return expectedOutputWatts; }
 
     // test for a reasonable power limit that allows us to assume that an input
     // channel with little energy is actually not producing, rather than
@@ -101,37 +98,42 @@ uint16_t PowerLimiterSolarInverter::scaleLimit(uint16_t expectedOutputWatts)
         inverterEfficiencyFactor = (inverterEfficiencyFactor > 0) ? inverterEfficiencyFactor/100 : 0.967;
 
         // 98% of the expected power is good enough
-        auto expectedAcPowerPerChannel = (getCurrentLimitWatts() / dcTotalChnls) * 0.98;
+        auto expectedAcPowerPerMppt = (getCurrentLimitWatts() / dcTotalMppts) * 0.98;
 
         if (_verboseLogging) {
-            MessageOutput.printf("%s expected AC power per channel %f W\r\n",
-                    _logPrefix, expectedAcPowerPerChannel);
+            MessageOutput.printf("%s expected AC power per mppt %f W\r\n",
+                    _logPrefix, expectedAcPowerPerMppt);
         }
 
-        size_t dcShadedChnls = 0;
+        size_t dcShadedMppts = 0;
         auto shadedChannelACPowerSum = 0.0;
 
-        for (auto& c : dcChnls) {
-            auto channelPowerAC = pStats->getChannelFieldValue(TYPE_DC, c, FLD_PDC) * inverterEfficiencyFactor;
+        for (auto& m : dcMppts) {
+            float mpptPowerAC = 0.0;
+            std::vector<ChannelNum_t> mpptChnls = _spInverter->getChannelsByMppt(m);
 
-            if (channelPowerAC < expectedAcPowerPerChannel) {
-                dcShadedChnls++;
-                shadedChannelACPowerSum += channelPowerAC;
+            for (auto& c : mpptChnls) {
+                mpptPowerAC += pStats->getChannelFieldValue(TYPE_DC, c, FLD_PDC) * inverterEfficiencyFactor;
+            }
+
+            if (mpptPowerAC < expectedAcPowerPerMppt) {
+                dcShadedMppts++;
+                shadedChannelACPowerSum += mpptPowerAC;
             }
 
             if (_verboseLogging) {
-                MessageOutput.printf("%s ch %d AC power %f W\r\n",
-                        _logPrefix, c, channelPowerAC);
+                MessageOutput.printf("%s mppt-%c AC power %f W\r\n",
+                        _logPrefix, m + 'a', mpptPowerAC);
             }
         }
 
         // no shading or the shaded channels provide more power than what
         // we currently need.
-        if (dcShadedChnls == 0 || shadedChannelACPowerSum >= expectedOutputWatts) {
+        if (dcShadedMppts == 0 || shadedChannelACPowerSum >= expectedOutputWatts) {
             return expectedOutputWatts;
         }
 
-        if (dcShadedChnls == dcTotalChnls) {
+        if (dcShadedMppts == dcTotalMppts) {
             // keep the currentLimit when:
             // - all channels are shaded
             // - currentLimit >= expectedOutputWatts
@@ -139,7 +141,7 @@ uint16_t PowerLimiterSolarInverter::scaleLimit(uint16_t expectedOutputWatts)
             if (getCurrentLimitWatts() >= expectedOutputWatts &&
                     inverterOutputAC <= expectedOutputWatts) {
                 if (_verboseLogging) {
-                    MessageOutput.printf("%s all channels are shaded, "
+                    MessageOutput.printf("%s all mppts are shaded, "
                             "keeping the current limit of %d W\r\n",
                             _logPrefix, getCurrentLimitWatts());
                 }
@@ -151,31 +153,38 @@ uint16_t PowerLimiterSolarInverter::scaleLimit(uint16_t expectedOutputWatts)
             }
         }
 
-        size_t dcNonShadedChnls = dcTotalChnls - dcShadedChnls;
-        uint16_t overScaledLimit = (expectedOutputWatts - shadedChannelACPowerSum) / dcNonShadedChnls * dcTotalChnls;
+        size_t dcNonShadedMppts = dcTotalMppts - dcShadedMppts;
+        uint16_t overScaledLimit = (expectedOutputWatts - shadedChannelACPowerSum) / dcNonShadedMppts * dcTotalMppts;
 
         if (overScaledLimit <= expectedOutputWatts) { return expectedOutputWatts; }
 
         if (_verboseLogging) {
-            MessageOutput.printf("%s %d/%d channels are shaded, scaling %d W\r\n",
-                    _logPrefix, dcShadedChnls, dcTotalChnls, overScaledLimit);
+            MessageOutput.printf("%s %d/%d mppts are shaded, scaling %d W\r\n",
+                    _logPrefix, dcShadedMppts, dcTotalMppts, overScaledLimit);
         }
 
         return overScaledLimit;
     }
 
-    size_t dcProdChnls = 0;
-    for (auto& c : dcChnls) {
-        if (pStats->getChannelFieldValue(TYPE_DC, c, FLD_PDC) > 2.0) {
-            dcProdChnls++;
+    size_t dcProdMppts = 0;
+    for (auto& m : dcMppts) {
+        float dcPowerMppt = 0.0;
+        std::vector<ChannelNum_t> mpptChnls = _spInverter->getChannelsByMppt(m);
+
+        for (auto& c : mpptChnls) {
+            dcPowerMppt += pStats->getChannelFieldValue(TYPE_DC, c, FLD_PDC);
+        }
+
+        if (dcPowerMppt > 2.0 * mpptChnls.size()) {
+            dcProdMppts++;
         }
     }
 
-    if (dcProdChnls == 0 || dcProdChnls == dcTotalChnls) { return expectedOutputWatts; }
+    if (dcProdMppts == 0 || dcProdMppts == dcTotalMppts) { return expectedOutputWatts; }
 
-    uint16_t scaled = expectedOutputWatts / dcProdChnls * dcTotalChnls;
-    MessageOutput.printf("%s %d/%d channels are producing, scaling from %d to "
-            "%d W\r\n", _logPrefix, dcProdChnls, dcTotalChnls,
+    uint16_t scaled = expectedOutputWatts / dcProdMppts * dcTotalMppts;
+    MessageOutput.printf("%s %d/%d mppts are producing, scaling from %d to "
+            "%d W\r\n", _logPrefix, dcProdMppts, dcTotalMppts,
             expectedOutputWatts, scaled);
 
     return scaled;

--- a/src/PowerLimiterSolarInverter.cpp
+++ b/src/PowerLimiterSolarInverter.cpp
@@ -73,7 +73,7 @@ uint16_t PowerLimiterSolarInverter::scaleLimit(uint16_t expectedOutputWatts)
     if (!isProducing()) { return expectedOutputWatts; }
 
     auto pStats = _spInverter->Statistics();
-    std::vector<ChannelNum_t> dcChnls = _spInverter->getChannels();
+    std::vector<ChannelNum_t> dcChnls = _spInverter->getChannelsDC();
     std::vector<MpptNum_t> dcMppts = _spInverter->getMppts();
     size_t dcTotalChnls = dcChnls.size();
     size_t dcTotalMppts = dcMppts.size();
@@ -110,7 +110,7 @@ uint16_t PowerLimiterSolarInverter::scaleLimit(uint16_t expectedOutputWatts)
 
         for (auto& m : dcMppts) {
             float mpptPowerAC = 0.0;
-            std::vector<ChannelNum_t> mpptChnls = _spInverter->getChannelsByMppt(m);
+            std::vector<ChannelNum_t> mpptChnls = _spInverter->getChannelsDCByMppt(m);
 
             for (auto& c : mpptChnls) {
                 mpptPowerAC += pStats->getChannelFieldValue(TYPE_DC, c, FLD_PDC) * inverterEfficiencyFactor;
@@ -169,7 +169,7 @@ uint16_t PowerLimiterSolarInverter::scaleLimit(uint16_t expectedOutputWatts)
     size_t dcProdMppts = 0;
     for (auto& m : dcMppts) {
         float dcPowerMppt = 0.0;
-        std::vector<ChannelNum_t> mpptChnls = _spInverter->getChannelsByMppt(m);
+        std::vector<ChannelNum_t> mpptChnls = _spInverter->getChannelsDCByMppt(m);
 
         for (auto& c : mpptChnls) {
             dcPowerMppt += pStats->getChannelFieldValue(TYPE_DC, c, FLD_PDC);

--- a/src/PowerLimiterSolarInverter.cpp
+++ b/src/PowerLimiterSolarInverter.cpp
@@ -1,6 +1,5 @@
 #include "MessageOutput.h"
 #include "PowerLimiterSolarInverter.h"
-#include "inverters/HMS_4CH.h"
 
 PowerLimiterSolarInverter::PowerLimiterSolarInverter(bool verboseLogging, PowerLimiterInverterConfig const& config)
     : PowerLimiterInverter(verboseLogging, config) { }


### PR DESCRIPTION
This MR adds support for inverters, having multiple channels sharing one MPPT. This is achieved by combining all channels assigned to one MPPT before calculating any correction factors. The assignment between channels and MPPTs is added directly to the converter definition. For all inverters, that are already supported today, there should be no functional change, as the numb er of channels per MPPT is exactly one. The assignment of channel(s) to MPPT is currently calculated on every call - but I can also add some kind of caching for that.

If this approach is fine for you, I would try to get the changes of the Hoymiles library merged into the parent project.

I'm running custom build with these changes in my own setup (single HMT-2250) since a few days - and DPL seems to be stable.

@schlimmchen The MR targets your branch from #1216 