### PR TITLE
Fix table overflow in BatteryView

### DIFF
--- a/webapp/src/components/BatteryView.vue
+++ b/webapp/src/components/BatteryView.vue
@@ -48,43 +48,45 @@
                                 <div class="card" :class="{ 'border-info': true }">
                                     <div class="card-header text-bg-info">{{ $t('battery.' + section) }}</div>
                                     <div class="card-body">
-                                        <table class="table table-striped table-hover">
-                                            <thead>
-                                                <tr>
-                                                    <th scope="col">{{ $t('battery.Property') }}</th>
-                                                    <th style="text-align: right" scope="col">
-                                                        {{ $t('battery.Value') }}
-                                                    </th>
-                                                    <th scope="col">{{ $t('battery.Unit') }}</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                <tr v-for="(prop, key) in values" v-bind:key="key">
-                                                    <th scope="row">{{ $t('battery.' + key) }}</th>
-                                                    <td style="text-align: right">
-                                                        <template v-if="isStringValue(prop) && prop.translate">
-                                                            {{ $t('battery.' + prop.value) }}
-                                                        </template>
-                                                        <template v-else-if="isStringValue(prop)">
-                                                            {{ prop.value }}
-                                                        </template>
-                                                        <template v-else>
-                                                            {{
-                                                                $n(prop.v, 'decimal', {
-                                                                    minimumFractionDigits: prop.d,
-                                                                    maximumFractionDigits: prop.d,
-                                                                })
-                                                            }}
-                                                        </template>
-                                                    </td>
-                                                    <td>
-                                                        <template v-if="!isStringValue(prop)">
-                                                            {{ prop.u }}
-                                                        </template>
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
+                                        <div class="table-responsive">
+                                            <table class="table table-striped table-hover">
+                                                <thead>
+                                                    <tr>
+                                                        <th scope="col">{{ $t('battery.Property') }}</th>
+                                                        <th style="text-align: right" scope="col">
+                                                            {{ $t('battery.Value') }}
+                                                        </th>
+                                                        <th scope="col">{{ $t('battery.Unit') }}</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    <tr v-for="(prop, key) in values" v-bind:key="key">
+                                                        <th scope="row">{{ $t('battery.' + key) }}</th>
+                                                        <td style="text-align: right">
+                                                            <template v-if="isStringValue(prop) && prop.translate">
+                                                                {{ $t('battery.' + prop.value) }}
+                                                            </template>
+                                                            <template v-else-if="isStringValue(prop)">
+                                                                {{ prop.value }}
+                                                            </template>
+                                                            <template v-else>
+                                                                {{
+                                                                    $n(prop.v, 'decimal', {
+                                                                        minimumFractionDigits: prop.d,
+                                                                        maximumFractionDigits: prop.d,
+                                                                    })
+                                                                }}
+                                                            </template>
+                                                        </td>
+                                                        <td>
+                                                            <template v-if="!isStringValue(prop)">
+                                                                {{ prop.u }}
+                                                            </template>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </div>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
On my iPhone the BatteryView looked like this:

<img src="https://github.com/user-attachments/assets/143209fb-5f17-41df-aa6d-6779067470bf" width=50% height=50%>

I have added a second div with the "table-responsive" class (where "overflow-x: auto" is set) around the table (same solution as the VeDirectView used). 

Now the BatteryView looks  like this:

<img src="https://github.com/user-attachments/assets/c373bdb7-0ad7-44e5-bccd-1ae5ff3e0d43" width=50% height=50%>

