### PR TITLE
fix: DPL use current AC output for smart buffer reduction

### DIFF
--- a/src/PowerLimiterOverscalingInverter.cpp
+++ b/src/PowerLimiterOverscalingInverter.cpp
@@ -52,8 +52,6 @@ uint16_t PowerLimiterOverscalingInverter::scaleLimit(uint16_t expectedOutputWatt
     // producing very little due to the very low limit.
     if (getCurrentLimitWatts() < dcTotalChnls * 10) { return expectedOutputWatts; }
 
-    auto inverterOutputAC = pStats->getChannelFieldValue(TYPE_AC, CH0, FLD_PAC);
-
     float inverterEfficiencyFactor = pStats->getChannelFieldValue(TYPE_INV, CH0, FLD_EFF);
 
     // fall back to hoymiles peak efficiency as per datasheet if inverter
@@ -102,9 +100,9 @@ uint16_t PowerLimiterOverscalingInverter::scaleLimit(uint16_t expectedOutputWatt
         // keep the currentLimit when:
         // - all channels are shaded
         // - currentLimit >= expectedOutputWatts
-        // - we get the expected AC power or less and
+        // - we get the expected AC power or less
         if (getCurrentLimitWatts() >= expectedOutputWatts &&
-                inverterOutputAC <= expectedOutputWatts) {
+                getCurrentOutputAcWatts() <= expectedOutputWatts) {
             if (_verboseLogging) {
                 MessageOutput.printf("    all mppts are shaded, "
                         "keeping the current limit of %d W\r\n",

--- a/src/PowerLimiterSmartBufferInverter.cpp
+++ b/src/PowerLimiterSmartBufferInverter.cpp
@@ -53,8 +53,8 @@ uint16_t PowerLimiterSmartBufferInverter::applyReduction(uint16_t reduction, boo
         return 0;
     }
 
-    if ((getCurrentLimitWatts() - _config.LowerPowerLimit) >= reduction) {
-        setAcOutput(getCurrentLimitWatts() - reduction);
+    if ((getCurrentOutputAcWatts() - _config.LowerPowerLimit) >= reduction) {
+        setAcOutput(getCurrentOutputAcWatts() - reduction);
         return reduction;
     }
 


### PR DESCRIPTION
With the scaled limit we are not able to reduce the power as expected.
Closes #1665.