### PR TITLE
Add optional "load current" to live view, MQTT and HASS.

### DIFF
--- a/lib/VeDirectFrameHandler/VeDirectData.h
+++ b/lib/VeDirectFrameHandler/VeDirectData.h
@@ -26,8 +26,6 @@ struct veMpptStruct : veStruct {
     uint32_t panelVoltage_VPV_mV;       // panel voltage in mV
     uint32_t panelCurrent_mA;           // panel current in mA (calculated)
     int16_t  batteryOutputPower_W;      // battery output power in W (calculated, can be negative if load output is used)
-    uint32_t loadCurrent_IL_mA;         // Load current in mA (Available only for models with a load output)
-    bool     loadOutputState_LOAD;      // virtual load output state (on if battery voltage reaches upper limit, off if battery reaches lower limit)
     uint8_t  currentState_CS;           // current state of operation e.g. OFF or Bulk
     uint8_t  errorCode_ERR;             // error code
     uint32_t offReason_OR;              // off reason
@@ -37,6 +35,14 @@ struct veMpptStruct : veStruct {
     uint16_t maxPowerToday_H21_W;       // maximum power today W
     uint32_t yieldYesterday_H22_Wh;     // yield yesterday Wh
     uint16_t maxPowerYesterday_H23_W;   // maximum power yesterday W
+
+    // these are optional values communicated through the TEXT protocol. the pair's first
+    // value is the timestamp the respective info was last received. if it is
+    // zero, the value is deemed invalid. the timestamp is reset if no current
+    // value could be retrieved.
+    std::pair<uint32_t, bool> loadOutputState_LOAD;     // physical load output or virtual load output state (on if battery voltage
+                                                        // reaches upper limit, off if battery reaches lower limit)
+    std::pair<uint32_t, uint32_t> loadCurrent_IL_mA;    // Load current in mA (Available only for models with a physical load output)
 
     // these are values communicated through the HEX protocol. the pair's first
     // value is the timestamp the respective info was last received. if it is

--- a/src/MqttHandleVedirect.cpp
+++ b/src/MqttHandleVedirect.cpp
@@ -111,7 +111,6 @@ void MqttHandleVedirectClass::publish_mppt_data(const VeDirectMpptController::da
     PUBLISH(productID_PID,           "PID",  currentData.getPidAsString().data());
     PUBLISH(serialNr_SER,            "SER",  currentData.serialNr_SER);
     PUBLISH(firmwareVer_FW,           "FW",  currentData.firmwareVer_FW);
-    PUBLISH(loadOutputState_LOAD,   "LOAD",  (currentData.loadOutputState_LOAD ? "ON" : "OFF"));
     PUBLISH(currentState_CS,          "CS",  currentData.getCsAsString().data());
     PUBLISH(errorCode_ERR,           "ERR",  currentData.getErrAsString().data());
     PUBLISH(offReason_OR,             "OR",  currentData.getOrAsString().data());
@@ -136,6 +135,8 @@ void MqttHandleVedirectClass::publish_mppt_data(const VeDirectMpptController::da
         MqttSettings.publish(topic + t, String(val)); \
     }
 
+    PUBLISH_OPT(loadOutputState_LOAD,                     "LOAD",                         currentData.loadOutputState_LOAD.second ? "ON" : "OFF");
+    PUBLISH_OPT(loadCurrent_IL_mA,                        "IL",                           currentData.loadCurrent_IL_mA.second / 1000.0);
     PUBLISH_OPT(NetworkTotalDcInputPowerMilliWatts,       "NetworkTotalDcInputPower",     currentData.NetworkTotalDcInputPowerMilliWatts.second / 1000.0);
     PUBLISH_OPT(MpptTemperatureMilliCelsius,              "MpptTemperature",              currentData.MpptTemperatureMilliCelsius.second / 1000.0);
     PUBLISH_OPT(BatteryAbsorptionMilliVolt,               "BatteryAbsorption",            currentData.BatteryAbsorptionMilliVolt.second / 1000.0);

--- a/src/MqttHandleVedirectHass.cpp
+++ b/src/MqttHandleVedirectHass.cpp
@@ -63,7 +63,6 @@ void MqttHandleVedirectHassClass::publishConfig()
         auto optMpptData = VictronMppt.getData(idx);
         if (!optMpptData.has_value()) { continue; }
 
-        publishBinarySensor("MPPT load output state", "mdi:export", "LOAD", "ON", "OFF", *optMpptData);
         publishSensor("MPPT serial number", "mdi:counter", "SER", nullptr, nullptr, nullptr, *optMpptData);
         publishSensor("MPPT firmware number", "mdi:counter", "FW", nullptr, nullptr, nullptr, *optMpptData);
         publishSensor("MPPT state of operation", "mdi:wrench", "CS", nullptr, nullptr, nullptr, *optMpptData);
@@ -87,6 +86,14 @@ void MqttHandleVedirectHassClass::publishConfig()
         publishSensor("Panel maximum power today", NULL, "H21", "power", "measurement", "W", *optMpptData);
         publishSensor("Panel yield yesterday", NULL, "H22", "energy", "total", "kWh", *optMpptData);
         publishSensor("Panel maximum power yesterday", NULL, "H23", "power", "measurement", "W", *optMpptData);
+
+        // optional info, provided only if the charge controller delivers the information
+        if (optMpptData->loadOutputState_LOAD.first != 0) {
+            publishBinarySensor("MPPT load output state", "mdi:export", "LOAD", "ON", "OFF", *optMpptData);
+        }
+        if (optMpptData->loadCurrent_IL_mA.first != 0) {
+            publishSensor("MPPT load current", NULL, "IL", "current", "measurement", "A", *optMpptData);
+        }
 
         // optional info, provided only if TX is connected to charge controller
         if (optMpptData->NetworkTotalDcInputPowerMilliWatts.first != 0) {

--- a/src/WebApi_ws_vedirect_live.cpp
+++ b/src/WebApi_ws_vedirect_live.cpp
@@ -164,7 +164,14 @@ void WebApiWsVedirectLiveClass::populateJson(const JsonObject &root, const VeDir
     const JsonObject values = root["values"].to<JsonObject>();
 
     const JsonObject device = values["device"].to<JsonObject>();
-    device["LOAD"] = mpptData.loadOutputState_LOAD ? "ON" : "OFF";
+    if (mpptData.loadOutputState_LOAD.first > 0) {
+        device["LOAD"] = mpptData.loadOutputState_LOAD.second ? "ON" : "OFF";
+    }
+    if (mpptData.loadCurrent_IL_mA.first > 0) {
+        device["LOADCurrent"]["v"] = mpptData.loadCurrent_IL_mA.second / 1000.0;
+        device["LOADCurrent"]["u"] = "A";
+        device["LOADCurrent"]["d"] = 2;
+    }
     device["CS"] = mpptData.getCsAsString();
     device["MPPT"] = mpptData.getMpptAsString();
     device["OR"] = mpptData.getOrAsString();

--- a/src/WebApi_ws_vedirect_live.cpp
+++ b/src/WebApi_ws_vedirect_live.cpp
@@ -164,13 +164,19 @@ void WebApiWsVedirectLiveClass::populateJson(const JsonObject &root, const VeDir
     const JsonObject values = root["values"].to<JsonObject>();
 
     const JsonObject device = values["device"].to<JsonObject>();
+
+    // LOAD     IL      UI label    result
+    // ------------------------------------
+    // false    false               Do not display LOAD and IL (device has no physical load output and virtual load is not configured)
+    // true     false   "VIRTLOAD"  We display just LOAD (device has no physical load output and virtual load is configured)
+    // true     true    "LOAD"      We display LOAD and IL (device has physical load output, regardless if virtual load is configured or not)
     if (mpptData.loadOutputState_LOAD.first > 0) {
-        device["LOAD"] = mpptData.loadOutputState_LOAD.second ? "ON" : "OFF";
+        device[(mpptData.loadCurrent_IL_mA.first > 0) ? "LOAD" : "VIRTLOAD"] = mpptData.loadOutputState_LOAD.second ? "ON" : "OFF";
     }
     if (mpptData.loadCurrent_IL_mA.first > 0) {
-        device["LOADCurrent"]["v"] = mpptData.loadCurrent_IL_mA.second / 1000.0;
-        device["LOADCurrent"]["u"] = "A";
-        device["LOADCurrent"]["d"] = 2;
+        device["IL"]["v"] = mpptData.loadCurrent_IL_mA.second / 1000.0;
+        device["IL"]["u"] = "A";
+        device["IL"]["d"] = 2;
     }
     device["CS"] = mpptData.getCsAsString();
     device["MPPT"] = mpptData.getMpptAsString();

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -175,7 +175,8 @@
         "section_device": "Geräteinformation",
         "device": {
             "LOAD": "Status Lastausgang",
-            "LOADCurrent": "Laststrom",
+            "VIRTLOAD": "Status virtueller Lastausgang",
+            "IL": "Laststrom",
             "CS": "Betriebszustand",
             "MPPT": "Betriebszustand des Trackers",
             "OR": "Grund für das Ausschalten",

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -175,6 +175,7 @@
         "section_device": "Geräteinformation",
         "device": {
             "LOAD": "Status Lastausgang",
+            "LOADCurrent": "Laststrom",
             "CS": "Betriebszustand",
             "MPPT": "Betriebszustand des Trackers",
             "OR": "Grund für das Ausschalten",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -175,6 +175,7 @@
         "section_device": "Device Info",
         "device": {
             "LOAD": "Load output state",
+            "LOADCurrent": "Load current",
             "CS": "State of operation",
             "MPPT": "Tracker operation mode",
             "OR": "Off reason",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -175,7 +175,8 @@
         "section_device": "Device Info",
         "device": {
             "LOAD": "Load output state",
-            "LOADCurrent": "Load current",
+            "VIRTLOAD": "Virtual load output state",
+            "IL": "Load current",
             "CS": "State of operation",
             "MPPT": "Tracker operation mode",
             "OR": "Off reason",

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -175,6 +175,7 @@
         "section_device": "Device Info",
         "device": {
             "LOAD": "Load output state",
+            "LOADCurrent": "Load current",
             "CS": "State of operation",
             "MPPT": "Tracker operation mode",
             "OR": "Off reason",

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -175,7 +175,8 @@
         "section_device": "Device Info",
         "device": {
             "LOAD": "Load output state",
-            "LOADCurrent": "Load current",
+            "VIRTLOAD": "Virtual load output state",
+            "IL": "Load current",
             "CS": "State of operation",
             "MPPT": "Tracker operation mode",
             "OR": "Off reason",


### PR DESCRIPTION
- add optional "load current" to live view, MQTT and HASS.
- change "load output" to optional handling
Charge controller with physical "load output" will publish "load output state" and "load current"
Charge controller without physical "load output" but configured "virtual output" will publish just "load output state"
Charge controller without physical "load output" and not configured "virtual output" will not publish "load output state" and "load current"