### PR TITLE
Fix: Victron: ignore stale stats and prevent phantom device stats to persist

### DIFF
--- a/include/solarcharger/victron/Stats.h
+++ b/include/solarcharger/victron/Stats.h
@@ -24,14 +24,15 @@ public:
     void mqttPublish() const final;
     void mqttPublishSensors(const boolean forcePublish) const final;
 
-    void update(const String serial, const std::optional<VeDirectMpptController::data_t> mpptData, uint32_t lastUpdate) const;
+    void update(const String serial, const VeDirectMpptController::data_t mpptData, uint32_t lastUpdate) const;
 
 private:
     // TODO(andreasboehm): _data and _lastUpdate in two different structures is not ideal and needs to change
-    mutable std::map<String, std::optional<VeDirectMpptController::data_t>> _data;
-    mutable std::map<String, uint32_t> _lastUpdate;
+    using data_map_t = std::map<String, VeDirectMpptController::data_t>;
+    mutable data_map_t _data;
+    mutable data_map_t _previousData;
 
-    mutable std::map<String, VeDirectMpptController::data_t> _previousData;
+    mutable std::map<String, uint32_t> _lastUpdate;
 
     // point of time in millis() when updated values will be published
     mutable uint32_t _nextPublishUpdatesOnly = 0;
@@ -42,6 +43,8 @@ private:
     mutable bool _PublishFull;
 
     HassIntegration _hassIntegration;
+
+    bool isStale(data_map_t::value_type const& data) const;
 
     void populateJsonWithInstanceStats(const JsonObject &root, const VeDirectMpptController::data_t &mpptData) const;
 

--- a/include/solarcharger/victron/Stats.h
+++ b/include/solarcharger/victron/Stats.h
@@ -24,7 +24,7 @@ public:
     void mqttPublish() const final;
     void mqttPublishSensors(const boolean forcePublish) const final;
 
-    void update(const String serial, const VeDirectMpptController::data_t mpptData, uint32_t lastUpdate) const;
+    void update(const String key, const VeDirectMpptController::data_t mpptData, uint32_t lastUpdate) const;
 
 private:
     // TODO(andreasboehm): _data and _lastUpdate in two different structures is not ideal and needs to change

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
@@ -28,6 +28,7 @@ public:
     T const& getData() const { return _tmpFrame; }
     bool sendHexCommand(VeDirectHexCommand cmd, VeDirectHexRegister addr, uint32_t value = 0, uint8_t valsize = 0);
     bool isStateIdle() const { return (_state == State::IDLE); }
+    String getLogId() const { return String(_logId); }
 
 protected:
     VeDirectFrameHandler();

--- a/src/solarcharger/victron/Provider.cpp
+++ b/src/solarcharger/victron/Provider.cpp
@@ -69,8 +69,8 @@ void Provider::loop()
     for (auto const& upController : _controllers) {
         upController->loop();
 
-        if(upController->isDataValid()) {
-            _stats->update(upController->getData().serialNr_SER, upController->getData(), upController->getLastUpdate());
+        if (upController->isDataValid()) {
+            _stats->update(upController->getLogId(), upController->getData(), upController->getLastUpdate());
         }
     }
 }

--- a/src/solarcharger/victron/Provider.cpp
+++ b/src/solarcharger/victron/Provider.cpp
@@ -71,8 +71,6 @@ void Provider::loop()
 
         if(upController->isDataValid()) {
             _stats->update(upController->getData().serialNr_SER, upController->getData(), upController->getLastUpdate());
-        } else {
-            _stats->update(upController->getData().serialNr_SER, std::nullopt, upController->getLastUpdate());
         }
     }
 }

--- a/src/solarcharger/victron/Stats.cpp
+++ b/src/solarcharger/victron/Stats.cpp
@@ -6,13 +6,13 @@
 
 namespace SolarChargers::Victron {
 
-void Stats::update(const String serial, const VeDirectMpptController::data_t mpptData, uint32_t lastUpdate) const
+void Stats::update(const String key, const VeDirectMpptController::data_t mpptData, uint32_t lastUpdate) const
 {
-    // serial required as index
-    if (serial.isEmpty()) { return; }
+    // key required as index
+    if (key.isEmpty()) { return; }
 
-    _data[serial] = mpptData;
-    _lastUpdate[serial] = lastUpdate;
+    _data[key] = mpptData;
+    _lastUpdate[key] = lastUpdate;
 }
 
 uint32_t Stats::getAgeMillis() const
@@ -171,7 +171,7 @@ void Stats::getLiveViewData(JsonVariant& root, const boolean fullUpdate, const u
         auto hasUpdate = age != 0 && age < millis() - lastPublish;
         if (!fullUpdate && !hasUpdate) { continue; }
 
-        JsonObject instance = instances[entry.first].to<JsonObject>();
+        JsonObject instance = instances[entry.second.serialNr_SER].to<JsonObject>();
         instance["data_age_ms"] = age;
         instance["hide_serial"] = false;
         populateJsonWithInstanceStats(instance, entry.second);


### PR DESCRIPTION
When data corruption happens we get phantom devices and the stats of those devices must be ignored when they get stale. The same applies to regular devices that stopped sending stats for whatever reason. Additionally we prevent phantom device stats to persist by using the connection setup defined `_logId` of the controller as the key to store the stats instead of the serial. (Thanks @ranma for the brilliant idea to solve this)

Related to https://github.com/hoylabs/OpenDTU-OnBattery/issues/1692
Makses #1778 obsolete.