### PR TITLE
Fix: huawei grid charger: prevent deadlock on mutex

### DIFF
--- a/src/gridcharger/huawei/Controller.cpp
+++ b/src/gridcharger/huawei/Controller.cpp
@@ -287,6 +287,8 @@ void Controller::loop()
 
 void Controller::setParameter(float val, HardwareInterface::Setting setting)
 {
+    std::lock_guard<std::mutex> lock(_mutex);
+
     if (_mode == HUAWEI_MODE_AUTO_INT &&
         setting != HardwareInterface::Setting::OfflineVoltage &&
         setting != HardwareInterface::Setting::OfflineCurrent) { return; }
@@ -296,7 +298,7 @@ void Controller::setParameter(float val, HardwareInterface::Setting setting)
 
 void Controller::_setParameter(float val, HardwareInterface::Setting setting)
 {
-    std::lock_guard<std::mutex> lock(_mutex);
+    // NOTE: the mutex is locked by any method calling this private method
 
     if (!_upHardwareInterface) { return; }
 


### PR DESCRIPTION
the huawei grid charger's loop() uses the private method _setParameter() to update PSU settings. the loop() already holds the mutex, so _setParamater() must not try to lock the mutex again.

move the lock guard to the public setParameter() method, which resolves the issue.