### PR TITLE
Fix: 'create release badge' action 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,25 +141,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Get tags
-        run: git fetch --force --tags origin
+      - name: Get openDTU core tags
+        run: git fetch --force --tags https://github.com/tbnobody/OpenDTU.git
 
       - name: Get openDTU core release
         run: |
           echo "OPEN_DTU_CORE_RELEASE=$(git for-each-ref --sort=creatordate --format '%(refname) %(creatordate)' refs/tags | grep 'refs/tags/v' | tail -1 | sed 's#.*/##' | sed 's/ .*//')" >> $GITHUB_ENV
 
-# disabled as uploading the changed gist failed repeatedly.
-# maybe the token in secrets.GIST_SECRET has expired?
-# need help from repo owner @helgeerbe to fix this.
-#      - name: Create openDTU-core-release-Badge
-#        uses: schneegans/dynamic-badges-action@v1.6.0
-#        with:
-#          auth: ${{ secrets.GIST_SECRET }}
-#          gistID: 68b47cc8c8994d04ab3a4fa9d8aee5e6
-#          filename: openDTUcoreRelease.json
-#          label: based on original OpenDTU
-#          message: ${{ env.OPEN_DTU_CORE_RELEASE }}
-#          color: lightblue
+      - name: Create openDTU-core-release-Badge
+        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # version 1.7.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: 856dda48c1cadac6ea495213340c612b
+          filename: openDTUcoreRelease.json
+          label: based on upstream OpenDTU
+          message: ${{ env.OPEN_DTU_CORE_RELEASE }}
+          color: lightblue
 
       - name: Build Changelog
         id: github_release

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 [![OpenDTU-OnBattery Build](https://github.com/hoylabs/OpenDTU-OnBattery/actions/workflows/build.yml/badge.svg)](https://github.com/hoylabs/OpenDTU-OnBattery/actions/workflows/build.yml)
 [![cpplint](https://github.com/hoylabs/OpenDTU-OnBattery/actions/workflows/cpplint.yml/badge.svg)](https://github.com/hoylabs/OpenDTU-OnBattery/actions/workflows/cpplint.yml)
 [![Yarn Linting](https://github.com/hoylabs/OpenDTU-OnBattery/actions/workflows/yarnlint.yml/badge.svg)](https://github.com/hoylabs/OpenDTU-OnBattery/actions/workflows/yarnlint.yml)
-<!---
-disabled while "create release badge" action is broken, see .github/build.yml
-![GitHub tag (latest SemVer)](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/helgeerbe/68b47cc8c8994d04ab3a4fa9d8aee5e6/raw/openDTUcoreRelease.json)
---->
+![GitHub tag (latest SemVer)](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AndreasBoehm/856dda48c1cadac6ea495213340c612b/raw/openDTUcoreRelease.json)
 
 - [OpenDTU-OnBattery](#opendtu-onbattery)
   - [Getting Started](#getting-started)


### PR DESCRIPTION
GIST_SECRET and the gist are living on my personal account as its not possible to have a gist on organisation level