### PR TITLE
Fix: DPL: prevent underflow in solar charger output calculation

### DIFF
--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -724,16 +724,15 @@ bool PowerLimiterClass::updateInverters()
 
 uint16_t PowerLimiterClass::getSolarPassthroughPower()
 {
-    auto solarChargerOutput = SolarCharger.getStats()->getOutputPowerWatts();
-
-    if (!isSolarPassThroughEnabled()
-            || isBelowStopThreshold()
-            || !solarChargerOutput
-            ) {
+    if (!isSolarPassThroughEnabled() || isBelowStopThreshold()) {
         return 0;
     }
 
-    return *solarChargerOutput;
+    std::optional<float> oSolarChargerOutput = SolarCharger.getStats()->getOutputPowerWatts();
+
+    // do not trust this value to be positive. in particular, the MQTT solar
+    // provider happily processes negative values as well.
+    return std::max<float>(0, oSolarChargerOutput.value_or(0));
 }
 
 float PowerLimiterClass::getBatteryInvertersOutputAcWatts()

--- a/src/solarcharger/victron/Stats.cpp
+++ b/src/solarcharger/victron/Stats.cpp
@@ -37,8 +37,9 @@ std::optional<float> Stats::getOutputPowerWatts() const
 
     for (auto const& entry : _data) {
         if (!entry.second) { continue; }
-        
-        sum = sum.has_value() ? *sum + entry.second->batteryOutputPower_W : entry.second->batteryOutputPower_W;
+
+        // NOTE: batteryOutputPower_W can be negative if the load output is in use
+        sum = sum.value_or(0) + std::max<int16_t>(0, entry.second->batteryOutputPower_W);
     }
 
     return sum;


### PR DESCRIPTION
For reasons/explanations, see new comments in changeset.

Closes #1762.