### PR TITLE
add build env option 'generic_esp32s3_usb_octal_psram'

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -143,6 +143,18 @@ build_flags = ${env.build_flags}
     -DPIN_MAPPING_REQUIRED=1
 
 
+[env:generic_esp32s3_usb_octal_psram]
+board = esp32-s3-devkitc-1
+upload_protocol = esp-builtin
+board_build.arduino.memory_type = qio_opi
+board_build.psram_type = opi
+build_flags = ${env.build_flags}
+    -DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DPIN_MAPPING_REQUIRED=1
+    -DBOARD_HAS_PSRAM
+
+
 [env:olimex_esp32_poe]
 ; https://www.olimex.com/Products/IoT/ESP32/ESP32-POE/open-source-hardware
 board = esp32-poe

--- a/platformio.ini
+++ b/platformio.ini
@@ -144,10 +144,11 @@ build_flags = ${env.build_flags}
 
 
 [env:generic_esp32s3_usb_octal_psram]
+; Fusion Board v2.2 (N16R8).
+; WARNING! You can either use the PSRAM or the NRF24: https://github.com/markusdd/OpenDTUFusionDocs/blob/main/REVISIONS.md#v22
 board = esp32-s3-devkitc-1
 upload_protocol = esp-builtin
 board_build.arduino.memory_type = qio_opi
-board_build.psram_type = opi
 build_flags = ${env.build_flags}
     -DARDUINO_USB_MODE=1
     -DARDUINO_USB_CDC_ON_BOOT=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ extra_configs =
 [env]
 ; Make sure to NOT add any spaces in the custom_ci_action property
 ; (also the position in the file is important)
-custom_ci_action = generic_esp32_4mb_no_ota,generic_esp32_8mb,generic_esp32s3,generic_esp32s3_usb
+custom_ci_action = generic_esp32_4mb_no_ota,generic_esp32_8mb,generic_esp32s3,generic_esp32s3_usb,generic_esp32s3_usb_octal_psram
 
 framework = arduino
 platform = espressif32@6.10.0


### PR DESCRIPTION
Works with all Octal SPI PSRAM ESP32-S3, e.g. Fusion Board v2.2 (N16R8).

Be aware that on a Fusion Board v2.2 you can either use the PSRAM or the NRF24: https://github.com/markusdd/OpenDTUFusionDocs/blob/main/REVISIONS.md#v22

The ESP32S3R8 comes with 8MiB of PSRAM built-in, which can reduce stability issues related to memory usage: https://github.com/hoylabs/OpenDTU-OnBattery/issues/1260

This can increase the free non-PSRAM heap by around 20% (in my case from 135KiB to 162KiB free heap) at the expense of slower memory access.

![image](https://github.com/user-attachments/assets/9598f8a1-9390-4d94-8482-6193bd2b9a3a)
