### PR TITLE
Add battery temperature from "Smart Battery Sense" to Victron MPPT live view

### DIFF
--- a/src/WebApi_ws_vedirect_live.cpp
+++ b/src/WebApi_ws_vedirect_live.cpp
@@ -190,6 +190,11 @@ void WebApiWsVedirectLiveClass::populateJson(const JsonObject &root, const VeDir
     output["E"]["v"] = mpptData.mpptEfficiency_Percent;
     output["E"]["u"] = "%";
     output["E"]["d"] = 1;
+    if (mpptData.SmartBatterySenseTemperatureMilliCelsius.first > 0) {
+        output["SBSTemperature"]["v"] = mpptData.SmartBatterySenseTemperatureMilliCelsius.second / 1000.0;
+        output["SBSTemperature"]["u"] = "°C";
+        output["SBSTemperature"]["d"] = "0";
+    }
 
     const JsonObject input = values["input"].to<JsonObject>();
     if (mpptData.NetworkTotalDcInputPowerMilliWatts.first > 0) {

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -187,7 +187,8 @@
             "P": "Leistung (berechnet)",
             "V": "Spannung",
             "I": "Strom",
-            "E": "Effizienz (berechnet)"
+            "E": "Effizienz (berechnet)",
+            "SBSTemperature": "SBS Temperatur"
         },
         "section_input": "Eingang (Solarpanele)",
         "input": {

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -187,7 +187,8 @@
             "P": "Power (calculated)",
             "V": "Voltage",
             "I": "Current",
-            "E": "Efficiency (calculated)"
+            "E": "Efficiency (calculated)",
+            "SBSTemperature": "SBS temperature"
         },
         "section_input": "Input (Solar Panels)",
         "input": {

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -187,7 +187,8 @@
             "P": "Power (calculated)",
             "V": "Voltage",
             "I": "Current",
-            "E": "Efficiency (calculated)"
+            "E": "Efficiency (calculated)",
+            "SBSTemperature": "SBS temperature"
         },
         "section_input": "Input (Solar Panels)",
         "input": {


### PR DESCRIPTION
I have integrated the battery temperature provided by the “Smart Battery Sense” into the web UI. The battery temperature is only displayed if a “Smart Battery Sense” or “BVM” is present and valid data is available.
Like on the Victron app the value will be displaced in °C without decimal places
Bugfix: Converting temperature from [K] to [°C]

Test cases: 
- Display on the web UI when the "Smart Battery Sense" is present (temperature displayed)
- Display on the web UI when the "Smart Battery Sense" is not present (temperature not displayed)
- Display on the web UI when the "Smart Battery Sense" fails during operation. (temperature disappears after 10 – 60 seconds)

![grafik](https://github.com/user-attachments/assets/e64826f8-b523-4892-a4ed-af4d9bed740a)
