### PR TITLE
Fix: DPL limit is changing with every loop (solar-powered inverters)

### DIFF
--- a/src/PowerLimiterSolarInverter.cpp
+++ b/src/PowerLimiterSolarInverter.cpp
@@ -63,10 +63,8 @@ uint16_t PowerLimiterSolarInverter::getMaxIncreaseWatts() const
     }
 
     if (dcNonShadedMppts == 0) {
-        // all mppts are shaded according to our calculation.
-        // but because we can not be sure we assume that we can
-        // increase the power by 3% of the max power.
-        return getConfiguredMaxPowerWatts() / 33;
+        // all mppts are shaded, we can't increase the power
+        return 0;
     }
 
     if (dcNonShadedMppts == dcTotalMppts) {

--- a/src/PowerLimiterSolarInverter.cpp
+++ b/src/PowerLimiterSolarInverter.cpp
@@ -27,14 +27,6 @@ uint16_t PowerLimiterSolarInverter::getMaxIncreaseWatts() const
     // the maximum increase possible for this inverter
     int16_t maxTotalIncrease = getConfiguredMaxPowerWatts() - getCurrentOutputAcWatts();
 
-    // when the current limit is less than 15% of the max power of the inverter
-    // the output will not match the limit as the inverters are not able to work
-    // with those low limits. In this case we assume that the inverter is able to
-    // provide more power and we return the maximum possible increase.
-    // thanks spcqike for creating a table that can be found here:
-    // https://github.com/hoylabs/OpenDTU-OnBattery/issues/1087#issuecomment-2216787552
-    if (getCurrentLimitWatts() < getInverterMaxPowerWatts() * 0.15) { return maxTotalIncrease; }
-
     auto pStats = _spInverter->Statistics();
     std::vector<MpptNum_t> dcMppts = _spInverter->getMppts();
     size_t dcTotalMppts = dcMppts.size();


### PR DESCRIPTION
Reverted as it leads to frequent, high changes of the limit on every other DPL loop.
Example: https://github.com/hoylabs/OpenDTU-OnBattery/discussions/1524

Original info that is true but can't be fixed with the rule that has been applied.
>Low limits
>Inverters with low limit (below 15%) are usually not able to provide the expected power and we would rate mppts as shaded.
>This will result in us thinking that we can't get more power from that inverter and the limit is 'stuck'.

Also reverts https://github.com/hoylabs/OpenDTU-OnBattery/pull/1507

Fixes https://github.com/hoylabs/OpenDTU-OnBattery/issues/1530