### PR TITLE
Improvement: Ve.Direct, FrameHandler, Handle timestamp of multiple frames

### DIFF
--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
@@ -106,7 +106,13 @@ void VeDirectFrameHandler<T>::reset()
 template<typename T>
 void VeDirectFrameHandler<T>::loop()
 {
-	while ( _vedirectSerial->available()) {
+	// if the data is older than 10 seconds, it is no longer valid (millis() rollover safe)
+	if (_dataValid && ((millis() - _lastUpdate) > (10 * 1000))) {
+		_dataValid = false;     // data is now outdated
+		_startUpPassed = false; // reset the start-up condition
+	}
+
+	while (_vedirectSerial->available()) {
 		rxData(_vedirectSerial->read());
 		_lastByteMillis = millis();
 	}
@@ -354,20 +360,6 @@ typename VeDirectFrameHandler<T>::State VeDirectFrameHandler<T>::hexRxEvent(uint
 	}
 
 	return ret;
-}
-
-
-// Returns true if the dataset is valid and not older than 10 seconds
-template<typename T>
-bool VeDirectFrameHandler<T>::isDataValid()
-{
-    // if the data is older than 10 seconds, it is no longer valid (millis() rollover safe)
-    if (_dataValid && (millis() - _lastUpdate > (10 * 1000))) {
-        _dataValid = false;     // data is outdated
-        _startUpPassed = false; // reset the start-up condition
-    }
-
-	return _dataValid;
 }
 
 // Returns the millis() timestamp of the last successfully received dataset

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
@@ -242,8 +242,8 @@ void VeDirectFrameHandler<T>::rxData(uint8_t inbyte)
 
             // A dataset can be fragmented across multiple frames,
             // so we give just frames containing the field-label "V" a timestamp to avoid
-            // multible timestamps on related data. We also take care to have a complete dataset from
-            // multible frames after a start or restart or fault before we set the data as valid.
+            // multible timestamps on related data. We also take care to have the dataset complete
+            // after a start or restart or fault before we set the data as valid.
             // Note: At startup, it may take up to 2 seconds for the first timestamp to be available
             if (_frameContainsFieldV) {
                 if (_startUpPassed) {

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
@@ -50,6 +50,8 @@ template<typename T>
 VeDirectFrameHandler<T>::VeDirectFrameHandler() :
 	_msgOut(&MessageOutputDummy),
 	_lastUpdate(0),
+    _actFrameNumber(0),
+    _endFrameNumber(0),
 	_state(State::IDLE),
 	_checksum(0),
 	_textPointer(0),
@@ -230,13 +232,28 @@ void VeDirectFrameHandler<T>::rxData(uint8_t inbyte)
 	{
 		if (_verboseLogging) { dumpDebugBuffer(); }
 		if (_checksum == 0) {
+
+            // we use the field-label "V" to detect the start frame because all VE.Direct devices send this field
+            bool startFrame = false;
 			for (auto const& event : _textData) {
-				processTextData(event.first, event.second);
+				if (processTextData(event.first, event.second)) { startFrame = true; }
 			}
-			_lastUpdate = millis();
+
+            // related data can be fragmented across multiple frames (start frame -> end frame),
+            // so we check how many frames are required to get all related data
+            // once we kow the amount of frames we set the timestamp (_lastupdate) on the end frame
+            // Note: At startup, it may take up to 2 seconds for the first timestamp to become available.
+            if (startFrame) {
+                if (_actFrameNumber != 0) { _endFrameNumber = _actFrameNumber; } // buffer the end frame number
+                _actFrameNumber = 1;
+            } else {
+                if (_actFrameNumber != 0) { _actFrameNumber++; } // we do not count frames until we have a start frame
+            }
+            if ((_endFrameNumber != 0) && (_actFrameNumber == _endFrameNumber)) { _lastUpdate = millis(); }
 			frameValidEvent();
 		}
 		else {
+            _actFrameNumber = 0;
 			_msgOut->printf("%s checksum 0x%02x != 0x00, invalid frame\r\n", _logId, _checksum);
 		}
 		reset();
@@ -250,51 +267,53 @@ void VeDirectFrameHandler<T>::rxData(uint8_t inbyte)
 
 /*
  * This function is called every time a new name/value is successfully parsed.  It writes the values to the temporary buffer.
+ * Returns true if we have received the start frame (contains field-label "V")
  */
 template<typename T>
-void VeDirectFrameHandler<T>::processTextData(std::string const& name, std::string const& value) {
+bool VeDirectFrameHandler<T>::processTextData(std::string const& name, std::string const& value) {
 	if (_verboseLogging) {
 		_msgOut->printf("%s Text Data '%s' = '%s'\r\n",
 				_logId, name.c_str(), value.c_str());
 	}
 
-	if (processTextDataDerived(name, value)) { return; }
+	if (processTextDataDerived(name, value)) { return false; }
 
 	if (name == "PID") {
 		_tmpFrame.productID_PID = strtol(value.c_str(), nullptr, 0);
-		return;
+		return false;
 	}
 
 	if (name == "SER") {
 		strncpy(_tmpFrame.serialNr_SER, value.c_str(), sizeof(_tmpFrame.serialNr_SER));
-		return;
+		return false;
 	}
 
 	if (name == "FW") {
 		_tmpFrame.firmwareVer_FWE[0] = '\0';
 		strncpy(_tmpFrame.firmwareVer_FW, value.c_str(), sizeof(_tmpFrame.firmwareVer_FW));
-		return;
+		return false;
 	}
 
 	// some devices use "FWE" instead of "FW" for the firmware version.
 	if (name == "FWE") {
 		_tmpFrame.firmwareVer_FW[0] = '\0';
 		strncpy(_tmpFrame.firmwareVer_FWE, value.c_str(), sizeof(_tmpFrame.firmwareVer_FWE));
-		return;
+		return false;
 	}
 
 	if (name == "V") {
 		_tmpFrame.batteryVoltage_V_mV = atol(value.c_str());
-		return;
+		return true; // start frame
 	}
 
 	if (name == "I") {
 		_tmpFrame.batteryCurrent_I_mA = atol(value.c_str());
-		return;
+		return false;
 	}
 
 	_msgOut->printf("%s Unknown text data '%s' (value '%s')\r\n",
 			_logId, name.c_str(), value.c_str());
+    return false;
 }
 
 /*
@@ -340,10 +359,10 @@ typename VeDirectFrameHandler<T>::State VeDirectFrameHandler<T>::hexRxEvent(uint
 template<typename T>
 bool VeDirectFrameHandler<T>::isDataValid() const
 {
-	// VE.Direct text frame data is valid if we receive a device serialnumber and
-	// the data is not older as 10 seconds
-	// we accept a glitch where the data is valid for ten seconds when serialNr_SER != "" and (millis() - _lastUpdate) overflows
-	return strlen(_tmpFrame.serialNr_SER) > 0 && (millis() - _lastUpdate) < (10 * 1000);
+	// VE.Direct text frame data is valid if we receive a device voltage and
+	// the data is not older as 10 seconds and the end frame was received
+	// we accept a glitch where the data is valid for ten seconds when batteryVoltage_V_mV != 0.0f and (millis() - _lastUpdate) overflows
+	return (_tmpFrame.batteryVoltage_V_mV != 0.0f) && (millis() - _lastUpdate) < (10 * 1000) && _lastUpdate != 0;
 }
 
 template<typename T>

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
@@ -242,7 +242,7 @@ void VeDirectFrameHandler<T>::rxData(uint8_t inbyte)
 
             // A dataset can be fragmented across multiple frames,
             // so we give just frames containing the field-label "V" a timestamp to avoid
-            // multible timestamps on related data. We also take care to have the dataset complete
+            // multiple timestamps on related data. We also take care to have the dataset complete
             // after a start or restart or fault before we set the data as valid.
             // Note: At startup, it may take up to 2 seconds for the first timestamp to be available
             if (_frameContainsFieldV) {

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
@@ -58,8 +58,8 @@ VeDirectFrameHandler<T>::VeDirectFrameHandler() :
 	_value(""),
 	_debugIn(0),
 	_lastByteMillis(0),
-    _dataValid(false),
-    _startUpPassed(false)
+	_dataValid(false),
+	_startUpPassed(false)
 {
 }
 
@@ -76,8 +76,8 @@ void VeDirectFrameHandler<T>::init(char const* who, gpio_num_t rx, gpio_num_t tx
 	_msgOut = msgOut;
 	_verboseLogging = verboseLogging;
 	_debugIn = 0;
-    _startUpPassed = false; // to obtain a complete dataset after a new start or restart
-    _dataValid = false;     // data is not valid on start or restart
+	_startUpPassed = false; // to obtain a complete dataset after a new start or restart
+	_dataValid = false;     // data is not valid on start or restart
 	snprintf(_logId, sizeof(_logId), "[VE.Direct %s %d/%d]", who, rx, tx);
 	if (_verboseLogging) { _msgOut->printf("%s init complete\r\n", _logId); }
 }
@@ -241,23 +241,25 @@ void VeDirectFrameHandler<T>::rxData(uint8_t inbyte)
 		if (_verboseLogging) { dumpDebugBuffer(); }
 		if (_checksum == 0) {
 
-            _frameContainsFieldV = false;
+			_frameContainsFieldV = false;
 			for (auto const& event : _textData) {
 				processTextData(event.first, event.second);
 			}
 
-            // A dataset can be fragmented across multiple frames,
-            // so we give just frames containing the field-label "V" a timestamp to avoid
-            // multiple timestamps on related data. We also take care to have the dataset complete
-            // after a start or restart or fault before we set the data as valid.
-            // Note: At startup, it may take up to 2 seconds for the first timestamp to be available
-            if (_frameContainsFieldV) {
-                if (_startUpPassed) {
-                    _lastUpdate = millis();
-                    _dataValid = true;
-                }
-                _startUpPassed = true;
-            }
+			// A dataset can be fragmented across multiple frames,
+			// so we give just frames containing the field-label "V" a timestamp to avoid
+			// multiple timestamps on related data. We also take care to have the dataset complete
+			// after a start or restart or fault before we set the data as valid.
+			// Note: At startup, it may take up to 2 seconds for the first timestamp to be available
+			if (_frameContainsFieldV)
+			{
+				if (_startUpPassed)
+				{
+					_lastUpdate = millis();
+					_dataValid = true;
+				}
+				_startUpPassed = true;
+			}
 			frameValidEvent();
 		}
 		else {
@@ -309,7 +311,7 @@ void VeDirectFrameHandler<T>::processTextData(std::string const& name, std::stri
 
 	if (name == "V") {
 		_tmpFrame.batteryVoltage_V_mV = atol(value.c_str());
-        _frameContainsFieldV = true; // frame contains the field-label "V"
+		_frameContainsFieldV = true; // frame contains the field-label "V"
 		return;
 	}
 

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
@@ -50,8 +50,6 @@ template<typename T>
 VeDirectFrameHandler<T>::VeDirectFrameHandler() :
 	_msgOut(&MessageOutputDummy),
 	_lastUpdate(0),
-    _actFrameNumber(0),
-    _endFrameNumber(0),
 	_state(State::IDLE),
 	_checksum(0),
 	_textPointer(0),
@@ -59,7 +57,9 @@ VeDirectFrameHandler<T>::VeDirectFrameHandler() :
 	_name(""),
 	_value(""),
 	_debugIn(0),
-	_lastByteMillis(0)
+	_lastByteMillis(0),
+    _dataValid(false),
+    _startUpPassed(false)
 {
 }
 
@@ -76,6 +76,8 @@ void VeDirectFrameHandler<T>::init(char const* who, gpio_num_t rx, gpio_num_t tx
 	_msgOut = msgOut;
 	_verboseLogging = verboseLogging;
 	_debugIn = 0;
+    _startUpPassed = false; // to obtain a complete dataset after a new start or restart
+    _dataValid = false;     // data is not valid on start or restart
 	snprintf(_logId, sizeof(_logId), "[VE.Direct %s %d/%d]", who, rx, tx);
 	if (_verboseLogging) { _msgOut->printf("%s init complete\r\n", _logId); }
 }
@@ -233,27 +235,26 @@ void VeDirectFrameHandler<T>::rxData(uint8_t inbyte)
 		if (_verboseLogging) { dumpDebugBuffer(); }
 		if (_checksum == 0) {
 
-            // we use the field-label "V" to detect the start frame because all VE.Direct devices send this field
-            bool startFrame = false;
+            _frameContainsFieldV = false;
 			for (auto const& event : _textData) {
-				if (processTextData(event.first, event.second)) { startFrame = true; }
+				processTextData(event.first, event.second);
 			}
 
-            // related data can be fragmented across multiple frames (start frame -> end frame),
-            // so we check how many frames are required to get all related data
-            // once we kow the amount of frames we set the timestamp (_lastupdate) on the end frame
-            // Note: At startup, it may take up to 2 seconds for the first timestamp to become available.
-            if (startFrame) {
-                if (_actFrameNumber != 0) { _endFrameNumber = _actFrameNumber; } // buffer the end frame number
-                _actFrameNumber = 1;
-            } else {
-                if (_actFrameNumber != 0) { _actFrameNumber++; } // we do not count frames until we have a start frame
+            // A dataset can be fragmented across multiple frames,
+            // so we give just frames containing the field-label "V" a timestamp to avoid
+            // multible timestamps on related data. We also take care to have a complete dataset from
+            // multible frames after a start or restart or fault before we set the data as valid.
+            // Note: At startup, it may take up to 2 seconds for the first timestamp to be available
+            if (_frameContainsFieldV) {
+                if (_startUpPassed) {
+                    _lastUpdate = millis();
+                    _dataValid = true;
+                }
+                _startUpPassed = true;
             }
-            if ((_endFrameNumber != 0) && (_actFrameNumber == _endFrameNumber)) { _lastUpdate = millis(); }
 			frameValidEvent();
 		}
 		else {
-            _actFrameNumber = 0;
 			_msgOut->printf("%s checksum 0x%02x != 0x00, invalid frame\r\n", _logId, _checksum);
 		}
 		reset();
@@ -267,53 +268,52 @@ void VeDirectFrameHandler<T>::rxData(uint8_t inbyte)
 
 /*
  * This function is called every time a new name/value is successfully parsed.  It writes the values to the temporary buffer.
- * Returns true if we have received the start frame (contains field-label "V")
  */
 template<typename T>
-bool VeDirectFrameHandler<T>::processTextData(std::string const& name, std::string const& value) {
+void VeDirectFrameHandler<T>::processTextData(std::string const& name, std::string const& value) {
 	if (_verboseLogging) {
 		_msgOut->printf("%s Text Data '%s' = '%s'\r\n",
 				_logId, name.c_str(), value.c_str());
 	}
 
-	if (processTextDataDerived(name, value)) { return false; }
+	if (processTextDataDerived(name, value)) { return; }
 
 	if (name == "PID") {
 		_tmpFrame.productID_PID = strtol(value.c_str(), nullptr, 0);
-		return false;
+		return;
 	}
 
 	if (name == "SER") {
 		strncpy(_tmpFrame.serialNr_SER, value.c_str(), sizeof(_tmpFrame.serialNr_SER));
-		return false;
+		return;
 	}
 
 	if (name == "FW") {
 		_tmpFrame.firmwareVer_FWE[0] = '\0';
 		strncpy(_tmpFrame.firmwareVer_FW, value.c_str(), sizeof(_tmpFrame.firmwareVer_FW));
-		return false;
+		return;
 	}
 
 	// some devices use "FWE" instead of "FW" for the firmware version.
 	if (name == "FWE") {
 		_tmpFrame.firmwareVer_FW[0] = '\0';
 		strncpy(_tmpFrame.firmwareVer_FWE, value.c_str(), sizeof(_tmpFrame.firmwareVer_FWE));
-		return false;
+		return;
 	}
 
 	if (name == "V") {
 		_tmpFrame.batteryVoltage_V_mV = atol(value.c_str());
-		return true; // start frame
+        _frameContainsFieldV = true; // frame contains the field-label "V"
+		return;
 	}
 
 	if (name == "I") {
 		_tmpFrame.batteryCurrent_I_mA = atol(value.c_str());
-		return false;
+		return;
 	}
 
 	_msgOut->printf("%s Unknown text data '%s' (value '%s')\r\n",
 			_logId, name.c_str(), value.c_str());
-    return false;
 }
 
 /*
@@ -356,15 +356,22 @@ typename VeDirectFrameHandler<T>::State VeDirectFrameHandler<T>::hexRxEvent(uint
 	return ret;
 }
 
+
+// Returns true if the dataset is valid and not older than 10 seconds
 template<typename T>
-bool VeDirectFrameHandler<T>::isDataValid() const
+bool VeDirectFrameHandler<T>::isDataValid()
 {
-	// VE.Direct text frame data is valid if we receive a device voltage and
-	// the data is not older as 10 seconds and the end frame was received
-	// we accept a glitch where the data is valid for ten seconds when batteryVoltage_V_mV != 0.0f and (millis() - _lastUpdate) overflows
-	return (_tmpFrame.batteryVoltage_V_mV != 0.0f) && (millis() - _lastUpdate) < (10 * 1000) && _lastUpdate != 0;
+    // if the data is older than 10 seconds, it is no longer valid (millis() rollover safe)
+    if (_dataValid && (millis() - _lastUpdate > (10 * 1000))) {
+        _dataValid = false;     // data is outdated
+        _startUpPassed = false; // reset the start-up condition
+    }
+
+	return _dataValid;
 }
 
+// Returns the millis() timestamp of the last successfully received dataset
+// Note: Be aware of millis() rollover every 49 days
 template<typename T>
 uint32_t VeDirectFrameHandler<T>::getLastUpdate() const
 {

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
@@ -38,7 +38,9 @@ protected:
 
     bool _verboseLogging;
     Print* _msgOut;
-    uint32_t _lastUpdate;
+    uint32_t _lastUpdate;                       // timestamp of end frame (data may be fragmented across multiple frames)
+    size_t _actFrameNumber;                     // counts the necessary frames to obtain all related data
+    size_t _endFrameNumber;                     // buffer the end frame number
 
     T _tmpFrame;
 
@@ -49,7 +51,7 @@ private:
     void reset();
     void dumpDebugBuffer();
     void rxData(uint8_t inbyte);              // byte of serial data
-    void processTextData(std::string const& name, std::string const& value);
+    bool processTextData(std::string const& name, std::string const& value);
     virtual bool processTextDataDerived(std::string const& name, std::string const& value) = 0;
     virtual void frameValidEvent() { }
     bool disassembleHexData(VeDirectHexData &data);     //return true if disassembling was possible

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
@@ -24,7 +24,7 @@ class VeDirectFrameHandler {
 public:
     virtual void loop();                         // main loop to read ve.direct data
     uint32_t getLastUpdate() const;              // timestamp of last successful frame read
-    bool isDataValid();                          // return true if data valid and not outdated
+    bool isDataValid() const { return _dataValid; }
     T const& getData() const { return _tmpFrame; }
     bool sendHexCommand(VeDirectHexCommand cmd, VeDirectHexRegister addr, uint32_t value = 0, uint8_t valsize = 0);
     bool isStateIdle() const { return (_state == State::IDLE); }

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
@@ -24,7 +24,7 @@ class VeDirectFrameHandler {
 public:
     virtual void loop();                         // main loop to read ve.direct data
     uint32_t getLastUpdate() const;              // timestamp of last successful frame read
-    bool isDataValid() const;                    // return true if data valid and not outdated
+    bool isDataValid();                          // return true if data valid and not outdated
     T const& getData() const { return _tmpFrame; }
     bool sendHexCommand(VeDirectHexCommand cmd, VeDirectHexRegister addr, uint32_t value = 0, uint8_t valsize = 0);
     bool isStateIdle() const { return (_state == State::IDLE); }
@@ -38,9 +38,7 @@ protected:
 
     bool _verboseLogging;
     Print* _msgOut;
-    uint32_t _lastUpdate;                       // timestamp of end frame (data may be fragmented across multiple frames)
-    size_t _actFrameNumber;                     // counts the necessary frames to obtain all related data
-    size_t _endFrameNumber;                     // buffer the end frame number
+    uint32_t _lastUpdate;                       // timestamp of frame containing field "V"
 
     T _tmpFrame;
 
@@ -51,7 +49,7 @@ private:
     void reset();
     void dumpDebugBuffer();
     void rxData(uint8_t inbyte);              // byte of serial data
-    bool processTextData(std::string const& name, std::string const& value);
+    void processTextData(std::string const& name, std::string const& value);
     virtual bool processTextDataDerived(std::string const& name, std::string const& value) = 0;
     virtual void frameValidEvent() { }
     bool disassembleHexData(VeDirectHexData &data);     //return true if disassembling was possible
@@ -80,6 +78,9 @@ private:
     std::array<uint8_t, 512> _debugBuffer;
     unsigned _debugIn;
     uint32_t _lastByteMillis;                  // time of last parsed byte
+    bool _dataValid;                           // true if data is valid and not outdated
+    bool _startUpPassed;                       // helps to handle correct start up on multible frames
+    bool _frameContainsFieldV;                 // true if frame contains field "V"
 
     /**
      * not every frame contains every value the device is communicating, i.e.,

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
@@ -79,7 +79,7 @@ private:
     unsigned _debugIn;
     uint32_t _lastByteMillis;                  // time of last parsed byte
     bool _dataValid;                           // true if data is valid and not outdated
-    bool _startUpPassed;                       // helps to handle correct start up on multible frames
+    bool _startUpPassed;                       // helps to handle correct start up on multiple frames
     bool _frameContainsFieldV;                 // true if frame contains field "V"
 
     /**


### PR DESCRIPTION
This PR can be one possible solution of issue #1499 

Testing is ongoing on system with 1 smart shunt (2 frames) and 2 solar charger (1 frame) 

Note: isDataValid() use now the batteryVoltage_V_mV instead of the serialNr_SER because batteryVoltage_V_mV is available on all VE.Direct devices and serialNr_SER only on solar charger.