### PR TITLE
WIP: see if availableForWriteAll() is a problem

### DIFF
--- a/src/MessageOutput.cpp
+++ b/src/MessageOutput.cpp
@@ -109,7 +109,7 @@ void MessageOutputClass::loop()
         return;
     }
 
-    while (!_lines.empty() && _ws->availableForWriteAll()) {
+    while (!_lines.empty()) {
         Syslog.write(_lines.front().data(), _lines.front().size());
         _ws->textAll(std::make_shared<message_t>(std::move(_lines.front())));
         _lines.pop();

--- a/src/WebApi_ws_console.cpp
+++ b/src/WebApi_ws_console.cpp
@@ -45,6 +45,9 @@ void WebApiWsConsoleClass::reload()
 
 void WebApiWsConsoleClass::wsCleanupTaskCb()
 {
-    // see: https://github.com/me-no-dev/ESPAsyncWebServer#limiting-the-number-of-web-socket-clients
-    _ws.cleanupClients();
+    // see: https://github.com/ESP32Async/ESPAsyncWebServer#limiting-the-number-of-web-socket-clients
+    // calling this function without an argument will use a default maximum
+    // number of clients to keep. since the web console is using quite a lot
+    // of memory, we only permit two clients at the same time.
+    _ws.cleanupClients(2);
 }


### PR DESCRIPTION
It is possible that `availableForWriteAll()` does return false, leading us to keep a whole bunch of lines of text forever.