### PR TITLE
Feature: show mqtt battery live view card

### DIFF
--- a/include/BatteryStats.h
+++ b/include/BatteryStats.h
@@ -348,7 +348,5 @@ class MqttBatteryStats : public BatteryStats {
         // we do NOT publish the same data under a different topic.
         void mqttPublish() const final { }
 
-        void getLiveViewData(JsonVariant& root) const final;
-
         bool supportsAlarmsAndWarnings() const final { return false; }
 };

--- a/src/BatteryStats.cpp
+++ b/src/BatteryStats.cpp
@@ -109,15 +109,6 @@ void BatteryStats::getLiveViewData(JsonVariant& root) const
     root["showIssues"] = supportsAlarmsAndWarnings();
 }
 
-void MqttBatteryStats::getLiveViewData(JsonVariant& root) const
-{
-    // as we don't want to repeat the data that is already shown in the live data card
-    // we only add the live view data here when the discharge current limit can be shown
-    if (isDischargeCurrentLimitValid()) {
-        BatteryStats::getLiveViewData(root);
-    }
-}
-
 void PylontechBatteryStats::getLiveViewData(JsonVariant& root) const
 {
     BatteryStats::getLiveViewData(root);


### PR DESCRIPTION
Always show mqtt battery live view card as it provides the data age

Closes https://github.com/hoylabs/OpenDTU-OnBattery/issues/1540