### PR TITLE
Fix: use battery when in full solar-passthrough

### DIFF
--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -81,9 +81,9 @@ private:
     void reloadConfig();
     std::pair<float, char const*> getInverterDcVoltage();
     float getBatteryVoltage(bool log = false);
-    uint16_t solarDcToInverterAc(uint16_t dcPower);
+    uint16_t dcPowerBusToInverterAc(uint16_t dcPower);
     void fullSolarPassthrough(PowerLimiterClass::Status reason);
-    int16_t calcHouseholdConsumption();
+    int16_t calcConsumption();
     using inverter_filter_t = std::function<bool(PowerLimiterInverter const&)>;
     uint16_t updateInverterLimits(uint16_t powerRequested, inverter_filter_t filter, std::string const& filterExpression);
     uint16_t calcPowerBusUsage(uint16_t powerRequested);

--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -32,7 +32,6 @@ public:
         InverterCmdPending,
         ConfigReload,
         InverterStatsPending,
-        FullSolarPassthrough,
         UnconditionalSolarPassthrough,
         Stable,
     };
@@ -87,7 +86,7 @@ private:
     int16_t calcHouseholdConsumption();
     using inverter_filter_t = std::function<bool(PowerLimiterInverter const&)>;
     uint16_t updateInverterLimits(uint16_t powerRequested, inverter_filter_t filter, std::string const& filterExpression);
-    uint16_t calcBatteryAllowance(uint16_t powerRequested);
+    uint16_t calcPowerBusUsage(uint16_t powerRequested);
     bool updateInverters();
     uint16_t getSolarPassthroughPower();
     std::optional<uint16_t> getBatteryDischargeLimit();


### PR DESCRIPTION
re-using the unconditional full solar-passthrough implementation does not work if the battery is full (full solar-passthrough active) while the grid consumption is higher than the solar output. we then only produce as much power as is available from the charge controllers, where we actually should match the grid cosumption using the battery's power.

notice that this makes "uncondictional full solar-passthrough" (the DPL mode of operation set through MQTT) something different than just "full solar-passthrough", as was before #1216.

closes #1422.