### PR TITLE
Feature: adjust limit commands for inverters with fw >= 1.1.12

### DIFF
--- a/lib/Hoymiles/src/commands/ActivePowerControlCommand.cpp
+++ b/lib/Hoymiles/src/commands/ActivePowerControlCommand.cpp
@@ -76,7 +76,10 @@ bool ActivePowerControlCommand::handleResponse(const fragment_t fragment[], cons
         return false;
     }
 
-    if ((getType() == PowerLimitControlType::RelativNonPersistent) || (getType() == PowerLimitControlType::RelativPersistent)) {
+    if ((getType() == PowerLimitControlType::RelativNonPersistent)
+        || (getType() == PowerLimitControlType::RelativPersistent)
+        || (getType() == PowerLimitControlType::RelativNonPersistentPDL)
+        || (getType() == PowerLimitControlType::RelativPersistentPDL)) {
         _inv->SystemConfigPara()->setLimitPercent(getLimit());
     } else {
         const uint16_t max_power = _inv->DevInfo()->getMaxPower();

--- a/lib/Hoymiles/src/commands/ActivePowerControlCommand.h
+++ b/lib/Hoymiles/src/commands/ActivePowerControlCommand.h
@@ -6,8 +6,12 @@
 typedef enum { // ToDo: to be verified by field tests
     AbsolutNonPersistent = 0x0000, // 0
     RelativNonPersistent = 0x0001, // 1
+    AbsolutNonPersistentPDL = 0x0002, // 2
+    RelativNonPersistentPDL = 0x0003, // 3
     AbsolutPersistent = 0x0100, // 256
-    RelativPersistent = 0x0101 // 257
+    RelativPersistent = 0x0101, // 257
+    AbsolutPersistentPDL = 0x0102, // 258
+    RelativPersistentPDL = 0x0103 // 259
 } PowerLimitControlType;
 
 class ActivePowerControlCommand : public DevControlCommand {


### PR DESCRIPTION
## Infos
As explained by stefant in this comment https://github.com/tbnobody/OpenDTU/discussions/2153#discussioncomment-11914884 we should use type `0x0003` for setting the relative non-persistent limit on firmware version 01.01.12 and above.

This also fixes the issue with firmware version 2.0.4 where the inverter switches to its persistent limit ~4-5 minutes after the last non-persistent limit has been set using the 'old' command type `0x0001`. (See https://github.com/hoylabs/OpenDTU-OnBattery/discussions/1881#discussioncomment-12892621 and https://github.com/tbnobody/OpenDTU/discussions/2153#discussioncomment-12900240)

Closes #1890 

## Input from Dirk (Ahoy)
```
// Power Distribution Logic (PDL) is available from Firmware verison 1.01.12
// the commands are backward compatible to older verisons, which act the same
// before adding PDL feature to Ahoy
static constexpr uint16_t PDL = 0x0002;

typedef enum {
    AbsolutNonPersistent  = 0x0000 | PDL,
    RelativNonPersistent  = 0x0001 | PDL,
    AbsolutPersistent     = 0x0100 | PDL,
    RelativPersistent     = 0x0101 | PDL
} PowerLimitControlType;
```

> mittlerweile hab ich aber rausgefunden das die älteren firmwares ewig dauern zum fressen des 3er commands - daher muss noch eine abfrage der version rein.

Source: https://discord.com/channels/984173303147155506/992022163307638887/1364265050139005011

## ToDo
- [ ] only apply the new command type when HMS with FW >= 1.1.12 is used
- [ ] don't break setting of the persistent limits
- [ ] use new command for persistent limits when HMS with FW >= 1.1.12 is used
- [ ] implement it in a nice way
- [ ] fully test it with firmware 1.0.x
- [ ] fully test it with firmware 1.1.12
- [ ] fully test it with firmware 2.0.4
