### PR TITLE
Fix webconsole heap issue

### DIFF
--- a/include/WebApi_ws_console.h
+++ b/include/WebApi_ws_console.h
@@ -11,6 +11,8 @@ public:
     void reload();
 
 private:
+    void onWebsocketEvent(AsyncWebSocket* server, AsyncWebSocketClient* client, AwsEventType type, void* arg, uint8_t* data, size_t len);
+
     AsyncWebSocket _ws;
     AsyncAuthenticationMiddleware _simpleDigestAuth;
 

--- a/src/MessageOutput.cpp
+++ b/src/MessageOutput.cpp
@@ -105,8 +105,12 @@ void MessageOutputClass::loop()
 
     while (!_lines.empty()) {
         Syslog.write(_lines.front().data(), _lines.front().size());
-        if (_ws && _ws->availableForWriteAll()) {
-            _ws->textAll(std::make_shared<message_t>(std::move(_lines.front())));
+        if (_ws) {
+            auto msg = std::make_shared<message_t>(std::move(_lines.front()));
+            for (auto& client : _ws->getClients()) {
+                if (client.queueIsFull()) { continue; }
+                client.text(msg);
+            }
         }
         _lines.pop();
     }

--- a/src/MessageOutput.cpp
+++ b/src/MessageOutput.cpp
@@ -103,17 +103,11 @@ void MessageOutputClass::loop()
         ++map_iter;
     }
 
-    if (!_ws) {
-        while (!_lines.empty()) {
-            Syslog.write(_lines.front().data(), _lines.front().size());
-            _lines.pop(); // do not hog memory
-        }
-        return;
-    }
-
-    while (!_lines.empty() && _ws->availableForWriteAll()) {
+    while (!_lines.empty()) {
         Syslog.write(_lines.front().data(), _lines.front().size());
-        _ws->textAll(std::make_shared<message_t>(std::move(_lines.front())));
+        if (_ws && _ws->availableForWriteAll()) {
+            _ws->textAll(std::make_shared<message_t>(std::move(_lines.front())));
+        }
         _lines.pop();
     }
 }

--- a/src/MessageOutput.cpp
+++ b/src/MessageOutput.cpp
@@ -109,7 +109,14 @@ void MessageOutputClass::loop()
             auto msg = std::make_shared<message_t>(std::move(_lines.front()));
             for (auto& client : _ws->getClients()) {
                 if (client.queueIsFull()) { continue; }
+
                 client.text(msg);
+
+                if (client.queueIsFull()) {
+                    static char const warningStr[] = "WARNING: dropping log line(s) as websocket client's queue is full\r\n";
+                    message_t warningVec(warningStr, warningStr + sizeof(warningStr) - 1);
+                    msg->swap(warningVec);
+                }
             }
         }
         _lines.pop();

--- a/src/WebApi_ws_console.cpp
+++ b/src/WebApi_ws_console.cpp
@@ -16,8 +16,16 @@ WebApiWsConsoleClass::WebApiWsConsoleClass()
 
 void WebApiWsConsoleClass::init(AsyncWebServer& server, Scheduler& scheduler)
 {
+    using std::placeholders::_1;
+    using std::placeholders::_2;
+    using std::placeholders::_3;
+    using std::placeholders::_4;
+    using std::placeholders::_5;
+    using std::placeholders::_6;
+
     server.addHandler(&_ws);
     MessageOutput.register_ws_output(&_ws);
+    _ws.onEvent(std::bind(&WebApiWsConsoleClass::onWebsocketEvent, this, _1, _2, _3, _4, _5, _6));
 
     scheduler.addTask(_wsCleanupTask);
     _wsCleanupTask.enable();
@@ -26,6 +34,21 @@ void WebApiWsConsoleClass::init(AsyncWebServer& server, Scheduler& scheduler)
     _simpleDigestAuth.setRealm("console websocket");
 
     reload();
+}
+
+void WebApiWsConsoleClass::onWebsocketEvent(AsyncWebSocket* server, AsyncWebSocketClient* client, AwsEventType type, void* arg, uint8_t* data, size_t len)
+{
+    if (type == WS_EVT_CONNECT) {
+        char str[64];
+        snprintf(str, sizeof(str), "Websocket: [%s][%u] connect", server->url(), client->id());
+        Serial.println(str);
+        MessageOutput.println(str);
+    } else if (type == WS_EVT_DISCONNECT) {
+        char str[64];
+        snprintf(str, sizeof(str), "Websocket: [%s][%u] disconnect", server->url(), client->id());
+        Serial.println(str);
+        MessageOutput.println(str);
+    }
 }
 
 void WebApiWsConsoleClass::reload()


### PR DESCRIPTION
I am done trying to figure out what goes wrong in some people's setups. Aviv/Sorbat and I are chatting about this from time to time for weeks now, but I am out of ideas.

However, what I can provide, is this changeset, which solves the worst part of the issue: The heap will not overrun any more and using the webconsole should therefore no longer cause unexpected reboots.

New approach: We move log message lines to the websocket clients individually. If any client's queue is full after adding the message line, we do the following:
1. Replace the last message with a warning that messages were dropped.
2. Drop all messages while the client's queue is full.

This works, as we no longer keep log lines indefinitely, expecting that all websocket clients will eventually process all messages. Instead, we **will** discard log message lines, and only if the websocket client can keep up with the rate of messages, all of them will arrive. Otherwise, the warning message will appear and lines will be missing.

@AndreasBoehm If you merge this rather than me, please **squash** and polish the commit title and message.

Closes #1561.