### PR TITLE
fix http power meter custom port regression bug

### DIFF
--- a/src/HttpGetter.cpp
+++ b/src/HttpGetter.cpp
@@ -61,8 +61,8 @@ bool HttpGetter::init()
     // get port
     index = _host.indexOf(':');
     if (index >= 0) {
-        _host = _host.substring(0, index); // up until colon
         _port = _host.substring(index + 1).toInt(); // after colon
+        _host = _host.substring(0, index); // up until colon
     }
 
     if (_useHttps) {


### PR DESCRIPTION
Due to power meter refactoring (#1077) a regression bug appeared, rendering the original bug (#612) useless.
Thx to @stefan123t for proposing a quick & easy fix by just swapping line 64 w/ line 65.
Fixes #1327