### PR TITLE
webapp: hide overscaling thresh. for inv with PDL

### DIFF
--- a/webapp/src/views/PowerLimiterAdminView.vue
+++ b/webapp/src/views/PowerLimiterAdminView.vue
@@ -141,7 +141,10 @@
                         />
 
                         <InputElement
-                            v-if="powerLimiterConfigList.inverters[idx].use_overscaling_to_compensate_shading"
+                            v-if="
+                                powerLimiterConfigList.inverters[idx].use_overscaling_to_compensate_shading &&
+                                inverterSupportsOverscaling(inv.serial)
+                            "
                             :label="$t('powerlimiteradmin.ScalingPowerThreshold')"
                             v-model="powerLimiterConfigList.inverters[idx].scaling_threshold"
                             :tooltip="$t('powerlimiteradmin.ScalingPowerThresholdHint')"


### PR DESCRIPTION
This fixes that when a inverter was configured for overscaling with a firmware before PDL was introduced, then updated to a firmware that supports PDL you can still see the overscaling threshold input field in the DPL config.

w/o fix it looks like this
![Screenshot 2025-02-06 at 11 07 06](https://github.com/user-attachments/assets/da2d5c68-90c1-4d8c-abf0-1a1f7e6c4087)
