### PR TITLE
Fix: do not retry limit commands

### DIFF
--- a/include/PowerLimiterInverter.h
+++ b/include/PowerLimiterInverter.h
@@ -112,8 +112,11 @@ private:
 
     char _serialStr[16];
 
-    // track (target) state
+    // track the number of times an update command
+    // issued to the inverter timed out *or* failed
     uint8_t _updateTimeouts = 0;
+
+    // track (target) state
     std::optional<uint32_t> _oUpdateStartMillis = std::nullopt;
     std::optional<uint16_t> _oTargetPowerLimitWatts = std::nullopt;
     std::optional<bool> _oTargetPowerState = std::nullopt;


### PR DESCRIPTION
once a limit command completes, we forget about it, even if it failed. this is a good choice since the limit value might be outdated once it timed out. the DPL shall calculate a new limit, which is then sent to the inverter instead.

we still retry power commands to shut down or wake up inverters as it is unlikely that the respective inverter shall have a different power state in the next DPL loop.

closes #1709.