### PR TITLE
Fix: (hack) single solar inverter ignores shading

### DIFF
--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -42,6 +42,7 @@ public:
     uint8_t getPowerLimiterState();
     int32_t getInverterOutput() { return _lastExpectedInverterOutput; }
     bool getFullSolarPassThroughEnabled() const { return _fullSolarPassThroughEnabled; }
+    size_t getGovernedInverterCount() const { return _inverters.size(); }
 
     enum class Mode : unsigned {
         Normal = 0,

--- a/src/PowerLimiterSolarInverter.cpp
+++ b/src/PowerLimiterSolarInverter.cpp
@@ -1,5 +1,6 @@
 #include "MessageOutput.h"
 #include "PowerLimiterSolarInverter.h"
+#include "PowerLimiter.h"
 
 PowerLimiterSolarInverter::PowerLimiterSolarInverter(bool verboseLogging, PowerLimiterInverterConfig const& config)
     : PowerLimiterOverscalingInverter(verboseLogging, config) { }
@@ -22,6 +23,16 @@ uint16_t PowerLimiterSolarInverter::getMaxIncreaseWatts() const
         // the inverter is not producing, we don't know how much we can increase
         // the power, so we return the maximum possible increase
         return getConfiguredMaxPowerWatts();
+    }
+
+    // If there is only one inverter, we ignore the shading and assume that
+    // we can increase the power by the maximum possible amount by using the
+    // same calculation as for battery-powered inverters.
+    // This is a hack to prevent the inverters from getting stuck at low limits.
+    // This is a temporary solution until we have a better way to handle this situation.
+    // TODO(andreasboehm): Remove this hack once we have a better solution.
+    if (PowerLimiter.getGovernedInverterCount() == 1) {
+        return getConfiguredMaxPowerWatts() - getCurrentLimitWatts();
     }
 
     // the maximum increase possible for this inverter


### PR DESCRIPTION
As a temporary hacky solution we assume that a single DPL controller solar inverter can always increase its power to the maximum. This is needed because a lot of people only use a single solar inverter and are having issues that the inverter gets stuck at low limits. We need to get rid of this hack at some point in time and provide a real solution for the problem.

Workaround for https://github.com/hoylabs/OpenDTU-OnBattery/issues/1675

Test build is available here: https://github.com/hoylabs/OpenDTU-OnBattery/actions/runs/13398858828