### PR TITLE
fix: wrong usage of 'isSunsetAvailable'

### DIFF
--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -234,7 +234,7 @@ void PowerLimiterClass::loop()
     auto getBatteryPower = [this,&config]() -> bool {
         if (!usesBatteryPoweredInverter()) { return false; }
 
-        auto isDayPeriod = SunPosition.isSunsetAvailable() ? SunPosition.isDayPeriod() : true;
+        auto isDayPeriod = SunPosition.isDayPeriod();
 
         if (_nighttimeDischarging && isDayPeriod) {
             _nighttimeDischarging = false;

--- a/src/SunPosition.cpp
+++ b/src/SunPosition.cpp
@@ -41,6 +41,7 @@ bool SunPositionClass::isDayPeriod() const
     return (minutesPastMidnight >= _sunriseMinutes) && (minutesPastMidnight < _sunsetMinutes);
 }
 
+// Returns if sunset/sunrise exists (e.g. in norway sunset/sunrise don't happen in summer months)
 bool SunPositionClass::isSunsetAvailable() const
 {
     return _isSunsetAvailable;


### PR DESCRIPTION
Closes https://github.com/hoylabs/OpenDTU-OnBattery/issues/1407

I assumed that 'isSunsetAvailable' tells us if NTP is working and we got the correct time and timezone but actually it tells us if sunrise/sunset exists for the current timeperiod in the current timezone.