### PR TITLE
Fix: SBS battery: use Batteries::Stats setCurrent

### DIFF
--- a/include/battery/sbs/Stats.h
+++ b/include/battery/sbs/Stats.h
@@ -11,7 +11,6 @@ friend class Provider;
 public:
     void getLiveViewData(JsonVariant& root) const final;
     void mqttPublish() const final;
-    float getChargeCurrent() const { return _current; } ;
     float getChargeCurrentLimitation() const { return _chargeCurrentLimitation; } ;
 
 private:
@@ -20,7 +19,6 @@ private:
     float _chargeVoltage;
     float _chargeCurrentLimitation;
     uint16_t _stateOfHealth;
-    float _current;
     float _temperature;
 
     bool _alarmUnderTemperature;

--- a/src/battery/sbs/Provider.cpp
+++ b/src/battery/sbs/Provider.cpp
@@ -22,11 +22,11 @@ void Provider::onMessage(twai_message_t rx_message)
     switch (rx_message.identifier) {
         case 0x610: {
             _stats->setVoltage(this->readUnsignedInt16(rx_message.data)* 0.001, millis());
-            _stats->_current =(this->readSignedInt16(rx_message.data + 3)) * 0.001;
+            _stats->setCurrent(this->readSignedInt16(rx_message.data + 3) * 0.001, 2/*precision*/, millis());
             _stats->setSoC(static_cast<float>(this->readUnsignedInt16(rx_message.data + 6)), 1, millis());
 
             if (_verboseLogging) {
-                MessageOutput.printf("[SBS Unipower] 1552 SoC: %f Voltage: %f Current: %f\r\n", _stats->getSoC(), _stats->getVoltage(), _stats->_current);
+                MessageOutput.printf("[SBS Unipower] 1552 SoC: %f Voltage: %f Current: %f\r\n", _stats->getSoC(), _stats->getVoltage(), _stats->getChargeCurrent());
             }
             break;
         }
@@ -152,7 +152,7 @@ void Provider::dummyData()
     _stats->setDischargeCurrentLimit(dummyFloat(12), millis());
     _stats->_stateOfHealth = 99;
     _stats->setVoltage(48.67, millis());
-    _stats->_current = dummyFloat(-1);
+    _stats->setCurrent(dummyFloat(-1), 2/*precision*/, millis());
     _stats->_temperature = dummyFloat(20);
 
     _stats->_chargeEnabled = true;

--- a/src/battery/sbs/Stats.cpp
+++ b/src/battery/sbs/Stats.cpp
@@ -12,7 +12,6 @@ void Stats::getLiveViewData(JsonVariant& root) const
     addLiveViewValue(root, "chargeVoltage", _chargeVoltage, "V", 1);
     addLiveViewValue(root, "chargeCurrentLimitation", _chargeCurrentLimitation, "A", 1);
     addLiveViewValue(root, "stateOfHealth", _stateOfHealth, "%", 0);
-    addLiveViewValue(root, "current", _current, "A", 1);
     addLiveViewValue(root, "temperature", _temperature, "°C", 1);
     addLiveViewTextValue(root, "chargeEnabled", (_chargeEnabled?"yes":"no"));
     addLiveViewTextValue(root, "dischargeEnabled", (_dischargeEnabled?"yes":"no"));
@@ -34,7 +33,6 @@ void Stats::mqttPublish() const
     MqttSettings.publish("battery/settings/chargeVoltage", String(_chargeVoltage));
     MqttSettings.publish("battery/settings/chargeCurrentLimitation", String(_chargeCurrentLimitation));
     MqttSettings.publish("battery/stateOfHealth", String(_stateOfHealth));
-    MqttSettings.publish("battery/current", String(_current));
     MqttSettings.publish("battery/temperature", String(_temperature));
     MqttSettings.publish("battery/alarm/underVoltage", String(_alarmUnderVoltage));
     MqttSettings.publish("battery/alarm/overVoltage", String(_alarmOverVoltage));


### PR DESCRIPTION
Align stats of SBS battery provider with other providers and use the shared 'setCurrent' method instead of maintaining its own field.

I discovered this while checking if there are timestamp differences possible between 'current' and 'voltage' in our batttery providers.