### PR TITLE
add schlimmchen to FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
 ko_fi: schlimmchen
-ko_fi: andreasboehm

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
-ko_fi: tbnobody
+ko_fi: schlimmchen
+ko_fi: andreasboehm


### PR DESCRIPTION
The FUNDING.yml is used by github to show sponsorship links on the repository overview.

![Screenshot 2025-01-22 at 11 37 47](https://github.com/user-attachments/assets/fd657177-1a34-46db-bc85-37bb526485b1)
