### PR TITLE
Minor corrections: Solar charger - Victron

### DIFF
--- a/include/solarcharger/Stats.h
+++ b/include/solarcharger/Stats.h
@@ -30,10 +30,10 @@ public:
     enum class StateOfOperation : uint8_t { Off = 0, Bulk = 1, Absorption = 2, Float = 3, Various = 255 };
     virtual std::optional<Stats::StateOfOperation> getStateOfOperation() const;
 
-    // float voltage from the first available charge controller
+    // float voltage from the first available charge controller in V
     virtual std::optional<float> getFloatVoltage() const;
 
-    // absorption voltage from the first available charge controller
+    // absorption voltage from the first available charge controller in V
     virtual std::optional<float> getAbsorptionVoltage() const;
 
     // convert stats to JSON for web application live view

--- a/src/solarcharger/victron/Stats.cpp
+++ b/src/solarcharger/victron/Stats.cpp
@@ -78,7 +78,7 @@ std::optional<uint16_t> Stats::getPanelPowerWatts() const
         // requests, we should have the "network total DC input power" available.
         auto networkPower = entry.second->NetworkTotalDcInputPowerMilliWatts;
         if (networkPower.first > 0) {
-            return static_cast<int32_t>(networkPower.second / 1000.0);
+            return static_cast<uint16_t>(networkPower.second / 1000.0);
         }
 
         sum += entry.second->panelPower_PPV_W;
@@ -99,6 +99,7 @@ std::optional<float> Stats::getYieldTotal() const
         sum += entry.second->yieldTotal_H19_Wh / 1000.0;
     }
 
+    if (0 == sum) { return std::nullopt; }
     return sum;
 }
 
@@ -112,6 +113,7 @@ std::optional<float> Stats::getYieldDay() const
         sum += entry.second->yieldToday_H20_Wh;
     }
 
+    if (0 == sum) { return std::nullopt; }
     return sum;
 }
 
@@ -123,7 +125,6 @@ std::optional<Stats::StateOfOperation> Stats::getStateOfOperation() const
         switch (entry.second->currentState_CS) {
             case 0: return Stats::StateOfOperation::Off;
             case 3: return Stats::StateOfOperation::Bulk;
-            case 246:
             case 4: return Stats::StateOfOperation::Absorption;
             case 5: return Stats::StateOfOperation::Float;
             default: return Stats::StateOfOperation::Various;

--- a/src/solarcharger/victron/Stats.cpp
+++ b/src/solarcharger/victron/Stats.cpp
@@ -91,29 +91,35 @@ std::optional<uint16_t> Stats::getPanelPowerWatts() const
 
 std::optional<float> Stats::getYieldTotal() const
 {
-    float sum = 0;
+    std::optional<float> sum = std::nullopt;
 
     for (auto const& entry : _data) {
         if (!entry.second) { continue; }
 
-        sum += entry.second->yieldTotal_H19_Wh / 1000.0;
+        if (!sum.has_value()) {
+            sum = entry.second->yieldTotal_H19_Wh / 1000.0;
+        } else {
+            *sum += entry.second->yieldTotal_H19_Wh / 1000.0;
+        }
     }
 
-    if (0 == sum) { return std::nullopt; }
     return sum;
 }
 
 std::optional<float> Stats::getYieldDay() const
 {
-    float sum = 0;
+    std::optional<float> sum = std::nullopt;
 
     for (auto const& entry : _data) {
         if (!entry.second) { continue; }
 
-        sum += entry.second->yieldToday_H20_Wh;
+        if (!sum.has_value()) {
+            sum = entry.second->yieldToday_H20_Wh;
+        } else {
+            *sum += entry.second->yieldToday_H20_Wh;
+        }
     }
 
-    if (0 == sum) { return std::nullopt; }
     return sum;
 }
 

--- a/src/solarcharger/victron/Stats.cpp
+++ b/src/solarcharger/victron/Stats.cpp
@@ -33,45 +33,37 @@ uint32_t Stats::getAgeMillis() const
 
 std::optional<float> Stats::getOutputPowerWatts() const
 {
-    float sum = 0;
-    auto data = false;
+    std::optional<float> sum = std::nullopt;
 
     for (auto const& entry : _data) {
         if (!entry.second) { continue; }
-        data = true;
-        sum += entry.second->batteryOutputPower_W;
+        
+        sum = sum.has_value() ? *sum + entry.second->batteryOutputPower_W : entry.second->batteryOutputPower_W;
     }
-
-    if (!data) { return std::nullopt; }
 
     return sum;
 }
 
 std::optional<float> Stats::getOutputVoltage() const
 {
-    float min = -1;
+    std::optional<float> min = std::nullopt;
 
     for (auto const& entry : _data) {
         if (!entry.second) { continue; }
 
         float volts = entry.second->batteryVoltage_V_mV / 1000.0;
-        if (min == -1) { min = volts; }
-        min = std::min(min, volts);
+        min = min.has_value() ? std::min(*min, volts) : volts;
     }
-
-    if (min == -1) { return std::nullopt; }
 
     return min;
 }
 
 std::optional<uint16_t> Stats::getPanelPowerWatts() const
 {
-    uint16_t sum = 0;
-    auto data = false;
+    std::optional<float> sum = std::nullopt;
 
     for (auto const& entry : _data) {
         if (!entry.second) { continue; }
-        data = true;
 
         // if any charge controller is part of a VE.Smart network, and if the
         // charge controller is connected in a way that allows to send
@@ -81,10 +73,8 @@ std::optional<uint16_t> Stats::getPanelPowerWatts() const
             return static_cast<uint16_t>(networkPower.second / 1000.0);
         }
 
-        sum += entry.second->panelPower_PPV_W;
+        sum = sum.has_value() ? *sum + entry.second->panelPower_PPV_W : entry.second->panelPower_PPV_W;
     }
-
-    if (!data) { return std::nullopt; }
 
     return sum;
 }
@@ -96,11 +86,8 @@ std::optional<float> Stats::getYieldTotal() const
     for (auto const& entry : _data) {
         if (!entry.second) { continue; }
 
-        if (!sum.has_value()) {
-            sum = entry.second->yieldTotal_H19_Wh / 1000.0;
-        } else {
-            *sum += entry.second->yieldTotal_H19_Wh / 1000.0;
-        }
+        float yield = entry.second->yieldTotal_H19_Wh / 1000.0;
+        sum = sum.has_value() ? *sum + yield : yield;
     }
 
     return sum;
@@ -113,11 +100,7 @@ std::optional<float> Stats::getYieldDay() const
     for (auto const& entry : _data) {
         if (!entry.second) { continue; }
 
-        if (!sum.has_value()) {
-            sum = entry.second->yieldToday_H20_Wh;
-        } else {
-            *sum += entry.second->yieldToday_H20_Wh;
-        }
+        sum = sum.has_value() ? *sum + entry.second->yieldToday_H20_Wh : entry.second->yieldToday_H20_Wh;
     }
 
     return sum;


### PR DESCRIPTION
Changes:

- Removed case 246. This case is not used by solar charger, see Victron documentation for more details
- Add of unit information on function description
- Optional returning functions getYieldTotal() and getYieldDay() never return std::nullopt
- getPanelPowerWatts() cast explicit from float into int32_t and implizit from int32_t into uint16_t

currently no problem at all. Just to avoid problems in future.