### PR TITLE
Fix: assume small increase for shaded inverter

### DIFF
--- a/src/PowerLimiterSolarInverter.cpp
+++ b/src/PowerLimiterSolarInverter.cpp
@@ -71,8 +71,10 @@ uint16_t PowerLimiterSolarInverter::getMaxIncreaseWatts() const
     }
 
     if (dcNonShadedMppts == 0) {
-        // all mppts are shaded, we can't increase the power
-        return 0;
+        // all mppts are shaded according to our calculation.
+        // but because we can not be sure we assume that we can
+        // increase the power by 3% of the max power.
+        return getConfiguredMaxPowerWatts() / 33;
     }
 
     if (dcNonShadedMppts == dcTotalMppts) {


### PR DESCRIPTION
To prevent solar powered inverters from getting stuck at their limit because all MPPTs assume shaded we assume that we can increase the limit by 3% of the max power.

As discussed here: https://github.com/hoylabs/OpenDTU-OnBattery/pull/1473#issuecomment-2576016384

Test builds can be found here: https://github.com/hoylabs/OpenDTU-OnBattery/actions/runs/12667599063?pr=1507