### PR TITLE
Fix: maxIncrease for overscaling solar inverter

### DIFF
--- a/src/PowerLimiterSolarInverter.cpp
+++ b/src/PowerLimiterSolarInverter.cpp
@@ -82,9 +82,13 @@ uint16_t PowerLimiterSolarInverter::getMaxIncreaseWatts() const
         return maxTotalIncrease;
     }
 
-    // for inverter with PDL we use the max power of the inverter because each MPPT can deliver its max power,
     // for inverters without PDL we use the configured max power, because the limit will be divided equally across the MPPTs by the inverter.
-    int16_t inverterMaxPower = _spInverter->supportsPowerDistributionLogic() ? getInverterMaxPowerWatts() : getConfiguredMaxPowerWatts();
+    int16_t inverterMaxPower = getConfiguredMaxPowerWatts();
+
+    // for inverter with PDL or when overscaling is enabled we use the max power of the inverter because each MPPT can deliver its max power.
+    if (_spInverter->supportsPowerDistributionLogic() || _config.UseOverscaling) {
+        inverterMaxPower = getInverterMaxPowerWatts();
+    }
 
     int16_t maxPowerPerMppt = inverterMaxPower / dcTotalMppts;
 


### PR DESCRIPTION
Use inverter maxPower instead of configuredMaxPower when overscaling is enabled for a solar inverter to calculate the maxIncrease, because the limit will be overscaled to allow every MPPT to provide its maximum power.

Follow up to https://github.com/hoylabs/OpenDTU-OnBattery/pull/1513