### PR TITLE
Fix: inspect usage of isEligibile()

### DIFF
--- a/include/PowerLimiterInverter.h
+++ b/include/PowerLimiterInverter.h
@@ -90,9 +90,9 @@ public:
         Nighttime
     };
 
-    // only returns Eligibility::Eligible if the inverter can participate
+    // only returns true if the inverter can participate
     // in achieving the requested change in power output
-    Eligibility isEligible() const;
+    bool isEligible() const;
 
 protected:
     PowerLimiterInverter(bool verboseLogging, PowerLimiterInverterConfig const& config);
@@ -115,6 +115,9 @@ protected:
     char _logPrefix[32];
 
 private:
+    // returns the detailed eligibility status of the inverter
+    Eligibility getEligibility() const;
+
     virtual void setAcOutput(uint16_t expectedOutputWatts) = 0;
 
     bool _retired = false; // true if to be abandoned by DPL

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -361,19 +361,24 @@ void PowerLimiterClass::loop()
 std::pair<float, char const*> PowerLimiterClass::getInverterDcVoltage() {
     auto const& config = Configuration.get();
 
-    auto iter = _inverters.begin();
-    while(iter != _inverters.end()) {
+    auto iter = _inverters.cbegin();
+    while(iter != _inverters.cend()) {
         if ((*iter)->getSerial() == config.PowerLimiter.InverterSerialForDcVoltage) {
             break;
         }
         ++iter;
     }
 
-    if (iter == _inverters.end()) {
-        return { -1.0, "<unknown>" };
+    auto voltage = -1.0;
+
+    if (iter == _inverters.cend()) {
+        return { voltage, "<unknown>" };
     }
 
-    auto voltage = (*iter)->getDcVoltage(config.PowerLimiter.InverterChannelIdForDcVoltage);
+    if ((*iter)->isReachable()) {
+        voltage = (*iter)->getDcVoltage(config.PowerLimiter.InverterChannelIdForDcVoltage);
+    }
+
     return { voltage, (*iter)->getSerialStr() };
 }
 

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -457,9 +457,9 @@ void PowerLimiterClass::unconditionalFullSolarPassthrough()
 
     uint16_t targetOutput = 0;
 
-    auto solarChargerOuput = SolarCharger.getStats()->getOutputPowerWatts();
-    if (solarChargerOuput) {
-        targetOutput = static_cast<uint16_t>(std::max<int32_t>(0, *solarChargerOuput));
+    auto solarChargerOutput = SolarCharger.getStats()->getOutputPowerWatts();
+    if (solarChargerOutput) {
+        targetOutput = static_cast<uint16_t>(std::max<int32_t>(0, *solarChargerOutput));
         targetOutput = dcPowerBusToInverterAc(targetOutput);
     }
 

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -183,8 +183,7 @@ void PowerLimiterClass::loop()
         // in particular, we don't want to wait for stats from inverters that
         // are not eligible because they are (currently) unreachable. this is
         // fine as we ignore them throughout the DPL loop if they are not eligible.
-        auto eligible = PowerLimiterInverter::Eligibility::Eligible;
-        if (eligible != upInv->isEligible()) { continue; }
+        if (!upInv->isEligible()) { continue; }
 
         auto oStatsMillis = upInv->getLatestStatsMillis();
         if (!oStatsMillis) {
@@ -451,7 +450,7 @@ void PowerLimiterClass::unconditionalFullSolarPassthrough()
     _lastCalculation = now;
 
     for (auto const& upInv : _inverters) {
-        if (PowerLimiterInverter::Eligibility::Eligible != upInv->isEligible()) { continue; }
+        if (!upInv->isEligible()) { continue; }
         if (!upInv->isBatteryPowered()) { upInv->setMaxOutput(); }
     }
 
@@ -551,7 +550,7 @@ uint16_t PowerLimiterClass::calcTargetOutput()
     for (auto const& upInv : _inverters) {
         // non-eligible inverters don't participate in this DPL round at all.
         // inverters in standby report 0 W output, so we can iterate them.
-        if (PowerLimiterInverter::Eligibility::Eligible != upInv->isEligible()) { continue; }
+        if (!upInv->isEligible()) { continue; }
 
         currentTotalOutput += upInv->getCurrentOutputAcWatts();
     }
@@ -582,7 +581,7 @@ uint16_t PowerLimiterClass::updateInverterLimits(uint16_t powerRequested,
     for (auto& upInv : _inverters) {
         if (!filter(*upInv)) { continue; }
 
-        if (PowerLimiterInverter::Eligibility::Eligible != upInv->isEligible()) { continue; }
+        if (!upInv->isEligible()) { continue; }
 
         producing += upInv->getCurrentOutputAcWatts();
         matchingInverters.push_back(upInv.get());

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -446,10 +446,12 @@ uint16_t PowerLimiterClass::dcPowerBusToInverterAc(uint16_t dcPower)
  */
 void PowerLimiterClass::unconditionalFullSolarPassthrough()
 {
-    if ((millis() - _lastCalculation) < _calculationBackoffMs) { return; }
-    _lastCalculation = millis();
+    auto now = millis();
+    if ((now - _lastCalculation) < _calculationBackoffMs) { return; }
+    _lastCalculation = now;
 
-    for (auto& upInv : _inverters) {
+    for (auto const& upInv : _inverters) {
+        if (PowerLimiterInverter::Eligibility::Eligible != upInv->isEligible()) { continue; }
         if (!upInv->isBatteryPowered()) { upInv->setMaxOutput(); }
     }
 

--- a/src/PowerLimiterBatteryInverter.cpp
+++ b/src/PowerLimiterBatteryInverter.cpp
@@ -5,7 +5,7 @@ PowerLimiterBatteryInverter::PowerLimiterBatteryInverter(bool verboseLogging, Po
 
 uint16_t PowerLimiterBatteryInverter::getMaxReductionWatts(bool allowStandby) const
 {
-    if (isEligible() != Eligibility::Eligible) { return 0; }
+    if (!isEligible()) { return 0; }
 
     if (!isProducing()) { return 0; }
 
@@ -18,7 +18,7 @@ uint16_t PowerLimiterBatteryInverter::getMaxReductionWatts(bool allowStandby) co
 
 uint16_t PowerLimiterBatteryInverter::getMaxIncreaseWatts() const
 {
-    if (isEligible() != Eligibility::Eligible) { return 0; }
+    if (!isEligible()) { return 0; }
 
     if (!isProducing()) {
         return getConfiguredMaxPowerWatts();
@@ -38,7 +38,7 @@ uint16_t PowerLimiterBatteryInverter::getMaxIncreaseWatts() const
 
 uint16_t PowerLimiterBatteryInverter::applyReduction(uint16_t reduction, bool allowStandby)
 {
-    if (isEligible() != Eligibility::Eligible) { return 0; }
+    if (!isEligible()) { return 0; }
 
     if (reduction == 0) { return 0; }
 
@@ -67,7 +67,7 @@ uint16_t PowerLimiterBatteryInverter::applyReduction(uint16_t reduction, bool al
 
 uint16_t PowerLimiterBatteryInverter::applyIncrease(uint16_t increase)
 {
-    if (isEligible() != Eligibility::Eligible) { return 0; }
+    if (!isEligible()) { return 0; }
 
     if (increase == 0) { return 0; }
 

--- a/src/PowerLimiterInverter.cpp
+++ b/src/PowerLimiterInverter.cpp
@@ -42,7 +42,7 @@ PowerLimiterInverter::PowerLimiterInverter(bool verboseLogging, PowerLimiterInve
     snprintf(_logPrefix, sizeof(_logPrefix), "[DPL inverter %s]:", _serialStr);
 }
 
-PowerLimiterInverter::Eligibility PowerLimiterInverter::isEligible() const
+PowerLimiterInverter::Eligibility PowerLimiterInverter::getEligibility() const
 {
     // at dawn, solar-powered inverters switch to standby, but are still
     // reachable. during this time, we shall not use them. we assume that
@@ -68,6 +68,11 @@ PowerLimiterInverter::Eligibility PowerLimiterInverter::isEligible() const
     return Eligibility::Eligible;
 }
 
+bool PowerLimiterInverter::isEligible() const
+{
+    return getEligibility() == Eligibility::Eligible;
+}
+
 bool PowerLimiterInverter::update()
 {
     auto reset = [this]() -> bool {
@@ -77,7 +82,7 @@ bool PowerLimiterInverter::update()
         return false;
     };
 
-    switch (isEligible()) {
+    switch (getEligibility()) {
         case Eligibility::Eligible:
             break;
 
@@ -345,7 +350,7 @@ void PowerLimiterInverter::debug() const
     if (!_verboseLogging) { return; }
 
     String eligibility("disqualified");
-    switch (isEligible()) {
+    switch (getEligibility()) {
         case Eligibility::Nighttime:
             eligibility += " (nighttime)";
             break;

--- a/src/PowerLimiterOverscalingInverter.cpp
+++ b/src/PowerLimiterOverscalingInverter.cpp
@@ -6,7 +6,7 @@ PowerLimiterOverscalingInverter::PowerLimiterOverscalingInverter(bool verboseLog
 
 uint16_t PowerLimiterOverscalingInverter::applyIncrease(uint16_t increase)
 {
-    if (isEligible() != Eligibility::Eligible) { return 0; }
+    if (!isEligible()) { return 0; }
 
     if (increase == 0) { return 0; }
 

--- a/src/PowerLimiterSmartBufferInverter.cpp
+++ b/src/PowerLimiterSmartBufferInverter.cpp
@@ -6,7 +6,7 @@ PowerLimiterSmartBufferInverter::PowerLimiterSmartBufferInverter(bool verboseLog
 
 uint16_t PowerLimiterSmartBufferInverter::getMaxReductionWatts(bool allowStandby) const
 {
-    if (isEligible() != Eligibility::Eligible) { return 0; }
+    if (!isEligible()) { return 0; }
 
     if (!isProducing()) { return 0; }
 
@@ -19,7 +19,7 @@ uint16_t PowerLimiterSmartBufferInverter::getMaxReductionWatts(bool allowStandby
 
 uint16_t PowerLimiterSmartBufferInverter::getMaxIncreaseWatts() const
 {
-    if (isEligible() != Eligibility::Eligible) { return 0; }
+    if (!isEligible()) { return 0; }
 
     if (!isProducing()) {
         return getConfiguredMaxPowerWatts();
@@ -53,7 +53,7 @@ uint16_t PowerLimiterSmartBufferInverter::getMaxIncreaseWatts() const
 
 uint16_t PowerLimiterSmartBufferInverter::applyReduction(uint16_t reduction, bool allowStandby)
 {
-    if (isEligible() != Eligibility::Eligible) { return 0; }
+    if (!isEligible()) { return 0; }
 
     if (reduction == 0) { return 0; }
 

--- a/src/PowerLimiterSolarInverter.cpp
+++ b/src/PowerLimiterSolarInverter.cpp
@@ -6,7 +6,7 @@ PowerLimiterSolarInverter::PowerLimiterSolarInverter(bool verboseLogging, PowerL
 
 uint16_t PowerLimiterSolarInverter::getMaxReductionWatts(bool) const
 {
-    if (isEligible() != Eligibility::Eligible) { return 0; }
+    if (!isEligible()) { return 0; }
 
     if (!isProducing()) { return 0; }
 
@@ -18,7 +18,7 @@ uint16_t PowerLimiterSolarInverter::getMaxReductionWatts(bool) const
 
 uint16_t PowerLimiterSolarInverter::getMaxIncreaseWatts() const
 {
-    if (isEligible() != Eligibility::Eligible) { return 0; }
+    if (!isEligible()) { return 0; }
 
     if (!isProducing()) {
         // the inverter is not producing, we don't know how much we can increase
@@ -129,7 +129,7 @@ uint16_t PowerLimiterSolarInverter::getMaxIncreaseWatts() const
 
 uint16_t PowerLimiterSolarInverter::applyReduction(uint16_t reduction, bool)
 {
-    if (isEligible() != Eligibility::Eligible) { return 0; }
+    if (!isEligible()) { return 0; }
 
     if (reduction == 0) { return 0; }
 


### PR DESCRIPTION
I looked at the use of `_inverters` in the DPL again to make sure `isEligible()` is called when needed. It seems we are fine now, except for unconditional solar passthrough.

In this context I noticed that we should not use an outdated voltage reading from an unreachable inverter.

Method `isEligible()` was simplified to do what the name suggests: return a boolean, which simplifies its usage.