### PR TITLE
fix: millis() rollover issue in smart shunt loop()

### DIFF
--- a/src/VictronSmartShunt.cpp
+++ b/src/VictronSmartShunt.cpp
@@ -37,7 +37,7 @@ void VictronSmartShunt::loop()
 {
     VeDirectShunt.loop();
 
-    if (VeDirectShunt.getLastUpdate() <= _lastUpdate) { return; }
+    if (VeDirectShunt.getLastUpdate() == _lastUpdate) { return; }
 
     _stats->updateFrom(VeDirectShunt.getData());
     _lastUpdate = VeDirectShunt.getLastUpdate();


### PR DESCRIPTION
Theoretically the battery provider "Smart Shunt" will stop providing data after 49 days.



