### PR TITLE
Fix: cannot un-govern solar-powered inverters

### DIFF
--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -49,7 +49,7 @@ public:
         UnconditionalFullSolarPassthrough = 2
     };
 
-    void setMode(Mode m) { _mode = m; }
+    void setMode(Mode m) { _mode = m; _reloadConfigFlag = true; }
     Mode getMode() const { return _mode; }
     bool usesBatteryPoweredInverter();
     bool usesSmartBufferPoweredInverter();
@@ -72,16 +72,15 @@ private:
     Mode _mode = Mode::Normal;
 
     std::deque<std::unique_ptr<PowerLimiterInverter>> _inverters;
+    std::deque<std::unique_ptr<PowerLimiterInverter>> _retirees;
     bool _batteryDischargeEnabled = false;
     bool _nighttimeDischarging = false;
     std::pair<bool, uint32_t> _nextInverterRestart = { false, 0 };
     bool _fullSolarPassThroughEnabled = false;
     bool _verboseLogging = true;
-    bool _shutdownComplete = false;
 
     frozen::string const& getStatusText(Status status);
     void announceStatus(Status status);
-    bool isDisabled();
     void reloadConfig();
     std::pair<float, char const*> getInverterDcVoltage();
     float getBatteryVoltage(bool log = false);

--- a/include/PowerLimiterInverter.h
+++ b/include/PowerLimiterInverter.h
@@ -15,6 +15,12 @@ public:
     // state is NOT yet reached, false otherwise.
     bool update();
 
+    // retire an inverter from the DPL. the inverter will have it's standby()
+    // function (different outcome for different types of inverters) called
+    // once. afterwards this method returns true as long as the target state
+    // is pending.
+    bool retire();
+
     // returns the timestamp of the oldest stats received for this inverter
     // *after* its last command completed. return std::nullopt if new stats
     // are pending after the last command completed.
@@ -109,6 +115,8 @@ protected:
 
 private:
     virtual void setAcOutput(uint16_t expectedOutputWatts) = 0;
+
+    bool _retired = false; // true if to be abandoned by DPL
 
     char _serialStr[16];
 

--- a/src/PowerLimiterInverter.cpp
+++ b/src/PowerLimiterInverter.cpp
@@ -230,6 +230,13 @@ bool PowerLimiterInverter::update()
     return reset();
 }
 
+bool PowerLimiterInverter::retire()
+{
+    if (!_retired) { standby(); }
+    _retired = true;
+    return update();
+}
+
 std::optional<uint32_t> PowerLimiterInverter::getLatestStatsMillis() const
 {
     uint32_t now = millis();


### PR DESCRIPTION
the standby() method of battery- and smart-buffer-powered inverters only sets the inverter to actual standby. reaching that state can be checked for, so the update() method returns false (read: not busy) immediately if the inverter is already in standby.

on the other hand, solar-powered inverters update their limit to the configured minimum limit. testing for "is that limit already set" is not implemented and shall not be implemented. instead, we record a timestamp when starting the update, send the limit, and wait for it to complete before the update() method returns false, i.e., it never returns false on the first call.

DPL's reloadConfig() method relied on update() returning false immediately at some point to complete reloading the config. hence, that did not work when removing a solar-powered inverter from the list of governed inverters.

a new concept is introduced in this changeset, getting rid of different convoluted ways to handle that inverters should be shut down and abandoned by the DPL. we now keep a list of retirees, i.e., inverters that should be shut down once by the DPL and then left alone. once an inverter is to be retired, it moves to that list. in updateInverters() we take care of our retirees by calling the new retire() method. it will return false eventually, at which point we remove the inverter from the list of retirees and are done with it.

Closes #1719.
Closes #1641.