### PR TITLE
Huawei grid charger usability fixes

### DIFF
--- a/include/gridcharger/huawei/HardwareInterface.h
+++ b/include/gridcharger/huawei/HardwareInterface.h
@@ -27,7 +27,7 @@ public:
     };
     void setParameter(Setting setting, float val);
 
-    std::unique_ptr<DataPointContainer> getCurrentData() { return std::move(_upDataCurrent); }
+    std::unique_ptr<DataPointContainer> getCurrentData();
 
     static uint32_t constexpr DataRequestIntervalMillis = 2500;
 

--- a/src/gridcharger/huawei/HardwareInterface.cpp
+++ b/src/gridcharger/huawei/HardwareInterface.cpp
@@ -169,6 +169,7 @@ void HardwareInterface::setParameter(HardwareInterface::Setting setting, float v
     }
 
     _sendQueue.push({setting, static_cast<uint16_t>(val)});
+    _nextRequestMillis = millis() - 1; // request param feedback immediately
 
     xTaskNotifyGive(_taskHandle);
 }

--- a/src/gridcharger/huawei/HardwareInterface.cpp
+++ b/src/gridcharger/huawei/HardwareInterface.cpp
@@ -31,7 +31,7 @@ bool HardwareInterface::startLoop()
 {
     uint32_t constexpr stackSize = 3072;
     return pdPASS == xTaskCreate(HardwareInterface::staticLoopHelper,
-            "HuaweiHwIfc", stackSize, this, 10/*prio*/, &_taskHandle);
+            "HuaweiHwIfc", stackSize, this, 16/*prio*/, &_taskHandle);
 }
 
 void HardwareInterface::stopLoop()

--- a/src/gridcharger/huawei/MCP2515.cpp
+++ b/src/gridcharger/huawei/MCP2515.cpp
@@ -16,8 +16,11 @@ void mcp2515Isr()
     if (sIsrTaskHandle == nullptr) { return; }
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;
     vTaskNotifyGiveFromISR(sIsrTaskHandle, &xHigherPriorityTaskWoken);
-    // we assume we can wait until the lower-priority task is scheduled
-    // anyways, so we ignore xHigherPriorityTaskWoken == pdTRUE.
+    // make sure that the high-priority hardware interface task is scheduled,
+    // as the timing is very critical. CAN messages will be missed if the
+    // MCP2515 interrupt is not serviced immediately, as a new message
+    // overwrites a pending message.
+    portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 }
 
 std::optional<uint8_t> MCP2515::_oSpiBus = std::nullopt;


### PR DESCRIPTION
* Fetching CAN messages (from the MCP2515) is very time critical. Attempt to miss less (hopefully none at all) messages.
* Stop caching new values for too long. Restore the previous trigger to push the values up to higher software levels.
* Send a request for data immediately after sending a parameter, allowing to update the PSU values in a timely manner.