### PR TITLE
Fix: ignore stats of non-eligible inverters

### DIFF
--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -180,6 +180,12 @@ void PowerLimiterClass::loop()
     uint32_t latestInverterStats = 0;
 
     for (auto const& upInv : _inverters) {
+        // in particular, we don't want to wait for stats from inverters that
+        // are not eligible because they are (currently) unreachable. this is
+        // fine as we ignore them throughout the DPL loop if they are not eligible.
+        auto eligible = PowerLimiterInverter::Eligibility::Eligible;
+        if (eligible != upInv->isEligible()) { continue; }
+
         auto oStatsMillis = upInv->getLatestStatsMillis();
         if (!oStatsMillis) {
             return announceStatus(Status::InverterStatsPending);


### PR DESCRIPTION
as non-eligible inverters do not participate in the current DPL loop, we can and we should ignore whether or not we have current statistics on them. in particular this makes for unreachable inverters, which will not send stats for how ever long they are unreachable. the DPL shall not wait for those inverters to become reachable before continuing to do calculations, which ignore those inverters any way.

closes #1779.