### PR TITLE
Improvement: DPL: improve handling without overscaling

### DIFF
--- a/include/PowerLimiterOverscalingInverter.h
+++ b/include/PowerLimiterOverscalingInverter.h
@@ -11,6 +11,7 @@ public:
 
 protected:
     void setAcOutput(uint16_t expectedOutputWatts) final;
+    bool overscalingEnabled() const;
 
 private:
     uint16_t scaleLimit(uint16_t expectedOutputWatts);

--- a/src/PowerLimiterBatteryInverter.cpp
+++ b/src/PowerLimiterBatteryInverter.cpp
@@ -27,7 +27,7 @@ uint16_t PowerLimiterBatteryInverter::getMaxIncreaseWatts() const
     // this should not happen for battery-powered inverters, but we want to
     // be robust in case something else set a limit on the inverter (or in
     // case we did something wrong...).
-    if (getCurrentLimitWatts() >= getConfiguredMaxPowerWatts()) { return 0; }
+    if (getCurrentLimitWatts() > getConfiguredMaxPowerWatts()) { return 0; }
 
     // we must not substract the current AC output here, but the current
     // limit value, so we avoid trying to produce even more even if the


### PR DESCRIPTION
When overscaling is not in use we should make most decisions based on `getCurrentLimitWatts()`. Additionally the max increase is now constrained by the inverters max limit when overscaling is in use.