### PR TITLE
Feature: chunked webconsole messages

### DIFF
--- a/include/MessageOutput.h
+++ b/include/MessageOutput.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <unordered_map>
 #include <queue>
+#include <memory>
 
 class MessageOutputClass : public Print {
 public:
@@ -30,6 +31,21 @@ private:
     // this way we prevent mangling of messages from different contexts.
     std::unordered_map<TaskHandle_t, message_t> _task_messages;
     std::queue<message_t> _lines;
+
+    // we chunk the websocket output to circumvent issues with TCP delayed ACKs:
+    // if the websocket client (Windows in particular) is using delayed ACKs,
+    // and since we wait for an ACK before sending the next chunk, we will
+    // accumulate way too many messages and we won't be able to send them out
+    // fast enough as the rate of produced messages is higher than the rate of
+    // ACKs received. by chunking and waiting in between chunks, we either
+    // "motivate" the client to send out ACKs immediately as the TCP packets are
+    // "large", or we will wait long enough for the TCP stack to send out the
+    // ACK anyways.
+    void send_ws_chunk(message_t&& line);
+    static constexpr size_t WS_CHUNK_SIZE_BYTES = 512;
+    static constexpr uint32_t WS_CHUNK_INTERVAL_MS = 250;
+    std::shared_ptr<message_t> _ws_chunk = nullptr;
+    uint32_t _last_ws_chunk_sent = 0;
 
     AsyncWebSocket* _ws = nullptr;
 

--- a/src/MessageOutput.cpp
+++ b/src/MessageOutput.cpp
@@ -113,9 +113,8 @@ void MessageOutputClass::loop()
                 client.text(msg);
 
                 if (client.queueIsFull()) {
-                    static char const warningStr[] = "WARNING: dropping log line(s) as websocket client's queue is full\r\n";
-                    message_t warningVec(warningStr, warningStr + sizeof(warningStr) - 1);
-                    msg->swap(warningVec);
+                    static char const warningStr[] = "\r\nWARNING: websocket client's queue is full, expect log lines missing\r\n";
+                    msg->insert(msg->end(), warningStr, warningStr + sizeof(warningStr) - 1);
                 }
             }
         }

--- a/src/MessageOutput.cpp
+++ b/src/MessageOutput.cpp
@@ -88,6 +88,43 @@ size_t MessageOutputClass::write(const uint8_t *buffer, size_t size)
     return size;
 }
 
+void MessageOutputClass::send_ws_chunk(message_t&& line)
+{
+    if (!_ws) { return; }
+
+    if (nullptr == _ws_chunk) {
+        _ws_chunk = std::make_shared<message_t>(std::move(line));
+        _ws_chunk->reserve(WS_CHUNK_SIZE_BYTES + 128); // add room for one more line
+    }
+    else {
+        _ws_chunk->insert(_ws_chunk->end(), line.begin(), line.end());
+    }
+
+    bool small = _ws_chunk->size() < WS_CHUNK_SIZE_BYTES;
+    bool recent = (millis() - _last_ws_chunk_sent) < WS_CHUNK_INTERVAL_MS;
+    if (small && recent) { return; }
+
+    bool added_warning = false;
+    for (auto& client : _ws->getClients()) {
+        if (client.queueIsFull()) { continue; }
+
+        client.text(_ws_chunk);
+
+        // note that all clients will see the warning, even if only one
+        // client is struggeling. however, this should be rare. we
+        // won't be copying chunks around to avoid this. we do however,
+        // avoid adding the warning multiple times.
+        if (client.queueIsFull() && !added_warning) {
+            static char const warningStr[] = "\r\nWARNING: websocket client's queue is full, expect log lines missing\r\n";
+            _ws_chunk->insert(_ws_chunk->end(), warningStr, warningStr + sizeof(warningStr) - 1);
+            added_warning = true;
+        }
+    }
+
+    _ws_chunk = nullptr;
+    _last_ws_chunk_sent = millis();
+}
+
 void MessageOutputClass::loop()
 {
     std::lock_guard<std::mutex> lock(_msgLock);
@@ -105,19 +142,7 @@ void MessageOutputClass::loop()
 
     while (!_lines.empty()) {
         Syslog.write(_lines.front().data(), _lines.front().size());
-        if (_ws) {
-            auto msg = std::make_shared<message_t>(std::move(_lines.front()));
-            for (auto& client : _ws->getClients()) {
-                if (client.queueIsFull()) { continue; }
-
-                client.text(msg);
-
-                if (client.queueIsFull()) {
-                    static char const warningStr[] = "\r\nWARNING: websocket client's queue is full, expect log lines missing\r\n";
-                    msg->insert(msg->end(), warningStr, warningStr + sizeof(warningStr) - 1);
-                }
-            }
-        }
+        send_ws_chunk(std::move(_lines.front()));
         _lines.pop();
     }
 }


### PR DESCRIPTION
we observed that for some users (@Sorbat in particular) the heap would be overrun when using the websocket, see #1561. I then changed the code such that the heap would not overrun and the ESP would not reboot in #1748. the warning message I added there clearly indicated that now a very significant amount of log lines were missing from the output. @Sorbat and I kept experimenting and exchanging notes and ideas, until it dawned on me that this must be an operating-system-specific problem and we would have to look at the TCP level to understand what's going on.

It turns out we are waiting for a TCP ACK for the previous data sent through the websocket before we send the next. Windows, as a receiver, uses delayed ACKs (with a ridiculous backoff), which causes every TCP packet to be spaced apart from the next by a significant time. this leads to a reduced throughput. so small, that we don't get the few log lines out in time...

try to convince the receiving host to send ACKs either for each TCP packet as they are now "big enough" to warrant an ACK (rather than a [delayed ACK](https://www.wikiwand.com/en/articles/TCP_delayed_acknowledgment)), or space the chunks/packets apart "long enough" to overcome delayed ACKs.
    
@Sorbat tested this and had immediate success.

Note that this issue does not present itself on Linux nor MacOS, as they use a much smaller delayed TCP ACK backoff.