### PR TITLE
Fix: Huawei AC charger sends signed values

### DIFF
--- a/include/Huawei_can.h
+++ b/include/Huawei_can.h
@@ -96,7 +96,7 @@ public:
     void loop();
     bool gotNewRxDataFrame(bool clear);
     uint8_t  getErrorCode(bool clear);
-    uint32_t getParameterValue(uint8_t parameter);
+    int32_t getParameterValue(uint8_t parameter);
     void setParameterValue(uint16_t in, uint8_t parameterType);
 
 private:
@@ -109,7 +109,7 @@ private:
 
     std::mutex _mutex;
 
-    uint32_t _recValues[12];
+    int32_t _recValues[12];
     uint16_t _txValues[5];
     bool     _hasNewTxValue[5];
 

--- a/src/Huawei_can.cpp
+++ b/src/Huawei_can.cpp
@@ -88,7 +88,7 @@ void HuaweiCanCommClass::loop()
     if((rxId & 0x80000000) == 0x80000000) {   // Determine if ID is standard (11 bits) or extended (29 bits)
       if ((rxId & 0x1FFFFFFF) == 0x1081407F && len == 8) {
 
-        uint32_t value = __bswap32(* reinterpret_cast<uint32_t*> (rxBuf + 4));
+        int32_t value = __bswap32(*reinterpret_cast<int32_t*>(rxBuf + 4));
 
         // Input power 0x70, Input frequency 0x71, Input current 0x72
         // Output power 0x73, Efficiency 0x74, Output Voltage 0x75 and Output Current 0x76
@@ -144,14 +144,13 @@ void HuaweiCanCommClass::loop()
 
 }
 
-uint32_t HuaweiCanCommClass::getParameterValue(uint8_t parameter)
+int32_t HuaweiCanCommClass::getParameterValue(uint8_t parameter)
 {
   std::lock_guard<std::mutex> lock(_mutex);
-  uint32_t v = 0;
   if (parameter < HUAWEI_OUTPUT_CURRENT1_IDX) {
-    v =  _recValues[parameter];
+    return _recValues[parameter];
   }
-  return v;
+  return 0;
 }
 
 bool HuaweiCanCommClass::gotNewRxDataFrame(bool clear)


### PR DESCRIPTION
as shown in #1432, the Huawei AC charger sends signed values to communicate the temperature. given that the value range for all other data points is expected to be less than ~2 million, we now interpret all data as signed values.

Closes #1432.