### PR TITLE
Fix: solar-powered inverters are non-eligible at nighttime

### DIFF
--- a/include/PowerLimiterInverter.h
+++ b/include/PowerLimiterInverter.h
@@ -86,7 +86,8 @@ public:
         SendingCommandsDisabled,
         MaxOutputUnknown,
         CurrentLimitUnknown,
-        Eligible
+        Eligible,
+        Nighttime
     };
 
     // only returns Eligibility::Eligible if the inverter can participate


### PR DESCRIPTION
we currently rely on solar-powered inverters becoming unreachable during the night. they eventually do, but until they do, there is a (potentially) long stretch of time where they are unable to produce any power, i.e., they are in standby, but still reachable. in that case we don't know what the inverter would produce if it was woken up, so we assume it can produce its rated power. that is nonsense when it is dawn.

it seems that it is already "night" according to SunPosition when the inverter switches to standby on its own, we add tha respective check.

Closes #1759.