### PR TITLE
Fix: DPL mode 2 for smart-buffer-powered inverters and unconditional-passthrough method name

### DIFF
--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -86,7 +86,7 @@ private:
     std::pair<float, char const*> getInverterDcVoltage();
     float getBatteryVoltage(bool log = false);
     uint16_t dcPowerBusToInverterAc(uint16_t dcPower);
-    void fullSolarPassthrough(PowerLimiterClass::Status reason);
+    void unconditionalFullSolarPassthrough();
     int16_t calcConsumption();
     using inverter_filter_t = std::function<bool(PowerLimiterInverter const&)>;
     uint16_t updateInverterLimits(uint16_t powerRequested, inverter_filter_t filter, std::string const& filterExpression);

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -459,7 +459,7 @@ void PowerLimiterClass::fullSolarPassthrough(PowerLimiterClass::Status reason)
     _lastCalculation = millis();
 
     for (auto& upInv : _inverters) {
-        if (upInv->isSolarPowered()) { upInv->setMaxOutput(); }
+        if (!upInv->isBatteryPowered()) { upInv->setMaxOutput(); }
     }
 
     uint16_t targetOutput = 0;

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -209,7 +209,7 @@ void PowerLimiterClass::loop()
     // calculation at all after surviving the loop above, which ensures that we
     // have inverter stats more recent than their respective last update command
     if (Mode::UnconditionalFullSolarPassthrough == _mode) {
-        return fullSolarPassthrough(Status::UnconditionalSolarPassthrough);
+        return unconditionalFullSolarPassthrough();
     }
 
     // if the power meter is being used, i.e., if its data is valid, we want to
@@ -448,12 +448,12 @@ uint16_t PowerLimiterClass::dcPowerBusToInverterAc(uint16_t dcPower)
 }
 
 /**
- * implements the "full solar passthrough" mode of operation. in this mode of
+ * implements the "uncoditional full solar passthrough" mode of operation. in this mode of
  * operation, the inverters shall behave as if they were connected to the solar
  * panels directly, i.e., all solar power (and only solar power) is converted
  * to AC power, independent from the power meter reading.
  */
-void PowerLimiterClass::fullSolarPassthrough(PowerLimiterClass::Status reason)
+void PowerLimiterClass::unconditionalFullSolarPassthrough()
 {
     if ((millis() - _lastCalculation) < _calculationBackoffMs) { return; }
     _lastCalculation = millis();
@@ -472,7 +472,7 @@ void PowerLimiterClass::fullSolarPassthrough(PowerLimiterClass::Status reason)
 
     _calculationBackoffMs = 1 * 1000;
     updateInverterLimits(targetOutput, sBatteryPoweredFilter, sBatteryPoweredExpression);
-    return announceStatus(reason);
+    return announceStatus(Status::UnconditionalSolarPassthrough);
 }
 
 uint8_t PowerLimiterClass::getInverterUpdateTimeouts() const


### PR DESCRIPTION
### fix: DPL mode 2 for smart-buffer-powered inverters
for smart-buffer-powered inverters, the unconditional full solar-passthrough implementation now sets the upper limit configured in the DPL settings.

### Fix: DPL unconditional-passthrough method name
To avoid confusion and to allow us to differentiate between the two modes/states the method 'fullSolarPassthrough' is now called 'unconditionalFullSolarPassthrough', which also better reflects its functionality.

