### PR TITLE
Use DataPoints for all PowerMeter Providers

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -132,6 +132,12 @@ struct POWERMETER_HTTP_SML_CONFIG_T {
 };
 using PowerMeterHttpSmlConfig = struct POWERMETER_HTTP_SML_CONFIG_T;
 
+struct POWERMETER_UDP_VICTRON_CONFIG_T {
+    uint16_t PollingIntervalMs;
+    uint8_t IpAddress[4];
+};
+using PowerMeterUdpVictronConfig = struct POWERMETER_UDP_VICTRON_CONFIG_T;
+
 struct POWERLIMITER_INVERTER_CONFIG_T {
     uint64_t Serial;
     bool IsGoverned;
@@ -369,6 +375,7 @@ struct CONFIG_T {
         PowerMeterSerialSdmConfig SerialSdm;
         PowerMeterHttpJsonConfig HttpJson;
         PowerMeterHttpSmlConfig HttpSml;
+        PowerMeterUdpVictronConfig UdpVictron;
     } PowerMeter;
 
     PowerLimiterConfig PowerLimiter;
@@ -413,6 +420,7 @@ public:
     static void serializePowerMeterSerialSdmConfig(PowerMeterSerialSdmConfig const& source, JsonObject& target);
     static void serializePowerMeterHttpJsonConfig(PowerMeterHttpJsonConfig const& source, JsonObject& target);
     static void serializePowerMeterHttpSmlConfig(PowerMeterHttpSmlConfig const& source, JsonObject& target);
+    static void serializePowerMeterUdpVictronConfig(PowerMeterUdpVictronConfig const& source, JsonObject& target);
     static void serializeBatteryConfig(BatteryConfig const& source, JsonObject& target);
     static void serializePowerLimiterConfig(PowerLimiterConfig const& source, JsonObject& target);
     static void serializeGridChargerConfig(GridChargerConfig const& source, JsonObject& target);
@@ -424,6 +432,7 @@ public:
     static void deserializePowerMeterSerialSdmConfig(JsonObject const& source, PowerMeterSerialSdmConfig& target);
     static void deserializePowerMeterHttpJsonConfig(JsonObject const& source, PowerMeterHttpJsonConfig& target);
     static void deserializePowerMeterHttpSmlConfig(JsonObject const& source, PowerMeterHttpSmlConfig& target);
+    static void deserializePowerMeterUdpVictronConfig(JsonObject const& source, PowerMeterUdpVictronConfig& target);
     static void deserializeBatteryConfig(JsonObject const& source, BatteryConfig& target);
     static void deserializePowerLimiterConfig(JsonObject const& source, PowerLimiterConfig& target);
     static void deserializeGridChargerConfig(JsonObject const& source, GridChargerConfig& target);

--- a/include/DataPoints.h
+++ b/include/DataPoints.h
@@ -62,6 +62,7 @@ class DataPointContainer {
 
         template<Label L>
         void add(typename Traits<L>::type val) {
+            _dataPoints.erase(L);
             _dataPoints.emplace(
                     L,
                     DataPoint(

--- a/include/powermeter/DataPoints.h
+++ b/include/powermeter/DataPoints.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdint>
+#include <DataPoints.h>
+
+namespace PowerMeters {
+
+enum class DataPointLabel {
+    PowerTotal,
+    PowerL1,
+    PowerL2,
+    PowerL3,
+    VoltageL1,
+    VoltageL2,
+    VoltageL3,
+    CurrentL1,
+    CurrentL2,
+    CurrentL3,
+    Import,
+    Export,
+};
+
+template<DataPointLabel> struct DataPointLabelTraits;
+
+#define LABEL_TRAIT(n, u) template<> struct DataPointLabelTraits<DataPointLabel::n> { \
+    using type = float; \
+    static constexpr char const name[] = #n; \
+    static constexpr char const unit[] = u; \
+};
+
+LABEL_TRAIT(PowerTotal,      "W");
+LABEL_TRAIT(PowerL1,         "W");
+LABEL_TRAIT(PowerL2,         "W");
+LABEL_TRAIT(PowerL3,         "W");
+LABEL_TRAIT(VoltageL1,       "V");
+LABEL_TRAIT(VoltageL2,       "V");
+LABEL_TRAIT(VoltageL3,       "V");
+LABEL_TRAIT(CurrentL1,       "A");
+LABEL_TRAIT(CurrentL2,       "A");
+LABEL_TRAIT(CurrentL3,       "A");
+LABEL_TRAIT(Import,          "kWh");
+LABEL_TRAIT(Export,          "kWh");
+#undef LABEL_TRAIT
+
+} // namespace PowerMeters
+
+template class DataPointContainer<DataPoint<float>,
+                                  PowerMeters::DataPointLabel,
+                                  PowerMeters::DataPointLabelTraits>;
+
+namespace PowerMeters {
+    using DataPointContainer = DataPointContainer<DataPoint<float>, DataPointLabel, DataPointLabelTraits>;
+} // namespace PowerMeters

--- a/include/powermeter/Provider.h
+++ b/include/powermeter/Provider.h
@@ -2,7 +2,8 @@
 #pragma once
 
 #include <atomic>
-#include "Configuration.h"
+#include <Configuration.h>
+#include <powermeter/DataPoints.h>
 
 namespace PowerMeters {
 
@@ -24,10 +25,10 @@ public:
     virtual bool init() = 0;
 
     virtual void loop() = 0;
-    virtual float getPowerTotal() const = 0;
     virtual bool isDataValid() const;
 
-    uint32_t getLastUpdate() const { return _lastUpdate; }
+    float getPowerTotal() const;
+    uint32_t getLastUpdate() const { return _dataCurrent.getLastUpdate(); }
     void mqttLoop() const;
 
 protected:
@@ -36,19 +37,11 @@ protected:
         _verboseLogging = config.PowerMeter.VerboseLogging;
     }
 
-    void gotUpdate() { _lastUpdate = millis(); }
-
-    void mqttPublish(String const& topic, float const& value) const;
-
     bool _verboseLogging;
 
+    DataPointContainer _dataCurrent;
+
 private:
-    virtual void doMqttPublish() const = 0;
-
-    // gotUpdate() updates this variable potentially from a different thread
-    // than users that request to read this variable through getLastUpdate().
-    std::atomic<uint32_t> _lastUpdate = 0;
-
     mutable uint32_t _lastMqttPublish = 0;
 };
 

--- a/include/powermeter/Provider.h
+++ b/include/powermeter/Provider.h
@@ -18,7 +18,8 @@ public:
         HTTP_JSON = 3,
         SERIAL_SML = 4,
         SMAHM2 = 5,
-        HTTP_SML = 6
+        HTTP_SML = 6,
+        UDP_VICTRON = 7
     };
 
     // returns true if the provider is ready for use, false otherwise

--- a/include/powermeter/json/http/Provider.h
+++ b/include/powermeter/json/http/Provider.h
@@ -26,12 +26,9 @@ public:
 
     bool init() final;
     void loop() final;
-    float getPowerTotal() const final;
     bool isDataValid() const final;
-    void doMqttPublish() const final;
 
-    using power_values_t = std::array<float, POWERMETER_HTTP_JSON_MAX_VALUES>;
-    using poll_result_t = std::variant<power_values_t, String>;
+    using poll_result_t = std::variant<DataPointContainer, String>;
     poll_result_t poll();
 
 private:
@@ -42,9 +39,6 @@ private:
     PowerMeterHttpJsonConfig const _cfg;
 
     uint32_t _lastPoll = 0;
-
-    mutable std::mutex _valueMutex;
-    power_values_t _powerValues = {};
 
     std::array<std::unique_ptr<HttpGetter>, POWERMETER_HTTP_JSON_MAX_VALUES> _httpGetters;
 

--- a/include/powermeter/json/mqtt/Provider.h
+++ b/include/powermeter/json/mqtt/Provider.h
@@ -19,25 +19,16 @@ public:
 
     bool init() final;
     void loop() final { }
-    float getPowerTotal() const final;
 
 private:
     using MsgProperties = espMqttClientTypes::MessageProperties;
     void onMessage(MsgProperties const& properties, char const* topic,
             uint8_t const* payload, size_t len, size_t index,
-            size_t total, float* targetVariable, PowerMeterMqttValue const* cfg);
-
-    // we don't need to republish data received from MQTT
-    void doMqttPublish() const final { };
+            size_t total, uint8_t const phaseIndex, PowerMeterMqttValue const* cfg);
 
     PowerMeterMqttConfig const _cfg;
 
-    using power_values_t = std::array<float, POWERMETER_MQTT_MAX_VALUES>;
-    power_values_t _powerValues;
-
     std::vector<String> _mqttSubscriptions;
-
-    mutable std::mutex _mutex;
 };
 
 } // namespace PowerMeters::Json::Mqtt

--- a/include/powermeter/sdm/serial/Provider.h
+++ b/include/powermeter/sdm/serial/Provider.h
@@ -26,9 +26,7 @@ public:
 
     bool init() final;
     void loop() final;
-    float getPowerTotal() const final;
     bool isDataValid() const final;
-    void doMqttPublish() const final;
 
 private:
     static void pollingLoopHelper(void* context);
@@ -40,17 +38,6 @@ private:
     PowerMeterSerialSdmConfig const _cfg;
 
     uint32_t _lastPoll = 0;
-
-    float _phase1Power = 0.0;
-    float _phase2Power = 0.0;
-    float _phase3Power = 0.0;
-    float _phase1Voltage = 0.0;
-    float _phase2Voltage = 0.0;
-    float _phase3Voltage = 0.0;
-    float _energyImport = 0.0;
-    float _energyExport = 0.0;
-
-    mutable std::mutex _valueMutex;
 
     std::unique_ptr<SoftwareSerial> _upSdmSerial = nullptr;
     std::unique_ptr<SDM> _upSdm = nullptr;

--- a/include/powermeter/udp/smahm/Provider.h
+++ b/include/powermeter/udp/smahm/Provider.h
@@ -15,8 +15,6 @@ public:
 
     bool init() final;
     void loop() final;
-    float getPowerTotal() const final { return _powerMeterPower; }
-    void doMqttPublish() const final;
 
 private:
     void Soutput(int kanal, int index, int art, int tarif,
@@ -24,10 +22,6 @@ private:
 
     uint8_t* decodeGroup(uint8_t* offset, uint16_t grouplen);
 
-    float _powerMeterPower = 0.0;
-    float _powerMeterL1 = 0.0;
-    float _powerMeterL2 = 0.0;
-    float _powerMeterL3 = 0.0;
     uint32_t _previousMillis = 0;
     uint32_t _serial = 0;
 };

--- a/include/powermeter/udp/victron/Provider.h
+++ b/include/powermeter/udp/victron/Provider.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2024 Holger-Steffen Stapf
+ */
+#pragma once
+
+#include <cstdint>
+#include <Configuration.h>
+#include <powermeter/Provider.h>
+
+namespace PowerMeters::Udp::Victron {
+
+class Provider : public ::PowerMeters::Provider {
+public:
+    explicit Provider(PowerMeterUdpVictronConfig const& cfg);
+    ~Provider();
+
+    bool init() final;
+    void loop() final;
+
+private:
+    void sendModbusRequest();
+    void parseModbusResponse();
+
+    uint32_t _lastRequest = 0;
+    PowerMeterUdpVictronConfig _cfg;
+};
+
+} // namespace PowerMeters::Udp::Victron

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -118,6 +118,12 @@ void ConfigurationClass::serializePowerMeterHttpSmlConfig(PowerMeterHttpSmlConfi
     serializeHttpRequestConfig(source.HttpRequest, target);
 }
 
+void ConfigurationClass::serializePowerMeterUdpVictronConfig(PowerMeterUdpVictronConfig const& source, JsonObject& target)
+{
+    target["polling_interval_ms"] = source.PollingIntervalMs;
+    target["ip_address"] = IPAddress(source.IpAddress).toString();
+}
+
 void ConfigurationClass::serializeBatteryConfig(BatteryConfig const& source, JsonObject& target)
 {
     target["enabled"] = config.Battery.Enabled;
@@ -361,6 +367,9 @@ bool ConfigurationClass::write()
     JsonObject powermeter_http_sml = powermeter["http_sml"].to<JsonObject>();
     serializePowerMeterHttpSmlConfig(config.PowerMeter.HttpSml, powermeter_http_sml);
 
+    JsonObject powermeter_udp_victron = powermeter["udp_victron"].to<JsonObject>();
+    serializePowerMeterUdpVictronConfig(config.PowerMeter.UdpVictron, powermeter_udp_victron);
+
     JsonObject powerlimiter = doc["powerlimiter"].to<JsonObject>();
     serializePowerLimiterConfig(config.PowerLimiter, powerlimiter);
 
@@ -461,6 +470,17 @@ void ConfigurationClass::deserializePowerMeterHttpSmlConfig(JsonObject const& so
 {
     target.PollingInterval = source["polling_interval"] | POWERMETER_POLLING_INTERVAL;
     deserializeHttpRequestConfig(source["http_request"], target.HttpRequest);
+}
+
+void ConfigurationClass::deserializePowerMeterUdpVictronConfig(JsonObject const& source, PowerMeterUdpVictronConfig& target)
+{
+    target.PollingIntervalMs = source["polling_interval_ms"] | POWERMETER_POLLING_INTERVAL * 1000;
+    IPAddress ip;
+    ip.fromString(source["ip_address"] | "");
+    target.IpAddress[0] = ip[0];
+    target.IpAddress[1] = ip[1];
+    target.IpAddress[2] = ip[2];
+    target.IpAddress[3] = ip[3];
 }
 
 void ConfigurationClass::deserializeBatteryConfig(JsonObject const& source, BatteryConfig& target)
@@ -741,6 +761,8 @@ bool ConfigurationClass::read()
     deserializePowerMeterHttpJsonConfig(powermeter["http_json"], config.PowerMeter.HttpJson);
 
     deserializePowerMeterHttpSmlConfig(powermeter["http_sml"], config.PowerMeter.HttpSml);
+
+    deserializePowerMeterUdpVictronConfig(powermeter["udp_victron"], config.PowerMeter.UdpVictron);
 
     deserializePowerLimiterConfig(doc["powerlimiter"], config.PowerLimiter);
 

--- a/src/powermeter/Controller.cpp
+++ b/src/powermeter/Controller.cpp
@@ -91,6 +91,7 @@ void Controller::loop()
     _upProvider->loop();
 
     auto const& pmcfg = Configuration.get().PowerMeter;
+    // we don't need to republish data received from MQTT
     if (pmcfg.Source == static_cast<uint8_t>(Provider::Type::MQTT)) { return; }
     _upProvider->mqttLoop();
 }

--- a/src/powermeter/Controller.cpp
+++ b/src/powermeter/Controller.cpp
@@ -7,6 +7,7 @@
 #include <powermeter/sml/http/Provider.h>
 #include <powermeter/sml/serial/Provider.h>
 #include <powermeter/udp/smahm/Provider.h>
+#include <powermeter/udp/victron/Provider.h>
 
 PowerMeters::Controller PowerMeter;
 
@@ -55,6 +56,9 @@ void Controller::updateSettings()
             break;
         case Provider::Type::HTTP_SML:
             _upProvider = std::make_unique<::PowerMeters::Sml::Http::Provider>(pmcfg.HttpSml);
+            break;
+        case Provider::Type::UDP_VICTRON:
+            _upProvider = std::make_unique<::PowerMeters::Udp::Victron::Provider>(pmcfg.UdpVictron);
             break;
     }
 

--- a/src/powermeter/sdm/serial/Provider.cpp
+++ b/src/powermeter/sdm/serial/Provider.cpp
@@ -68,32 +68,10 @@ void Provider::loop()
             stackSize, this, 1/*prio*/, &_taskHandle);
 }
 
-float Provider::getPowerTotal() const
-{
-    std::lock_guard<std::mutex> l(_valueMutex);
-    return _phase1Power + _phase2Power + _phase3Power;
-}
-
 bool Provider::isDataValid() const
 {
     uint32_t age = millis() - getLastUpdate();
     return getLastUpdate() > 0 && (age < (3 * _cfg.PollingInterval * 1000));
-}
-
-void Provider::doMqttPublish() const
-{
-    std::lock_guard<std::mutex> l(_valueMutex);
-    mqttPublish("power1", _phase1Power);
-    mqttPublish("voltage1", _phase1Voltage);
-    mqttPublish("import", _energyImport);
-    mqttPublish("export", _energyExport);
-
-    if (_phases == Phases::Three) {
-        mqttPublish("power2", _phase2Power);
-        mqttPublish("power3", _phase3Power);
-        mqttPublish("voltage2", _phase2Voltage);
-        mqttPublish("voltage3", _phase3Voltage);
-    }
 }
 
 void Provider::pollingLoopHelper(void* context)
@@ -195,20 +173,22 @@ void Provider::pollingLoop()
         if (!success) { continue; }
 
         {
-            std::lock_guard<std::mutex> l(_valueMutex);
-            _phase1Power = static_cast<float>(phase1Power);
-            _phase2Power = static_cast<float>(phase2Power);
-            _phase3Power = static_cast<float>(phase3Power);
-            _phase1Voltage = static_cast<float>(phase1Voltage);
-            _phase2Voltage = static_cast<float>(phase2Voltage);
-            _phase3Voltage = static_cast<float>(phase3Voltage);
-            _energyImport = static_cast<float>(energyImport);
-            _energyExport = static_cast<float>(energyExport);
+            auto scopedLock = _dataCurrent.lock();
+
+            _dataCurrent.add<DataPointLabel::PowerL1>(phase1Power);
+            _dataCurrent.add<DataPointLabel::VoltageL1>(phase1Voltage);
+            _dataCurrent.add<DataPointLabel::Import>(energyImport);
+            _dataCurrent.add<DataPointLabel::Export>(energyExport);
+
+            if (_phases == Phases::Three) {
+                _dataCurrent.add<DataPointLabel::PowerL2>(phase2Power);
+                _dataCurrent.add<DataPointLabel::PowerL3>(phase3Power);
+                _dataCurrent.add<DataPointLabel::VoltageL2>(phase2Voltage);
+                _dataCurrent.add<DataPointLabel::VoltageL3>(phase3Voltage);
+            }
         }
 
         MessageOutput.printf("[PowerMeters::Sdm::Serial] TotalPower: %5.2f\r\n", getPowerTotal());
-
-        gotUpdate();
     }
 }
 

--- a/src/powermeter/sml/http/Provider.cpp
+++ b/src/powermeter/sml/http/Provider.cpp
@@ -82,8 +82,6 @@ void Provider::pollingLoop()
             MessageOutput.printf("[PowerMeters::Sml::Http] %s\r\n", res.c_str());
             continue;
         }
-
-        gotUpdate();
     }
 }
 

--- a/src/powermeter/udp/victron/Provider.cpp
+++ b/src/powermeter/udp/victron/Provider.cpp
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2024 Holger-Steffen Stapf
+ */
+#include <powermeter/udp/victron/Provider.h>
+#include <Arduino.h>
+#include <WiFiUdp.h>
+#include <MessageOutput.h>
+
+namespace PowerMeters::Udp::Victron {
+
+static constexpr unsigned int modbusPort = 502;  // local port to listen on
+
+// we only send one request which spans all registers we want to read
+static constexpr uint16_t sTransactionId = 0xDEAD; // arbitrary value
+static constexpr uint8_t sUnitId = 0x01;
+static constexpr uint8_t sFunctionCode = 0x03; // read holding registers
+static constexpr uint16_t sRegisterAddress = 0x3032;
+static constexpr uint16_t sRegisterCount = 0x005A;
+
+static WiFiUDP VictronUdp;
+
+Provider::Provider(PowerMeterUdpVictronConfig const& cfg)
+    : _cfg(cfg)
+{
+}
+
+bool Provider::init()
+{
+    VictronUdp.begin(modbusPort);
+    return true;
+}
+
+Provider::~Provider()
+{
+    VictronUdp.stop();
+}
+
+void Provider::sendModbusRequest()
+{
+    auto interval = _cfg.PollingIntervalMs;
+
+    uint32_t currentMillis = millis();
+
+    if (currentMillis - _lastRequest < interval) { return; }
+
+    std::vector<uint8_t> payload;
+
+    payload.push_back(sTransactionId >> 8);
+    payload.push_back(sTransactionId & 0xFF);
+
+    // protocol ID
+    payload.push_back(0x00);
+    payload.push_back(0x00);
+
+    // length
+    payload.push_back(0x00);
+    payload.push_back(0x06);
+
+    payload.push_back(sUnitId);
+    payload.push_back(sFunctionCode);
+    payload.push_back(sRegisterAddress >> 8);
+    payload.push_back(sRegisterAddress & 0xFF);
+    payload.push_back(sRegisterCount >> 8);
+    payload.push_back(sRegisterCount & 0xFF);
+
+    VictronUdp.beginPacket(_cfg.IpAddress, modbusPort);
+    VictronUdp.write(payload.data(), payload.size());
+    VictronUdp.endPacket();
+
+    _lastRequest = currentMillis;
+}
+
+static float readInt16(uint8_t** buffer, uint8_t factor)
+{
+    uint8_t* p = *buffer;
+    int16_t value = (p[0] << 8) | p[1];
+    *buffer += 2;
+    return static_cast<float>(value) / factor;
+}
+
+static float readInt32(uint8_t** buffer, uint8_t factor)
+{
+    uint8_t* p = *buffer;
+    int32_t value = (p[0] << 24) | (p[1] << 16) | (p[2] << 8) | p[3];
+    *buffer += 4;
+    return static_cast<float>(value) / factor;
+}
+
+static float readUint32(uint8_t** buffer, uint8_t factor)
+{
+    uint8_t* p = *buffer;
+    uint32_t value = (p[0] << 24) | (p[1] << 16) | (p[2] << 8) | p[3];
+    *buffer += 4;
+    return static_cast<float>(value) / factor;
+}
+
+void Provider::parseModbusResponse()
+{
+    int packetSize = VictronUdp.parsePacket();
+    if (!packetSize) { return; }
+
+    uint8_t buffer[256];
+    VictronUdp.read(buffer, sizeof(buffer));
+
+    uint8_t* p = buffer;
+
+    if (_verboseLogging) {
+        MessageOutput.printf("[PowerMeters::Udp::Victron] received %d bytes:", packetSize);
+
+        for (int i = 0; i < packetSize; i++) {
+            if (i % 16 == 0) {
+                MessageOutput.print("\r\n");
+            }
+            MessageOutput.printf("%02X ", buffer[i]);
+        }
+
+        MessageOutput.print("\r\n");
+    }
+
+    uint16_t transactionId = (p[0] << 8) | p[1];
+    p += 2;
+
+    if (transactionId != sTransactionId) {
+        MessageOutput.printf("[PowerMeters::Udp::Victron] invalid transaction ID: %04X\r\n", transactionId);
+        return;
+    }
+
+    uint16_t protocolId = (p[0] << 8) | p[1];
+    p += 2;
+
+    if (protocolId != 0x0000) {
+        MessageOutput.printf("[PowerMeters::Udp::Victron] invalid protocol ID: %04X\r\n", protocolId);
+        return;
+    }
+
+    uint16_t length = (p[0] << 8) | p[1];
+    p += 2;
+
+    uint16_t expectedLength = (sRegisterCount * 2) + 3;
+    if (length != expectedLength) {
+        MessageOutput.printf("[PowerMeters::Udp::Victron] unexpected length: %04X, "
+            "expected %04X\r\n", length, expectedLength);
+        return;
+    }
+
+    uint8_t unitId = p[0];
+    p += 1;
+
+    if (unitId != sUnitId) {
+        MessageOutput.printf("[PowerMeters::Udp::Victron] unexpected unit ID: %02X, "
+            "expected %02X\r\n", unitId, sUnitId);
+        return;
+    }
+
+    uint8_t functionCode = p[0];
+    p += 1;
+
+    if (functionCode != sFunctionCode) {
+        MessageOutput.printf("[PowerMeters::Udp::Victron] unexpected function code: %02X, "
+            "expected %02X\r\n", functionCode, sFunctionCode);
+        return;
+    }
+
+    uint8_t byteCount = p[0];
+    p += 1;
+
+    uint8_t expectedByteCount = sRegisterCount * 2;
+    if (byteCount != expectedByteCount) {
+        MessageOutput.printf("[PowerMeters::Udp::Victron] unexpected byte count: %02X, "
+            "expected %02X\r\n", byteCount, expectedByteCount);
+        return;
+    }
+
+    using Label = ::PowerMeters::DataPointLabel;
+
+    auto scopedLock = _dataCurrent.lock();
+
+    p += 2; // skip register 0x3032 (AC frequency)
+    p += 2; // skip register 0x3033 (PEN voltage)
+
+    _dataCurrent.add<Label::Import>(readUint32(&p, 100)); // 0x3034f
+    _dataCurrent.add<Label::Export>(readUint32(&p, 100)); // 0x3036f
+    p += 16; // jump to register 0x3040
+    _dataCurrent.add<Label::VoltageL1>(readInt16(&p, 100)); // 0x3040
+    _dataCurrent.add<Label::CurrentL1>(readInt16(&p, 100)); // 0x3041
+    p += 12; // jump to register 0x3048
+    _dataCurrent.add<Label::VoltageL2>(readInt16(&p, 100)); // 0x3048
+    _dataCurrent.add<Label::CurrentL2>(readInt16(&p, 100)); // 0x3049
+    p += 12; // jump to register 0x3050
+    _dataCurrent.add<Label::VoltageL3>(readInt16(&p, 100)); // 0x3050
+    _dataCurrent.add<Label::CurrentL3>(readInt16(&p, 100)); // 0x3051
+    p += 92; // jump from 0x3052 to 0x3080 (0x2E registers = 92 bytes)
+    _dataCurrent.add<Label::PowerTotal>(readInt32(&p, 1)); // 0x3080f
+    _dataCurrent.add<Label::PowerL1>(readInt32(&p, 1)); // 0x3082f
+    p += 4; // jump to 0x3086
+    _dataCurrent.add<Label::PowerL2>(readInt32(&p, 1)); // 0x3086f
+    p += 4; // jump to 0x308A
+    _dataCurrent.add<Label::PowerL3>(readInt32(&p, 1)); // 0x308Af
+}
+
+void Provider::loop()
+{
+    sendModbusRequest();
+    parseModbusResponse();
+}
+
+} // namespace PowerMeters::Udp::Victron

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -633,11 +633,13 @@
         "typeSML": "SML/OBIS via serieller Verbindung (z.B. Hichi TTL)",
         "typeSMAHM2": "SMA Homemanager 2.0",
         "typeHTTP_SML": "HTTP(S) + SML (z.B. Tibber Pulse via Tibber Bridge)",
+        "typeUDP_VICTRON": "Victron VM-3P75CT (Modbus UDP)",
         "MqttValue": "Konfiguration Wert {valueNumber}",
         "MqttTopic": "MQTT Topic",
         "mqttJsonPath": "Optional: JSON-Pfad",
         "SDM": "SDM-Stromzähler Konfiguration",
         "sdmaddress": "Modbus Adresse",
+        "ipAddress": "IP-Adresse",
         "HTTP_JSON": "HTTP(S) + JSON - Allgemeine Konfiguration",
         "httpIndividualRequests": "Individuelle HTTP(S) Anfragen pro Wert",
         "urlExamplesHeading": "Beispiele für URLs",
@@ -654,7 +656,8 @@
         "testHttpJsonRequest": "HTTP(S)-Anfrage(n) senden und Antwort(en) verarbeiten",
         "testHttpSmlHeader": "Konfiguration testen",
         "testHttpSmlRequest": "HTTP(S)-Anfrage senden und Antwort verarbeiten",
-        "HTTP_SML": "HTTP(S) + SML - Konfiguration"
+        "HTTP_SML": "HTTP(S) + SML - Konfiguration",
+        "UDP_VICTRON": "Victron VM-3P75CT (Modbus UDP) - Konfiguration"
     },
     "httprequestsettings": {
         "url": "URL",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -635,11 +635,13 @@
         "typeSML": "SML/OBIS via serial connection (e.g. Hichi TTL)",
         "typeSMAHM2": "SMA Homemanager 2.0",
         "typeHTTP_SML": "HTTP(S) + SML (e.g. Tibber Pulse via Tibber Bridge)",
+        "typeUDP_VICTRON": "Victron VM-3P75CT (Modbus UDP)",
         "MqttValue": "Value {valueNumber} Configuration",
         "mqttJsonPath": "Optional: JSON Path",
         "MqttTopic": "MQTT Topic",
         "SDM": "SDM-Power Meter Parameter",
         "sdmaddress": "Modbus Address",
+        "ipAddress": "IP Address",
         "HTTP": "HTTP(S) + JSON - General configuration",
         "httpIndividualRequests": "Individual HTTP(S) requests per value",
         "urlExamplesHeading": "URL Examples",
@@ -656,7 +658,8 @@
         "testHttpJsonRequest": "Send HTTP(S) request(s) and process response(s)",
         "testHttpSmlHeader": "Test Configuration",
         "testHttpSmlRequest": "Send HTTP(S) request and process response",
-        "HTTP_SML": "Configuration"
+        "HTTP_SML": "Configuration",
+        "UDP_VICTRON": "Configuration"
     },
     "httprequestsettings": {
         "url": "URL",

--- a/webapp/src/types/PowerMeterConfig.ts
+++ b/webapp/src/types/PowerMeterConfig.ts
@@ -35,6 +35,11 @@ export interface PowerMeterHttpSmlConfig {
     http_request: HttpRequestConfig;
 }
 
+export interface PowerMeterUdpVictronConfig {
+    polling_interval_ms: number;
+    ip_address: string;
+}
+
 export interface PowerMeterConfig {
     enabled: boolean;
     verbose_logging: boolean;
@@ -44,4 +49,5 @@ export interface PowerMeterConfig {
     serial_sdm: PowerMeterSerialSdmConfig;
     http_json: PowerMeterHttpJsonConfig;
     http_sml: PowerMeterHttpSmlConfig;
+    udp_victron: PowerMeterUdpVictronConfig;
 }

--- a/webapp/src/views/PowerMeterAdminView.vue
+++ b/webapp/src/views/PowerMeterAdminView.vue
@@ -277,6 +277,29 @@
                         </BootstrapAlert>
                     </CardElement>
                 </template>
+
+                <template v-if="powerMeterConfigList.source === 7">
+                    <CardElement :text="$t('powermeteradmin.UDP_VICTRON')" textVariant="text-bg-primary" add-space>
+                        <InputElement
+                            :label="$t('powermeteradmin.pollingInterval')"
+                            v-model="udpVictronPollIntervalSeconds"
+                            type="number"
+                            min="0.5"
+                            max="15.0"
+                            step="0.1"
+                            :postfix="$t('powermeteradmin.seconds')"
+                            wide
+                        />
+
+                        <InputElement
+                            :label="$t('powermeteradmin.ipAddress')"
+                            v-model="powerMeterConfigList.udp_victron.ip_address"
+                            type="text"
+                            maxlength="15"
+                            wide
+                        />
+                    </CardElement>
+                </template>
             </template>
 
             <FormFooter @reload="getPowerMeterConfig" />
@@ -316,6 +339,7 @@ export default defineComponent({
                 { key: 4, value: this.$t('powermeteradmin.typeSML') },
                 { key: 5, value: this.$t('powermeteradmin.typeSMAHM2') },
                 { key: 6, value: this.$t('powermeteradmin.typeHTTP_SML') },
+                { key: 7, value: this.$t('powermeteradmin.typeUDP_VICTRON') },
             ],
             unitTypeList: [
                 { key: 1, value: 'mW' },
@@ -339,6 +363,16 @@ export default defineComponent({
     },
     created() {
         this.getPowerMeterConfig();
+    },
+    computed: {
+        udpVictronPollIntervalSeconds: {
+            get(): number {
+                return this.powerMeterConfigList.udp_victron.polling_interval_ms / 1000;
+            },
+            set(value: number) {
+                this.powerMeterConfigList.udp_victron.polling_interval_ms = value * 1000;
+            },
+        },
     },
     methods: {
         getPowerMeterConfig() {


### PR DESCRIPTION
With this PR we switch all PowerMeter Providers to use DataPoints. This will allow us to easily build a HASS integration, show individual phase values in the LiveView and also to group inverters by phase within the DPL.

Additonaly i added reading the total power directly for 3-phase SDM powermeters as requested in issue https://github.com/hoylabs/OpenDTU-OnBattery/issues/765

### Tested Providers
- [X] HTTP (schlimmchen)
- [X] MQTT (schlimmchen)
- [x] SDM 1-Phase (schlimmchen)
- [ ] SDM 3-Phase
- [ ] SML via Serial
- [X] SML via HTTP (schlimmchen)
- [x] SMA HomeManager2  (schlimmchen)
- [X] Victron Modbus UDP (Sorbat)

### Test version
~~https://github.com/hoylabs/OpenDTU-OnBattery/actions/runs/13398033363~~