### PR TITLE
Fix: DPL: ignore non-eligible inverters in every calculation

### DIFF
--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -87,7 +87,7 @@ private:
     float getBatteryVoltage(bool log = false);
     uint16_t dcPowerBusToInverterAc(uint16_t dcPower);
     void unconditionalFullSolarPassthrough();
-    int16_t calcConsumption();
+    uint16_t calcTargetOutput();
     using inverter_filter_t = std::function<bool(PowerLimiterInverter const&)>;
     uint16_t updateInverterLimits(uint16_t powerRequested, inverter_filter_t filter, std::string const& filterExpression);
     uint16_t calcPowerBusUsage(uint16_t powerRequested);

--- a/include/PowerLimiterInverter.h
+++ b/include/PowerLimiterInverter.h
@@ -75,9 +75,6 @@ public:
 
     void debug() const;
 
-protected:
-    PowerLimiterInverter(bool verboseLogging, PowerLimiterInverterConfig const& config);
-
     enum class Eligibility : unsigned {
         Unreachable,
         SendingCommandsDisabled,
@@ -86,9 +83,12 @@ protected:
         Eligible
     };
 
-    // returns false if the inverter cannot participate
+    // only returns Eligibility::Eligible if the inverter can participate
     // in achieving the requested change in power output
     Eligibility isEligible() const;
+
+protected:
+    PowerLimiterInverter(bool verboseLogging, PowerLimiterInverterConfig const& config);
 
     uint16_t getCurrentLimitWatts() const;
 

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -558,12 +558,7 @@ uint16_t PowerLimiterClass::calcTargetOutput()
         // inverters in standby report 0 W output, so we can iterate them.
         if (PowerLimiterInverter::Eligibility::Eligible != upInv->isEligible()) { continue; }
 
-        auto invOutput = upInv->getCurrentOutputAcWatts();
-        currentTotalOutput += invOutput;
-        if (_verboseLogging) {
-            MessageOutput.printf("[DPL] inverter %s is producing %u W\r\n",
-                    upInv->getSerialStr(), invOutput);
-        }
+        currentTotalOutput += upInv->getCurrentOutputAcWatts();
     }
 
     // this value is negative if we are exporting more than "targetConsumption"

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -339,11 +339,7 @@ void PowerLimiterClass::loop()
             config.PowerLimiter.ConductionLosses);
     };
 
-    // this value is negative if we are exporting power to the grid
-    // from power sources other than DPL-governed inverters.
-    int16_t consumption = calcConsumption();
-
-    uint16_t inverterTotalPower = (consumption > 0) ? static_cast<uint16_t>(consumption) : 0;
+    uint16_t inverterTotalPower = calcTargetOutput();
 
     auto totalAllowance = config.PowerLimiter.TotalUpperPowerLimit;
     inverterTotalPower = std::min(inverterTotalPower, totalAllowance);
@@ -506,7 +502,7 @@ uint8_t PowerLimiterClass::getPowerLimiterState()
     return _batteryDischargeEnabled ? PL_UI_STATE_USE_SOLAR_AND_BATTERY : PL_UI_STATE_USE_SOLAR_ONLY;
 }
 
-int16_t PowerLimiterClass::calcConsumption()
+uint16_t PowerLimiterClass::calcTargetOutput()
 {
     auto const& config = Configuration.get();
     auto targetConsumption = config.PowerLimiter.TargetPowerConsumption;
@@ -524,24 +520,62 @@ int16_t PowerLimiterClass::calcConsumption()
 
     if (!meterValid) { return baseLoad; }
 
-    auto consumption = static_cast<int16_t>(meterValue + (meterValue > 0 ? 0.5 : -0.5));
+    // the desired total output of all eligible inverters is whatever they are
+    // producing right now plus the difference between the target consumption
+    // and the power meter reading
+    auto roundedMeterValue = static_cast<int16_t>(meterValue + (meterValue > 0 ? 0.5 : -0.5));
 
+    // we have to correct the meter reading if there are inverters connected to
+    // AC between the grid (billing meter) and OpenDTU-OnBattery's power meter.
+    // example: billing meter in the basement, inverter connected next to it,
+    // and an additional power meter in the flat which is read by OpenDTU-
+    // OnBattery. in that case power produced by the respective inverter is
+    // still registered as consumed power by the power meter as it flows into
+    // the household, even though it is not billed. essentially, we derive the
+    // billing meter's reading, whose value we actually want to optimize to
+    // reach the target consumption setting value.
     for (auto const& upInv : _inverters) {
-        if (!upInv->isBehindPowerMeter()) { continue; }
+        if (upInv->isBehindPowerMeter()) { continue; }
 
-        // If the inverter is wired behind the power meter, i.e., if its
-        // output is part of the power meter measurement, the produced
-        // power of this inverter has to be taken into account.
+        // it is to be expected that solar-powered inverters are unreachable
+        // during the night, in which case we don't want to account for their
+        // last reported AC output, as they are not producing power.
+        auto isDayPeriod = SunPosition.isDayPeriod();
+        if (upInv->isSolarPowered() && !upInv->isReachable() && !isDayPeriod) { continue; }
+
+        // in all other cases, even for unreachable inverters, we assume that
+        // they still produce the amount of AC output that they last reported.
+        // if we assumed unreachable inverters are not producing, we will
+        // potentially produce way too much power. as information is missing
+        // that could make sure we do the right thing, we have to make an
+        // assumption about unreachable inverters.
+        roundedMeterValue -= upInv->getCurrentOutputAcWatts();
+    }
+
+    int16_t currentTotalOutput = 0;
+    for (auto const& upInv : _inverters) {
+        // non-eligible inverters don't participate in this DPL round at all.
+        // inverters in standby report 0 W output, so we can iterate them.
+        if (PowerLimiterInverter::Eligibility::Eligible != upInv->isEligible()) { continue; }
+
         auto invOutput = upInv->getCurrentOutputAcWatts();
-        consumption += invOutput;
+        currentTotalOutput += invOutput;
         if (_verboseLogging) {
-            MessageOutput.printf("[DPL] inverter %s is "
-                    "behind power meter producing %u W\r\n",
+            MessageOutput.printf("[DPL] inverter %s is producing %u W\r\n",
                     upInv->getSerialStr(), invOutput);
         }
     }
 
-    return consumption - targetConsumption;
+    // this value is negative if we are exporting more than "targetConsumption"
+    // power to the grid using generators other than DPL-governed inverters.
+    int16_t targetOutput = currentTotalOutput + roundedMeterValue - targetConsumption;
+
+    // if we are already exporting more power than the (negative) target
+    // consumption value allows us to, we don't want DPL-governed inverters to
+    // produce any power at all.
+    if (targetOutput < 0) { return 0; }
+
+    return static_cast<uint16_t>(targetOutput);
 }
 
 /**
@@ -558,21 +592,7 @@ uint16_t PowerLimiterClass::updateInverterLimits(uint16_t powerRequested,
     for (auto& upInv : _inverters) {
         if (!filter(*upInv)) { continue; }
 
-        if (!upInv->isReachable()) {
-            if (_verboseLogging) {
-                MessageOutput.printf("[DPL] skipping %s "
-                        "as it is not reachable\r\n", upInv->getSerialStr());
-            }
-            continue;
-        }
-
-        if (!upInv->isSendingCommandsEnabled()) {
-            if (_verboseLogging) {
-                MessageOutput.printf("[DPL] skipping %s as sending commands "
-                        "is disabled\r\n", upInv->getSerialStr());
-            }
-            continue;
-        }
+        if (PowerLimiterInverter::Eligibility::Eligible != upInv->isEligible()) { continue; }
 
         producing += upInv->getCurrentOutputAcWatts();
         matchingInverters.push_back(upInv.get());

--- a/src/PowerLimiterInverter.cpp
+++ b/src/PowerLimiterInverter.cpp
@@ -336,7 +336,7 @@ void PowerLimiterInverter::debug() const
 
     MessageOutput.printf(
         "%s\r\n"
-        "    %s-powered, %s %d W\r\n"
+        "    %s-powered, %s %d W, output %s power meter reading\r\n"
         "    lower/current/upper limit: %d/%d/%d W, output capability: %d W\r\n"
         "    sending commands %s, %s, %s\r\n"
         "    max reduction production/standby: %d/%d W, max increase: %d W\r\n"
@@ -344,6 +344,7 @@ void PowerLimiterInverter::debug() const
         _logPrefix,
         (isSmartBufferPowered()?"smart-buffer":(isSolarPowered()?"solar":"battery")),
         (isProducing()?"producing":"standing by at"), getCurrentOutputAcWatts(),
+        (isBehindPowerMeter()?"included in":"excluded from"),
         _config.LowerPowerLimit, getCurrentLimitWatts(), _config.UpperPowerLimit,
         getInverterMaxPowerWatts(),
         (isSendingCommandsEnabled()?"enabled":"disabled"),


### PR DESCRIPTION
1. Fix: non-eligible inverters don't participate in achieving a new target output value in a particular DPL loop. however, we did not ignore them in calculations leading up to setting new limits. unreachable inverters were hence included in calculations with their last reported AC output value, which can be significant and is always ~10W for solar-powered inverters which went to sleep for the night.
 2. Feature: instead of trying to calculate the household consumption, which is then used to calculate the desired total output of all DPL-governed inverters, we now enter a new DPL round with a target value ~~that is actually a difference~~ based on the power meter reading and eligible inverters alone: the eligible inverters shall produce whatever they produce now, but more or less the value that the power meter reads. this should be quite robust, and in particular, intermittent RF issues with inverters are not causing issues any more. if any inverter is non-eligible for any reason, it just does not participate *at all* in any DPL-related calculations, so the DPL tries to match the difference using the inverter which *are* reachable/eligible.
3. ~~Feature: given this new approach, it is irrelevant at what electrical junction the DPL-governed inverters feed into the household. for that reason, the "is behind power meter" setting is simply obsolete and removed.~~

~~@AndreasBoehm As long as solar-powered or buffer-powered inverters think that there is the slightest chance of increasing their output, they should tell us just that. Imagine this: A solar-powered inverter produces 100W (at whatever limit value). If the power meter reading is x[W] higher than the target consumption value, the DPL will request x+100W. The thing is: If the inverter receives a new limit and now produces 110W, but in the next DPL loop the power meter reading is still y[W] higher than the target consumption value, the DPL will request y+110W, and so on. Wow, this is hard to explain... What I want you to know is: This approach allows us to creep up to a limit value such that the inverters finally produce as much as is needed. That's also beneficial for battery-powered inverters whose AC output lags behind their limit. Can you follow what I mean?~~

Closes #1713.