### PR TITLE
add: "State of Operation", "Float voltage" and "Absorption Voltage"

### DIFF
--- a/include/solarcharger/DummyStats.h
+++ b/include/solarcharger/DummyStats.h
@@ -13,6 +13,9 @@ public:
     std::optional<uint16_t> getPanelPowerWatts() const final { return std::nullopt; }
     std::optional<float> getYieldTotal() const final { return std::nullopt; }
     std::optional<float> getYieldDay() const final { return std::nullopt; }
+    std::optional<uint8_t> getStateOfOperation() const final { return std::nullopt; }
+    std::optional<float> getFloatVoltage() const final { return std::nullopt; }
+    std::optional<float> getAbsorptionVoltage() const final { return std::nullopt; }
     void getLiveViewData(JsonVariant& root, const boolean fullUpdate, const uint32_t lastPublish) const final {}
     void mqttPublish() const final {}
     void mqttPublishSensors(const boolean forcePublish) const final {}

--- a/include/solarcharger/DummyStats.h
+++ b/include/solarcharger/DummyStats.h
@@ -13,7 +13,7 @@ public:
     std::optional<uint16_t> getPanelPowerWatts() const final { return std::nullopt; }
     std::optional<float> getYieldTotal() const final { return std::nullopt; }
     std::optional<float> getYieldDay() const final { return std::nullopt; }
-    std::optional<uint8_t> getStateOfOperation() const final { return std::nullopt; }
+    std::optional<StateOfOperation> getStateOfOperation() const final { return std::nullopt; }
     std::optional<float> getFloatVoltage() const final { return std::nullopt; }
     std::optional<float> getAbsorptionVoltage() const final { return std::nullopt; }
     void getLiveViewData(JsonVariant& root, const boolean fullUpdate, const uint32_t lastPublish) const final {}

--- a/include/solarcharger/Stats.h
+++ b/include/solarcharger/Stats.h
@@ -28,13 +28,13 @@ public:
 
     // state of operation from the first available controller
     enum class StateOfOperation : uint8_t { Off = 0, Bulk = 1, Absorption = 2, Float = 3, Various = 255 };
-    virtual std::optional<Stats::StateOfOperation> getStateOfOperation() const { return std::nullopt; };
+    virtual std::optional<Stats::StateOfOperation> getStateOfOperation() const;
 
     // float voltage from the first available charge controller
-    virtual std::optional<float> getFloatVoltage() const { return std::nullopt; };
+    virtual std::optional<float> getFloatVoltage() const;
 
     // absorption voltage from the first available charge controller
-    virtual std::optional<float> getAbsorptionVoltage() const { return std::nullopt; };
+    virtual std::optional<float> getAbsorptionVoltage() const;
 
     // convert stats to JSON for web application live view
     virtual void getLiveViewData(JsonVariant& root, const boolean fullUpdate, const uint32_t lastPublish) const;

--- a/include/solarcharger/Stats.h
+++ b/include/solarcharger/Stats.h
@@ -26,6 +26,15 @@ public:
     // sum of today's yield of all MPPT charge controllers in Wh
     virtual std::optional<float> getYieldDay() const;
 
+    // state of operation from the first available controller
+    virtual std::optional<uint8_t> getStateOfOperation() const { return std::nullopt; };
+
+    // float voltage from the first available charge controller
+    virtual std::optional<float> getFloatVoltage() const { return std::nullopt; };
+
+    // absorption voltage from the first available charge controller
+    virtual std::optional<float> getAbsorptionVoltage() const { return std::nullopt; };
+
     // convert stats to JSON for web application live view
     virtual void getLiveViewData(JsonVariant& root, const boolean fullUpdate, const uint32_t lastPublish) const;
 

--- a/include/solarcharger/Stats.h
+++ b/include/solarcharger/Stats.h
@@ -27,11 +27,7 @@ public:
     virtual std::optional<float> getYieldDay() const;
 
     // state of operation from the first available controller
-    enum class StateOfOperation : uint8_t {
-        Off = 0, LimitedPower = 1, Fault = 2, Bulk = 3, Absorption = 4, Float = 5, Storage = 6,
-        Equalize = 7, Inverting = 9, PowerSupply = 11, Starting = 245, AutoEqualize = 246,
-        Slave = 247, Disconnect = 248, None = 255,
-    };
+    enum class StateOfOperation : uint8_t { Off = 0, Bulk = 1, Absorption = 2, Float = 3, Various = 255 };
     virtual std::optional<Stats::StateOfOperation> getStateOfOperation() const { return std::nullopt; };
 
     // float voltage from the first available charge controller

--- a/include/solarcharger/Stats.h
+++ b/include/solarcharger/Stats.h
@@ -27,7 +27,12 @@ public:
     virtual std::optional<float> getYieldDay() const;
 
     // state of operation from the first available controller
-    virtual std::optional<uint8_t> getStateOfOperation() const { return std::nullopt; };
+    enum class StateOfOperation : uint8_t {
+        Off = 0, LimitedPower = 1, Fault = 2, Bulk = 3, Absorption = 4, Float = 5, Storage = 6,
+        Equalize = 7, Inverting = 9, PowerSupply = 11, Starting = 245, AutoEqualize = 246,
+        Slave = 247, Disconnect = 248, None = 255,
+    };
+    virtual std::optional<Stats::StateOfOperation> getStateOfOperation() const { return std::nullopt; };
 
     // float voltage from the first available charge controller
     virtual std::optional<float> getFloatVoltage() const { return std::nullopt; };

--- a/include/solarcharger/mqtt/Stats.h
+++ b/include/solarcharger/mqtt/Stats.h
@@ -17,6 +17,9 @@ public:
     std::optional<uint16_t> getPanelPowerWatts() const final { return std::nullopt; }
     std::optional<float> getYieldTotal() const final { return std::nullopt; }
     std::optional<float> getYieldDay() const final { return std::nullopt; }
+    std::optional<StateOfOperation> getStateOfOperation() const final { return std::nullopt; }
+    std::optional<float> getFloatVoltage() const final { return std::nullopt; }
+    std::optional<float> getAbsorptionVoltage() const final { return std::nullopt; }
 
     void getLiveViewData(JsonVariant& root, const boolean fullUpdate, const uint32_t lastPublish) const final;
 

--- a/include/solarcharger/victron/Stats.h
+++ b/include/solarcharger/victron/Stats.h
@@ -16,6 +16,9 @@ public:
     std::optional<uint16_t> getPanelPowerWatts() const final;
     std::optional<float> getYieldTotal() const final;
     std::optional<float> getYieldDay() const final;
+    std::optional<uint8_t> getStateOfOperation() const final;
+    std::optional<float> getFloatVoltage() const final;
+    std::optional<float> getAbsorptionVoltage() const final;
 
     void getLiveViewData(JsonVariant& root, const boolean fullUpdate, const uint32_t lastPublish) const final;
     void mqttPublish() const final;

--- a/include/solarcharger/victron/Stats.h
+++ b/include/solarcharger/victron/Stats.h
@@ -16,7 +16,7 @@ public:
     std::optional<uint16_t> getPanelPowerWatts() const final;
     std::optional<float> getYieldTotal() const final;
     std::optional<float> getYieldDay() const final;
-    std::optional<uint8_t> getStateOfOperation() const final;
+    std::optional<StateOfOperation> getStateOfOperation() const final;
     std::optional<float> getFloatVoltage() const final;
     std::optional<float> getAbsorptionVoltage() const final;
 

--- a/src/solarcharger/victron/Stats.cpp
+++ b/src/solarcharger/victron/Stats.cpp
@@ -115,11 +115,11 @@ std::optional<float> Stats::getYieldDay() const
     return sum;
 }
 
-std::optional<uint8_t> Stats::getStateOfOperation() const
+std::optional<Stats::StateOfOperation> Stats::getStateOfOperation() const
 {
     for (auto const& entry : _data) {
         if (!entry.second) { continue; }
-        return entry.second->currentState_CS;
+        return static_cast<Stats::StateOfOperation>(entry.second->currentState_CS);
     }
     return std::nullopt;
 }

--- a/src/solarcharger/victron/Stats.cpp
+++ b/src/solarcharger/victron/Stats.cpp
@@ -115,6 +115,39 @@ std::optional<float> Stats::getYieldDay() const
     return sum;
 }
 
+std::optional<uint8_t> Stats::getStateOfOperation() const
+{
+    for (auto const& entry : _data) {
+        if (!entry.second) { continue; }
+        return entry.second->currentState_CS;
+    }
+    return std::nullopt;
+}
+
+std::optional<float> Stats::getFloatVoltage() const
+{
+    for (auto const& entry : _data) {
+        if (!entry.second) { continue; }
+        auto voltage = entry.second->BatteryFloatMilliVolt;
+        if (voltage.first > 0) { // only return valid and not outdated value
+            return voltage.second / 1000.0;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<float> Stats::getAbsorptionVoltage() const
+{
+    for (auto const& entry : _data) {
+        if (!entry.second) { continue; }
+        auto voltage = entry.second->BatteryAbsorptionMilliVolt;
+        if (voltage.first > 0) { // only return valid and not outdated value
+            return voltage.second / 1000.0;
+        }
+    }
+    return std::nullopt;
+}
+
 void Stats::getLiveViewData(JsonVariant& root, const boolean fullUpdate, const uint32_t lastPublish) const
 {
     ::SolarChargers::Stats::getLiveViewData(root, fullUpdate, lastPublish);

--- a/src/solarcharger/victron/Stats.cpp
+++ b/src/solarcharger/victron/Stats.cpp
@@ -119,7 +119,15 @@ std::optional<Stats::StateOfOperation> Stats::getStateOfOperation() const
 {
     for (auto const& entry : _data) {
         if (!entry.second) { continue; }
-        return static_cast<Stats::StateOfOperation>(entry.second->currentState_CS);
+        // see victron protocol documentation for CS values
+        switch (entry.second->currentState_CS) {
+            case 0: return Stats::StateOfOperation::Off;
+            case 3: return Stats::StateOfOperation::Bulk;
+            case 246:
+            case 4: return Stats::StateOfOperation::Absorption;
+            case 5: return Stats::StateOfOperation::Float;
+            default: return Stats::StateOfOperation::Various;
+        }
     }
     return std::nullopt;
 }


### PR DESCRIPTION
I'm not sure if I did it the right way.

I want to get the "State of Operation", "Float voltage" and "Absorption Voltage" from the victron charge controller.
But I don't want to force every solar charger provider to provide these functions.
If other provider (MPPT) support these functions, then other functions like the "Surplus" or the "Batterie Guard" should also work.

At least that was the idea behind. 

Any suggestions?
