### PR TITLE
Feature: auto-detect SoC precision for MQTT Battery provider

### DIFF
--- a/include/MqttBattery.h
+++ b/include/MqttBattery.h
@@ -19,6 +19,7 @@ private:
     String _voltageTopic;
     String _dischargeCurrentLimitTopic;
     std::shared_ptr<MqttBatteryStats> _stats = std::make_shared<MqttBatteryStats>();
+    uint8_t _socPrecision = 0;
 
     void onMqttMessageSoC(espMqttClientTypes::MessageProperties const& properties,
             char const* topic, uint8_t const* payload, size_t len, size_t index, size_t total,


### PR DESCRIPTION
With this change we will allow users to set the decimal places (or precision) of the SoC when the MQTT Battery Provider is used.

|Live View|
|----------|
|![Screenshot 2024-12-07 at 18 53 43](https://github.com/user-attachments/assets/13d9d51a-a4af-42d2-ab94-52729f0269fd)|

Console 
```
18:56:32.934 > MqttBattery: Updated SoC to 49.93 from 'solarLights/battery/stateOfCharge'
18:56:33.076 > MqttBattery: Updated voltage to 52.68 from 'solarLights/battery/voltage'
...
18:56:51.454 > [DPL] battery interface enabled, SoC 49.9 % (used), age 3 s (valid)
18:56:51.462 > [DPL] BMS: 52.68 V, MPPT: -1.00 V, inverter 1164a00aaa1f: 52.80 
18:56:51.471 > [DPL] battery voltage 52.68 V, load-corrected voltage 52.68 V @ 0 W, factor 0.00130 1/A
```
