### PR TITLE
Fix: allow management of DPL inverters while DPL is off

### DIFF
--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -74,10 +74,11 @@ private:
     std::pair<bool, uint32_t> _nextInverterRestart = { false, 0 };
     bool _fullSolarPassThroughEnabled = false;
     bool _verboseLogging = true;
+    bool _shutdownComplete = false;
 
     frozen::string const& getStatusText(Status status);
     void announceStatus(Status status);
-    bool shutdown(Status status);
+    bool isDisabled();
     void reloadConfig();
     std::pair<float, char const*> getInverterDcVoltage();
     float getBatteryVoltage(bool log = false);


### PR DESCRIPTION
we do allow to send limit updates and to start or stop the inverter using the web UI or MQTT payloads or any other supported mean even if this inverter is governed by the DPL, while the DPL is disabled. this is also documented explicitly (see DPL mode MQTT docs).

after implementing support for multiple inverters, this behavior changed unintentionally. this changeset makes sure that inverters are shut down once when the DPL dis disabled, but are left alone afterwards for as long as the DPL is disabled.

closes #1521.