### PR TITLE
Feature: Add support for Victron VM-3P75CT Power Meter

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -132,6 +132,12 @@ struct POWERMETER_HTTP_SML_CONFIG_T {
 };
 using PowerMeterHttpSmlConfig = struct POWERMETER_HTTP_SML_CONFIG_T;
 
+struct POWERMETER_UDP_VICTRON_CONFIG_T {
+    uint16_t PollingIntervalMs;
+    uint8_t IpAddress[4];
+};
+using PowerMeterUdpVictronConfig = struct POWERMETER_UDP_VICTRON_CONFIG_T;
+
 struct POWERLIMITER_INVERTER_CONFIG_T {
     uint64_t Serial;
     bool IsGoverned;
@@ -369,6 +375,7 @@ struct CONFIG_T {
         PowerMeterSerialSdmConfig SerialSdm;
         PowerMeterHttpJsonConfig HttpJson;
         PowerMeterHttpSmlConfig HttpSml;
+        PowerMeterUdpVictronConfig UdpVictron;
     } PowerMeter;
 
     PowerLimiterConfig PowerLimiter;
@@ -413,6 +420,7 @@ public:
     static void serializePowerMeterSerialSdmConfig(PowerMeterSerialSdmConfig const& source, JsonObject& target);
     static void serializePowerMeterHttpJsonConfig(PowerMeterHttpJsonConfig const& source, JsonObject& target);
     static void serializePowerMeterHttpSmlConfig(PowerMeterHttpSmlConfig const& source, JsonObject& target);
+    static void serializePowerMeterUdpVictronConfig(PowerMeterUdpVictronConfig const& source, JsonObject& target);
     static void serializeBatteryConfig(BatteryConfig const& source, JsonObject& target);
     static void serializePowerLimiterConfig(PowerLimiterConfig const& source, JsonObject& target);
     static void serializeGridChargerConfig(GridChargerConfig const& source, JsonObject& target);
@@ -424,6 +432,7 @@ public:
     static void deserializePowerMeterSerialSdmConfig(JsonObject const& source, PowerMeterSerialSdmConfig& target);
     static void deserializePowerMeterHttpJsonConfig(JsonObject const& source, PowerMeterHttpJsonConfig& target);
     static void deserializePowerMeterHttpSmlConfig(JsonObject const& source, PowerMeterHttpSmlConfig& target);
+    static void deserializePowerMeterUdpVictronConfig(JsonObject const& source, PowerMeterUdpVictronConfig& target);
     static void deserializeBatteryConfig(JsonObject const& source, BatteryConfig& target);
     static void deserializePowerLimiterConfig(JsonObject const& source, PowerLimiterConfig& target);
     static void deserializeGridChargerConfig(JsonObject const& source, GridChargerConfig& target);

--- a/include/powermeter/Provider.h
+++ b/include/powermeter/Provider.h
@@ -18,7 +18,8 @@ public:
         HTTP_JSON = 3,
         SERIAL_SML = 4,
         SMAHM2 = 5,
-        HTTP_SML = 6
+        HTTP_SML = 6,
+        UDP_VICTRON = 7
     };
 
     // returns true if the provider is ready for use, false otherwise

--- a/include/powermeter/udp/victron/Provider.h
+++ b/include/powermeter/udp/victron/Provider.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2024 Holger-Steffen Stapf
+ */
+#pragma once
+
+#include <cstdint>
+#include <Configuration.h>
+#include <powermeter/Provider.h>
+
+namespace PowerMeters::Udp::Victron {
+
+class Provider : public ::PowerMeters::Provider {
+public:
+    explicit Provider(PowerMeterUdpVictronConfig const& cfg);
+    ~Provider();
+
+    bool init() final;
+    void loop() final;
+
+private:
+    void sendModbusRequest();
+    void parseModbusResponse();
+
+    uint32_t _lastRequest = 0;
+    PowerMeterUdpVictronConfig _cfg;
+};
+
+} // namespace PowerMeters::Udp::Victron

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -118,6 +118,12 @@ void ConfigurationClass::serializePowerMeterHttpSmlConfig(PowerMeterHttpSmlConfi
     serializeHttpRequestConfig(source.HttpRequest, target);
 }
 
+void ConfigurationClass::serializePowerMeterUdpVictronConfig(PowerMeterUdpVictronConfig const& source, JsonObject& target)
+{
+    target["polling_interval_ms"] = source.PollingIntervalMs;
+    target["ip_address"] = IPAddress(source.IpAddress).toString();
+}
+
 void ConfigurationClass::serializeBatteryConfig(BatteryConfig const& source, JsonObject& target)
 {
     target["enabled"] = config.Battery.Enabled;
@@ -361,6 +367,9 @@ bool ConfigurationClass::write()
     JsonObject powermeter_http_sml = powermeter["http_sml"].to<JsonObject>();
     serializePowerMeterHttpSmlConfig(config.PowerMeter.HttpSml, powermeter_http_sml);
 
+    JsonObject powermeter_udp_victron = powermeter["udp_victron"].to<JsonObject>();
+    serializePowerMeterUdpVictronConfig(config.PowerMeter.UdpVictron, powermeter_udp_victron);
+
     JsonObject powerlimiter = doc["powerlimiter"].to<JsonObject>();
     serializePowerLimiterConfig(config.PowerLimiter, powerlimiter);
 
@@ -461,6 +470,17 @@ void ConfigurationClass::deserializePowerMeterHttpSmlConfig(JsonObject const& so
 {
     target.PollingInterval = source["polling_interval"] | POWERMETER_POLLING_INTERVAL;
     deserializeHttpRequestConfig(source["http_request"], target.HttpRequest);
+}
+
+void ConfigurationClass::deserializePowerMeterUdpVictronConfig(JsonObject const& source, PowerMeterUdpVictronConfig& target)
+{
+    target.PollingIntervalMs = source["polling_interval_ms"] | POWERMETER_POLLING_INTERVAL * 1000;
+    IPAddress ip;
+    ip.fromString(source["ip_address"] | "");
+    target.IpAddress[0] = ip[0];
+    target.IpAddress[1] = ip[1];
+    target.IpAddress[2] = ip[2];
+    target.IpAddress[3] = ip[3];
 }
 
 void ConfigurationClass::deserializeBatteryConfig(JsonObject const& source, BatteryConfig& target)
@@ -741,6 +761,8 @@ bool ConfigurationClass::read()
     deserializePowerMeterHttpJsonConfig(powermeter["http_json"], config.PowerMeter.HttpJson);
 
     deserializePowerMeterHttpSmlConfig(powermeter["http_sml"], config.PowerMeter.HttpSml);
+
+    deserializePowerMeterUdpVictronConfig(powermeter["udp_victron"], config.PowerMeter.UdpVictron);
 
     deserializePowerLimiterConfig(doc["powerlimiter"], config.PowerLimiter);
 

--- a/src/powermeter/Controller.cpp
+++ b/src/powermeter/Controller.cpp
@@ -7,6 +7,7 @@
 #include <powermeter/sml/http/Provider.h>
 #include <powermeter/sml/serial/Provider.h>
 #include <powermeter/udp/smahm/Provider.h>
+#include <powermeter/udp/victron/Provider.h>
 
 PowerMeters::Controller PowerMeter;
 
@@ -55,6 +56,9 @@ void Controller::updateSettings()
             break;
         case Provider::Type::HTTP_SML:
             _upProvider = std::make_unique<::PowerMeters::Sml::Http::Provider>(pmcfg.HttpSml);
+            break;
+        case Provider::Type::UDP_VICTRON:
+            _upProvider = std::make_unique<::PowerMeters::Udp::Victron::Provider>(pmcfg.UdpVictron);
             break;
     }
 

--- a/src/powermeter/udp/victron/Provider.cpp
+++ b/src/powermeter/udp/victron/Provider.cpp
@@ -10,6 +10,14 @@
 namespace PowerMeters::Udp::Victron {
 
 static constexpr unsigned int modbusPort = 502;  // local port to listen on
+
+// we only send one request which spans all registers we want to read
+static constexpr uint16_t sTransactionId = 0xDEAD; // arbitrary value
+static constexpr uint8_t sUnitId = 0x01;
+static constexpr uint8_t sFunctionCode = 0x03; // read holding registers
+static constexpr uint16_t sRegisterAddress = 0x3040;
+static constexpr uint16_t sRegisterCount = 0x004C;
+
 static WiFiUDP VictronUdp;
 
 Provider::Provider(PowerMeterUdpVictronConfig const& cfg)
@@ -36,9 +44,47 @@ void Provider::sendModbusRequest()
 
     if (currentMillis - _lastRequest < interval) { return; }
 
-    // TODO(schlimmchen): implement
+    std::vector<uint8_t> payload;
+
+    payload.push_back(sTransactionId >> 8);
+    payload.push_back(sTransactionId & 0xFF);
+
+    // protocol ID
+    payload.push_back(0x00);
+    payload.push_back(0x00);
+
+    // length
+    payload.push_back(0x00);
+    payload.push_back(0x06);
+
+    payload.push_back(sUnitId);
+    payload.push_back(sFunctionCode);
+    payload.push_back(sRegisterAddress >> 8);
+    payload.push_back(sRegisterAddress & 0xFF);
+    payload.push_back(sRegisterCount >> 8);
+    payload.push_back(sRegisterCount & 0xFF);
+
+    VictronUdp.beginPacket(_cfg.IpAddress, modbusPort);
+    VictronUdp.write(payload.data(), payload.size());
+    VictronUdp.endPacket();
 
     _lastRequest = currentMillis;
+}
+
+static float readInt16(uint8_t** buffer, uint8_t factor)
+{
+    uint8_t* p = *buffer;
+    int16_t value = (p[0] << 8) | p[1];
+    *buffer += 2;
+    return static_cast<float>(value) / factor;
+}
+
+static float readInt32(uint8_t** buffer, uint8_t factor)
+{
+    uint8_t* p = *buffer;
+    int32_t value = (p[0] << 24) | (p[1] << 16) | (p[2] << 8) | p[3];
+    *buffer += 4;
+    return static_cast<float>(value) / factor;
 }
 
 void Provider::parseModbusResponse()
@@ -46,10 +92,94 @@ void Provider::parseModbusResponse()
     int packetSize = VictronUdp.parsePacket();
     if (!packetSize) { return; }
 
-    uint8_t buffer[1024];
-    int rSize = VictronUdp.read(buffer, 1024);
+    uint8_t buffer[256];
+    VictronUdp.read(buffer, sizeof(buffer));
 
-    // TODO(schlimmchen): implement
+    uint8_t* p = buffer;
+
+    if (_verboseLogging) {
+        MessageOutput.printf("[PowerMeters::Udp::Victron] received %d bytes:", packetSize);
+
+        for (int i = 0; i < packetSize; i++) {
+            if (i % 16 == 0) {
+                MessageOutput.print("\r\n");
+            }
+            MessageOutput.printf("%02X ", buffer[i]);
+        }
+
+        MessageOutput.print("\r\n");
+    }
+
+    uint16_t transactionId = (p[0] << 8) | p[1];
+    p += 2;
+
+    if (transactionId != sTransactionId) {
+        MessageOutput.printf("[PowerMeters::Udp::Victron] invalid transaction ID: %04X\r\n", transactionId);
+        return;
+    }
+
+    uint16_t protocolId = (p[0] << 8) | p[1];
+    p += 2;
+
+    if (protocolId != 0x0000) {
+        MessageOutput.printf("[PowerMeters::Udp::Victron] invalid protocol ID: %04X\r\n", protocolId);
+        return;
+    }
+
+    uint16_t length = (p[0] << 8) | p[1];
+    p += 2;
+
+    uint16_t expectedLength = (sRegisterCount * 2) + 3;
+    if (length != expectedLength) {
+        MessageOutput.printf("[PowerMeters::Udp::Victron] unexpected length: %04X, "
+            "expected %04X\r\n", length, expectedLength);
+        return;
+    }
+
+    uint8_t unitId = p[0];
+    p += 1;
+
+    if (unitId != sUnitId) {
+        MessageOutput.printf("[PowerMeters::Udp::Victron] unexpected unit ID: %02X, "
+            "expected %02X\r\n", unitId, sUnitId);
+        return;
+    }
+
+    uint8_t functionCode = p[0];
+    p += 1;
+
+    if (functionCode != sFunctionCode) {
+        MessageOutput.printf("[PowerMeters::Udp::Victron] unexpected function code: %02X, "
+            "expected %02X\r\n", functionCode, sFunctionCode);
+        return;
+    }
+
+    uint8_t byteCount = p[0];
+    p += 1;
+
+    uint8_t expectedByteCount = sRegisterCount * 2;
+    if (byteCount != expectedByteCount) {
+        MessageOutput.printf("[PowerMeters::Udp::Victron] unexpected byte count: %02X, "
+            "expected %02X\r\n", byteCount, expectedByteCount);
+        return;
+    }
+
+    using Label = ::PowerMeters::DataPointLabel;
+    _dataCurrent.add<Label::VoltageL1>(readInt16(&p, 100)); // 0x3040
+    _dataCurrent.add<Label::CurrentL1>(readInt16(&p, 100)); // 0x3041
+    p += 12; // jump to register 0x3048
+    _dataCurrent.add<Label::VoltageL2>(readInt16(&p, 100)); // 0x3048
+    _dataCurrent.add<Label::CurrentL2>(readInt16(&p, 100)); // 0x3049
+    p += 12; // jump to register 0x3050
+    _dataCurrent.add<Label::VoltageL3>(readInt16(&p, 100)); // 0x3050
+    _dataCurrent.add<Label::CurrentL3>(readInt16(&p, 100)); // 0x3051
+    p += 92; // jump from 0x3052 to 0x3080 (0x2E registers = 92 bytes)
+    _dataCurrent.add<Label::PowerTotal>(readInt32(&p, 1)); // 0x3080
+    _dataCurrent.add<Label::PowerL1>(readInt32(&p, 1)); // 0x3082
+    p += 4; // jump to 0x3086
+    _dataCurrent.add<Label::PowerL2>(readInt32(&p, 1)); // 0x3086
+    p += 4; // jump to 0x308A
+    _dataCurrent.add<Label::PowerL3>(readInt32(&p, 1)); // 0x308A
 }
 
 void Provider::loop()

--- a/src/powermeter/udp/victron/Provider.cpp
+++ b/src/powermeter/udp/victron/Provider.cpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2024 Holger-Steffen Stapf
+ */
+#include <powermeter/udp/victron/Provider.h>
+#include <Arduino.h>
+#include <WiFiUdp.h>
+#include <MessageOutput.h>
+
+namespace PowerMeters::Udp::Victron {
+
+static constexpr unsigned int modbusPort = 502;  // local port to listen on
+static WiFiUDP VictronUdp;
+
+Provider::Provider(PowerMeterUdpVictronConfig const& cfg)
+    : _cfg(cfg)
+{
+}
+
+bool Provider::init()
+{
+    VictronUdp.begin(modbusPort);
+    return true;
+}
+
+Provider::~Provider()
+{
+    VictronUdp.stop();
+}
+
+void Provider::sendModbusRequest()
+{
+    auto interval = _cfg.PollingIntervalMs;
+
+    uint32_t currentMillis = millis();
+
+    if (currentMillis - _lastRequest < interval) { return; }
+
+    // TODO(schlimmchen): implement
+
+    _lastRequest = currentMillis;
+}
+
+void Provider::parseModbusResponse()
+{
+    int packetSize = VictronUdp.parsePacket();
+    if (!packetSize) { return; }
+
+    uint8_t buffer[1024];
+    int rSize = VictronUdp.read(buffer, 1024);
+
+    // TODO(schlimmchen): implement
+}
+
+void Provider::loop()
+{
+    sendModbusRequest();
+    parseModbusResponse();
+}
+
+} // namespace PowerMeters::Udp::Victron

--- a/src/powermeter/udp/victron/Provider.cpp
+++ b/src/powermeter/udp/victron/Provider.cpp
@@ -174,6 +174,8 @@ void Provider::parseModbusResponse()
 
     using Label = ::PowerMeters::DataPointLabel;
 
+    auto scopedLock = _dataCurrent.lock();
+
     p += 2; // skip register 0x3032 (AC frequency)
     p += 2; // skip register 0x3033 (PEN voltage)
 

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -633,11 +633,13 @@
         "typeSML": "SML/OBIS via serieller Verbindung (z.B. Hichi TTL)",
         "typeSMAHM2": "SMA Homemanager 2.0",
         "typeHTTP_SML": "HTTP(S) + SML (z.B. Tibber Pulse via Tibber Bridge)",
+        "typeUDP_VICTRON": "Victron VM-3P75CT (Modbus UDP)",
         "MqttValue": "Konfiguration Wert {valueNumber}",
         "MqttTopic": "MQTT Topic",
         "mqttJsonPath": "Optional: JSON-Pfad",
         "SDM": "SDM-Stromzähler Konfiguration",
         "sdmaddress": "Modbus Adresse",
+        "ipAddress": "IP-Adresse",
         "HTTP_JSON": "HTTP(S) + JSON - Allgemeine Konfiguration",
         "httpIndividualRequests": "Individuelle HTTP(S) Anfragen pro Wert",
         "urlExamplesHeading": "Beispiele für URLs",
@@ -654,7 +656,8 @@
         "testHttpJsonRequest": "HTTP(S)-Anfrage(n) senden und Antwort(en) verarbeiten",
         "testHttpSmlHeader": "Konfiguration testen",
         "testHttpSmlRequest": "HTTP(S)-Anfrage senden und Antwort verarbeiten",
-        "HTTP_SML": "HTTP(S) + SML - Konfiguration"
+        "HTTP_SML": "HTTP(S) + SML - Konfiguration",
+        "UDP_VICTRON": "Victron VM-3P75CT (Modbus UDP) - Konfiguration"
     },
     "httprequestsettings": {
         "url": "URL",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -635,11 +635,13 @@
         "typeSML": "SML/OBIS via serial connection (e.g. Hichi TTL)",
         "typeSMAHM2": "SMA Homemanager 2.0",
         "typeHTTP_SML": "HTTP(S) + SML (e.g. Tibber Pulse via Tibber Bridge)",
+        "typeUDP_VICTRON": "Victron VM-3P75CT (Modbus UDP)",
         "MqttValue": "Value {valueNumber} Configuration",
         "mqttJsonPath": "Optional: JSON Path",
         "MqttTopic": "MQTT Topic",
         "SDM": "SDM-Power Meter Parameter",
         "sdmaddress": "Modbus Address",
+        "ipAddress": "IP Address",
         "HTTP": "HTTP(S) + JSON - General configuration",
         "httpIndividualRequests": "Individual HTTP(S) requests per value",
         "urlExamplesHeading": "URL Examples",
@@ -656,7 +658,8 @@
         "testHttpJsonRequest": "Send HTTP(S) request(s) and process response(s)",
         "testHttpSmlHeader": "Test Configuration",
         "testHttpSmlRequest": "Send HTTP(S) request and process response",
-        "HTTP_SML": "Configuration"
+        "HTTP_SML": "Configuration",
+        "UDP_VICTRON": "Configuration"
     },
     "httprequestsettings": {
         "url": "URL",

--- a/webapp/src/types/PowerMeterConfig.ts
+++ b/webapp/src/types/PowerMeterConfig.ts
@@ -35,6 +35,11 @@ export interface PowerMeterHttpSmlConfig {
     http_request: HttpRequestConfig;
 }
 
+export interface PowerMeterUdpVictronConfig {
+    polling_interval_ms: number;
+    ip_address: string;
+}
+
 export interface PowerMeterConfig {
     enabled: boolean;
     verbose_logging: boolean;
@@ -44,4 +49,5 @@ export interface PowerMeterConfig {
     serial_sdm: PowerMeterSerialSdmConfig;
     http_json: PowerMeterHttpJsonConfig;
     http_sml: PowerMeterHttpSmlConfig;
+    udp_victron: PowerMeterUdpVictronConfig;
 }

--- a/webapp/src/views/PowerMeterAdminView.vue
+++ b/webapp/src/views/PowerMeterAdminView.vue
@@ -277,6 +277,29 @@
                         </BootstrapAlert>
                     </CardElement>
                 </template>
+
+                <template v-if="powerMeterConfigList.source === 7">
+                    <CardElement :text="$t('powermeteradmin.UDP_VICTRON')" textVariant="text-bg-primary" add-space>
+                        <InputElement
+                            :label="$t('powermeteradmin.pollingInterval')"
+                            v-model="udpVictronPollIntervalSeconds"
+                            type="number"
+                            min="0.5"
+                            max="15.0"
+                            step="0.1"
+                            :postfix="$t('powermeteradmin.seconds')"
+                            wide
+                        />
+
+                        <InputElement
+                            :label="$t('powermeteradmin.ipAddress')"
+                            v-model="powerMeterConfigList.udp_victron.ip_address"
+                            type="text"
+                            maxlength="15"
+                            wide
+                        />
+                    </CardElement>
+                </template>
             </template>
 
             <FormFooter @reload="getPowerMeterConfig" />
@@ -316,6 +339,7 @@ export default defineComponent({
                 { key: 4, value: this.$t('powermeteradmin.typeSML') },
                 { key: 5, value: this.$t('powermeteradmin.typeSMAHM2') },
                 { key: 6, value: this.$t('powermeteradmin.typeHTTP_SML') },
+                { key: 7, value: this.$t('powermeteradmin.typeUDP_VICTRON') },
             ],
             unitTypeList: [
                 { key: 1, value: 'mW' },
@@ -339,6 +363,16 @@ export default defineComponent({
     },
     created() {
         this.getPowerMeterConfig();
+    },
+    computed: {
+        udpVictronPollIntervalSeconds: {
+            get(): number {
+                return this.powerMeterConfigList.udp_victron.polling_interval_ms / 1000;
+            },
+            set(value: number) {
+                this.powerMeterConfigList.udp_victron.polling_interval_ms = value * 1000;
+            },
+        },
     },
     methods: {
         getPowerMeterConfig() {


### PR DESCRIPTION
This implements #1736 but does not close it, yet. I want this to be squashed as "Feature: Add support for Victron VM-3P75CT Power Meter" into Andreas' "use datapoints for powermeters" branch, and then mark his PR #1651 as closing the request.

Using cursor (the IDE) and having the respective experience what has to be added in what places, this was quite a fun excercise and took astonishingly little time. Also, thanks to @Sorbat's exploration and detailed feature request, it was possible to get this working on the very first try except for one little bug (6b999ea).