### PR TITLE
VE.Direct frame error logging

### DIFF
--- a/include/battery/victronsmartshunt/Stats.h
+++ b/include/battery/victronsmartshunt/Stats.h
@@ -29,6 +29,7 @@ private:
     bool _alarmLowSOC;
     bool _alarmLowTemperature;
     bool _alarmHighTemperature;
+    float _transmissionErrors;
 };
 
 } // namespace Batteries::VictronSmartShunt

--- a/include/battery/victronsmartshunt/Stats.h
+++ b/include/battery/victronsmartshunt/Stats.h
@@ -29,7 +29,7 @@ private:
     bool _alarmLowSOC;
     bool _alarmLowTemperature;
     bool _alarmHighTemperature;
-    float _transmissionErrors;
+    float _transmitErrors;
 };
 
 } // namespace Batteries::VictronSmartShunt

--- a/lib/VeDirectFrameHandler/VeDirectData.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectData.cpp
@@ -361,3 +361,23 @@ frozen::string const& VeDirectHexData::getRegisterAsString() const
 
 	return getAsString(values, addr);
 }
+
+/*
+ * returns the transmission error as readable text.
+ */
+frozen::string const& veStruct::getTransmissionErrorAsString(veStruct::Error error) const
+{
+	static constexpr frozen::map<veStruct::Error, frozen::string, 9> values = {
+		{ Error::SUM, "Total Sum" },
+        { Error::TIMEOUT, "Frame Timeout" },
+		{ Error::TEXT_CHECKSUM, "Text Checksum" },
+        { Error::HEX_CHECKSUM, "Hex Checksum" },
+        { Error::HEX_BUFFER, "Hex Buffer" },
+        { Error::NESTED_HEX, "Nested Hex" },
+        { Error::DEBUG_BUFFER, "Debug Buffer" },
+        { Error::UNKNOWN_TEXT_DATA, "Unknown Data" },
+        { Error::NON_VALID_CHAR, "Invalid Char" }
+    };
+
+    return getAsString(values, error);
+}

--- a/lib/VeDirectFrameHandler/VeDirectData.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectData.cpp
@@ -365,17 +365,15 @@ frozen::string const& VeDirectHexData::getRegisterAsString() const
 /*
  * returns the transmission error as readable text.
  */
-frozen::string const& veStruct::getTransmissionErrorAsString(veStruct::Error error) const
+frozen::string const& veStruct::getTransmitErrorAsString(veStruct::Error error) const
 {
-	static constexpr frozen::map<veStruct::Error, frozen::string, 9> values = {
-		{ Error::SUM, "Total Sum" },
+	static constexpr frozen::map<veStruct::Error, frozen::string, 7> values = {
         { Error::TIMEOUT, "Frame Timeout" },
 		{ Error::TEXT_CHECKSUM, "Text Checksum" },
         { Error::HEX_CHECKSUM, "Hex Checksum" },
         { Error::HEX_BUFFER, "Hex Buffer" },
         { Error::NESTED_HEX, "Nested Hex" },
         { Error::DEBUG_BUFFER, "Debug Buffer" },
-        { Error::UNKNOWN_TEXT_DATA, "Unknown Data" },
         { Error::NON_VALID_CHAR, "Invalid Char" }
     };
 

--- a/lib/VeDirectFrameHandler/VeDirectData.h
+++ b/lib/VeDirectFrameHandler/VeDirectData.h
@@ -16,8 +16,13 @@ typedef struct {
     uint32_t batteryVoltage_V_mV = 0;       // battery voltage in mV
     int32_t batteryCurrent_I_mA = 0;        // battery current in mA (can be negative)
     float mpptEfficiency_Percent = 0;       // efficiency in percent (calculated, moving average)
+    float transmissionErrors_Day = 0;       // transmission errors per day
+
+    enum class Error { SUM, TIMEOUT, TEXT_CHECKSUM, HEX_CHECKSUM, HEX_BUFFER, NESTED_HEX, DEBUG_BUFFER,
+        UNKNOWN_TEXT_DATA, NON_VALID_CHAR, LAST };
 
     frozen::string const& getPidAsString() const; // product ID as string
+    frozen::string const& getTransmissionErrorAsString(Error error) const;
     uint32_t getFwVersionAsInteger() const;
     String getFwVersionFormatted() const;
 } veStruct;

--- a/lib/VeDirectFrameHandler/VeDirectData.h
+++ b/lib/VeDirectFrameHandler/VeDirectData.h
@@ -16,13 +16,12 @@ typedef struct {
     uint32_t batteryVoltage_V_mV = 0;       // battery voltage in mV
     int32_t batteryCurrent_I_mA = 0;        // battery current in mA (can be negative)
     float mpptEfficiency_Percent = 0;       // efficiency in percent (calculated, moving average)
-    float transmissionErrors_Day = 0;       // transmission errors per day
+    float transmitErrors_Day = 0.0f;        // transmit errors per day
 
-    enum class Error { SUM, TIMEOUT, TEXT_CHECKSUM, HEX_CHECKSUM, HEX_BUFFER, NESTED_HEX, DEBUG_BUFFER,
-        UNKNOWN_TEXT_DATA, NON_VALID_CHAR, LAST };
+    enum class Error { TIMEOUT, TEXT_CHECKSUM, HEX_CHECKSUM, HEX_BUFFER, NESTED_HEX, DEBUG_BUFFER, NON_VALID_CHAR, LAST };
 
     frozen::string const& getPidAsString() const; // product ID as string
-    frozen::string const& getTransmissionErrorAsString(Error error) const;
+    frozen::string const& getTransmitErrorAsString(Error error) const;
     uint32_t getFwVersionAsInteger() const;
     String getFwVersionFormatted() const;
 } veStruct;

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
@@ -31,6 +31,7 @@
  * 2020.06.21 - 0.2 - add MIT license, no code changes
  * 2020.08.20 - 0.3 - corrected #include reference
  * 2024.03.08 - 0.4 - adds the ability to send hex commands and disassemble hex messages
+ * 2025.03.29 - 0.5 - add of transmit error counters
  */
 
 #include <Arduino.h>
@@ -73,6 +74,9 @@ void VeDirectFrameHandler<T>::init(char const* who, gpio_num_t rx, gpio_num_t tx
 	_startUpPassed = false; // to obtain a complete dataset after a new start or restart
 	_dataValid = false;     // data is not valid on start or restart
 	snprintf(_logId, sizeof(_logId), "%s %d/%d", who, rx, tx);
+
+    _lastErrorCalcAndPrint = 0;     // initialize error counter print timer
+    _errorCounter.fill(0);          // initialize error counters
 	DTU_LOGI("init complete");
 }
 
@@ -109,10 +113,25 @@ void VeDirectFrameHandler<T>::loop()
 	// if such a large gap is observed, reset the state machine so it tries
 	// to decode a new frame / hex messages once more data arrives.
 	if ((State::IDLE != _state) && ((millis() - _lastByteMillis) > 500)) {
+        setErrorCounter(veStruct::Error::TIMEOUT);
 		DTU_LOGW("Resetting state machine (was %d) after timeout", static_cast<unsigned>(_state));
 		dumpDebugBuffer();
 		reset();
-	}
+    }
+
+    if ((millis() - _lastErrorCalcAndPrint) > 60*1000) {
+        _lastErrorCalcAndPrint = millis();
+
+        // calculate the average transmission errors per day
+        _tmpFrame.transmissionErrors_Day = _errorCounter.at(static_cast<size_t>(veStruct::Error::SUM));
+        float errorDays = esp_timer_get_time() / (24.0f*60*60*1000*1000); // 24h, use float to avoid int overflow
+        if (errorDays > 1.0f) { _tmpFrame.transmissionErrors_Day /= errorDays; }
+
+        // no need to print the errors if log level is not at least INFO or if we do not have any
+        if (DTU_LOG_IS_INFO && (_errorCounter.at(static_cast<size_t>(veStruct::Error::SUM)) != 0)) {
+            printErrorCounter();
+        }
+    }
 }
 
 static bool isValidChar(uint8_t inbyte)
@@ -144,17 +163,26 @@ void VeDirectFrameHandler<T>::rxData(uint8_t inbyte)
 		_debugBuffer[_debugIn] = inbyte;
 		_debugIn = (_debugIn + 1) % _debugBuffer.size();
 		if (0 == _debugIn) {
+            setErrorCounter(veStruct::Error::DEBUG_BUFFER);
 			DTU_LOGE("debug buffer overrun!");
 		}
 	}
 	if (_state != State::CHECKSUM && !isValidChar(inbyte)) {
+        setErrorCounter(veStruct::Error::NON_VALID_CHAR);
 		DTU_LOGW("non-ASCII character 0x%02x, invalid frame", inbyte);
 		reset();
 		return;
 	}
 
 	if ( (inbyte == ':') && (_state != State::CHECKSUM) ) {
-		_prevState = _state; //hex frame can interrupt TEXT
+
+        if (_prevState == State::RECORD_HEX) { setErrorCounter(veStruct::Error::NESTED_HEX); }
+
+        // Hex frame can interrupt text frame but hex frame
+        // never interrupt hex frame, in that case we had a transmission fault
+        // We just store the state if we come from a text frame state
+        if (_state != State::RECORD_HEX) { _prevState = _state; }
+
 		_state = State::RECORD_HEX;
 		_hexSize = 0;
 	}
@@ -250,6 +278,7 @@ void VeDirectFrameHandler<T>::rxData(uint8_t inbyte)
 			frameValidEvent();
 		}
 		else {
+            setErrorCounter(veStruct::Error::TEXT_CHECKSUM);
 			DTU_LOGW("checksum 0x%02x != 0x00, invalid frame", _checksum);
 		}
 		reset();
@@ -304,6 +333,7 @@ void VeDirectFrameHandler<T>::processTextData(std::string const& name, std::stri
 		return;
 	}
 
+    setErrorCounter(veStruct::Error::UNKNOWN_TEXT_DATA);
 	DTU_LOGI("Unknown text data '%s' (value '%s')", name.c_str(), value.c_str());
 }
 
@@ -338,6 +368,7 @@ typename VeDirectFrameHandler<T>::State VeDirectFrameHandler<T>::hexRxEvent(uint
 		_hexBuffer[_hexSize++]=inbyte;
 
 		if (_hexSize>=VE_MAX_HEX_LEN) { // oops -buffer overflow - something went wrong, we abort
+            setErrorCounter(veStruct::Error::HEX_BUFFER);
 			DTU_LOGE("hexRx buffer overflow - aborting read");
 			_hexSize=0;
 			ret = State::IDLE;
@@ -353,4 +384,49 @@ template<typename T>
 uint32_t VeDirectFrameHandler<T>::getLastUpdate() const
 {
 	return _lastUpdate;
+}
+
+/*
+ * Counts the transmission errors
+ */
+template<typename T>
+void VeDirectFrameHandler<T>::setErrorCounter(veStruct::Error type)
+{
+    // Start-up can be in the middle of a VE.Direct transmit.
+    // That errors must be ignored. We wait until the startup condition is passed
+    if (_startUpPassed) {
+
+        // increment the error counters
+        _errorCounter.at(static_cast<size_t>(veStruct::Error::SUM))++;
+        _errorCounter.at(static_cast<size_t>(type))++;
+
+        // to avoid overflow, we divide all counters by 2 if the sum exceeds 50k
+        if (_errorCounter.at(static_cast<size_t>(veStruct::Error::SUM)) > 50000) {
+            for (auto& counter : _errorCounter) { counter /= 2; }
+        }
+    }
+}
+
+/*
+ * Prints the specific error counters every 60 seconds
+ */
+template<typename T>
+void VeDirectFrameHandler<T>::printErrorCounter(void)
+{
+    DTU_LOGI("Average transmission errors per day: %0.1f 1/d", _tmpFrame.transmissionErrors_Day);
+
+    auto constexpr maxPerLine = 3; // maximum number of errors per line
+    std::string sBuffer;
+    for(size_t idx = 0; idx < _errorCounter.size(); ++idx) {
+        sBuffer.append(_tmpFrame.getTransmissionErrorAsString(static_cast<veStruct::Error>(idx)).data());
+        sBuffer.append(": ");
+        sBuffer.append(std::to_string(_errorCounter.at(static_cast<size_t>(idx))));
+
+        if (((idx + 1) % maxPerLine == 0) || (idx == _errorCounter.size() - 1)) {
+            DTU_LOGI("%s", sBuffer.c_str()); // print the buffer
+            sBuffer.clear();
+        } else {
+            sBuffer.append(", "); // add a comma to separate the errors
+        }
+    }
 }

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
@@ -49,6 +49,7 @@ template<typename T>
 VeDirectFrameHandler<T>::VeDirectFrameHandler() :
 	_lastUpdate(0),
 	_state(State::IDLE),
+    _prevState(State::IDLE),
 	_checksum(0),
 	_textPointer(0),
 	_hexSize(0),
@@ -174,12 +175,15 @@ void VeDirectFrameHandler<T>::rxData(uint8_t inbyte)
 
 	if ( (inbyte == ':') && (_state != State::CHECKSUM) ) {
 
-        if (_prevState == State::RECORD_HEX) { setErrorCounter(veStruct::Error::NESTED_HEX); }
-
-        // Hex frame can interrupt text frame but hex frame
-        // never interrupt hex frame, in that case we had a transmit fault
-        // We just store the state if we come from a text frame state
-        if (_state != State::RECORD_HEX) { _prevState = _state; }
+        // hex frame can interrupt text frame, but hex frame
+        // never interrupt hex frame, if we reach this line with
+        // _state == State::RECORD_HEX we had a transmit fault
+        if (_state == State::RECORD_HEX) {
+            setErrorCounter(veStruct::Error::NESTED_HEX);
+        } else {
+            // We just store the current state if we come from a text frame state
+            _prevState = _state;
+        }
 
 		_state = State::RECORD_HEX;
 		_hexSize = 0;

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
@@ -75,8 +75,6 @@ void VeDirectFrameHandler<T>::init(char const* who, gpio_num_t rx, gpio_num_t tx
 	_dataValid = false;     // data is not valid on start or restart
 	snprintf(_logId, sizeof(_logId), "%s %d/%d", who, rx, tx);
 
-    _lastErrorCalcAndPrint = 0;     // initialize error counter print timer
-    _errorCounter.fill(0);          // initialize error counters
 	DTU_LOGI("init complete");
 }
 
@@ -122,13 +120,13 @@ void VeDirectFrameHandler<T>::loop()
     if ((millis() - _lastErrorCalcAndPrint) > 60*1000) {
         _lastErrorCalcAndPrint = millis();
 
-        // calculate the average transmission errors per day
-        _tmpFrame.transmissionErrors_Day = _errorCounter.at(static_cast<size_t>(veStruct::Error::SUM));
+        // calculate the average transmit errors per day
+        _tmpFrame.transmitErrors_Day = static_cast<float>(_errorSumSinceStartup);
         float errorDays = esp_timer_get_time() / (24.0f*60*60*1000*1000); // 24h, use float to avoid int overflow
-        if (errorDays > 1.0f) { _tmpFrame.transmissionErrors_Day /= errorDays; }
+        if (errorDays > 1.0f) { _tmpFrame.transmitErrors_Day /= errorDays; }
 
         // no need to print the errors if log level is not at least INFO or if we do not have any
-        if (DTU_LOG_IS_INFO && (_errorCounter.at(static_cast<size_t>(veStruct::Error::SUM)) != 0)) {
+        if (DTU_LOG_IS_INFO && (_errorSumSinceStartup != 0)) {
             printErrorCounter();
         }
     }
@@ -179,7 +177,7 @@ void VeDirectFrameHandler<T>::rxData(uint8_t inbyte)
         if (_prevState == State::RECORD_HEX) { setErrorCounter(veStruct::Error::NESTED_HEX); }
 
         // Hex frame can interrupt text frame but hex frame
-        // never interrupt hex frame, in that case we had a transmission fault
+        // never interrupt hex frame, in that case we had a transmit fault
         // We just store the state if we come from a text frame state
         if (_state != State::RECORD_HEX) { _prevState = _state; }
 
@@ -333,7 +331,6 @@ void VeDirectFrameHandler<T>::processTextData(std::string const& name, std::stri
 		return;
 	}
 
-    setErrorCounter(veStruct::Error::UNKNOWN_TEXT_DATA);
 	DTU_LOGI("Unknown text data '%s' (value '%s')", name.c_str(), value.c_str());
 }
 
@@ -387,7 +384,7 @@ uint32_t VeDirectFrameHandler<T>::getLastUpdate() const
 }
 
 /*
- * Counts the transmission errors
+ * Counts the transmit errors
  */
 template<typename T>
 void VeDirectFrameHandler<T>::setErrorCounter(veStruct::Error type)
@@ -397,12 +394,15 @@ void VeDirectFrameHandler<T>::setErrorCounter(veStruct::Error type)
     if (_startUpPassed) {
 
         // increment the error counters
-        _errorCounter.at(static_cast<size_t>(veStruct::Error::SUM))++;
         _errorCounter.at(static_cast<size_t>(type))++;
+        _errorSumSinceStartup++; // with 1 error per second we would overflow after 136 years
 
-        // to avoid overflow, we divide all counters by 2 if the sum exceeds 50k
-        if (_errorCounter.at(static_cast<size_t>(veStruct::Error::SUM)) > 50000) {
-            for (auto& counter : _errorCounter) { counter /= 2; }
+        // to avoid overflow, we divide all counters by 2 if one of them exceeds 50k
+        for (size_t idx = 0; idx < _errorCounter.size(); ++idx) {
+            if (_errorCounter.at(idx) > 50000) {
+                for (auto& counter : _errorCounter) { counter /= 2; }
+                break;
+            }
         }
     }
 }
@@ -413,12 +413,12 @@ void VeDirectFrameHandler<T>::setErrorCounter(veStruct::Error type)
 template<typename T>
 void VeDirectFrameHandler<T>::printErrorCounter(void)
 {
-    DTU_LOGI("Average transmission errors per day: %0.1f 1/d", _tmpFrame.transmissionErrors_Day);
+    DTU_LOGI("Average transmit errors per day: %0.1f 1/d", _tmpFrame.transmitErrors_Day);
 
     auto constexpr maxPerLine = 3; // maximum number of errors per line
     std::string sBuffer;
     for(size_t idx = 0; idx < _errorCounter.size(); ++idx) {
-        sBuffer.append(_tmpFrame.getTransmissionErrorAsString(static_cast<veStruct::Error>(idx)).data());
+        sBuffer.append(_tmpFrame.getTransmitErrorAsString(static_cast<veStruct::Error>(idx)).data());
         sBuffer.append(": ");
         sBuffer.append(std::to_string(_errorCounter.at(static_cast<size_t>(idx))));
 

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
@@ -94,8 +94,9 @@ private:
     void setErrorCounter(veStruct::Error type);
     void printErrorCounter(void);
 
-    std::array<uint16_t, static_cast<size_t>(veStruct::Error::LAST)> _errorCounter;
-    uint32_t _lastErrorCalcAndPrint;           // timestamp of the last logging print
+    std::array<uint16_t, static_cast<size_t>(veStruct::Error::LAST)> _errorCounter = {0}; // error counters for each error type
+    uint32_t _errorSumSinceStartup = 0;        // sum of all errors since startup
+    uint32_t _lastErrorCalcAndPrint = 0;       // timestamp of the last logging print
 };
 
 template class VeDirectFrameHandler<veMpptStruct>;

--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.h
@@ -89,6 +89,13 @@ private:
      * queue, which is fine as we know the source frame was valid.
      */
     std::deque<std::pair<std::string, std::string>> _textData;
+
+
+    void setErrorCounter(veStruct::Error type);
+    void printErrorCounter(void);
+
+    std::array<uint16_t, static_cast<size_t>(veStruct::Error::LAST)> _errorCounter;
+    uint32_t _lastErrorCalcAndPrint;           // timestamp of the last logging print
 };
 
 template class VeDirectFrameHandler<veMpptStruct>;

--- a/lib/VeDirectFrameHandler/VeDirectFrameHexHandler.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHexHandler.cpp
@@ -81,7 +81,11 @@ bool VeDirectFrameHandler<T>::disassembleHexData(VeDirectHexData &data) {
     // reset hex data first
     data = {};
 
-    if ((len > 3) && (calcHexFrameCheckSum(buffer, len) == 0x00)) {
+    if (len <= 3) {
+        setErrorCounter(veStruct::Error::HEX_BUFFER);
+    } else if (calcHexFrameCheckSum(buffer, len) != 0x00) {
+        setErrorCounter(veStruct::Error::HEX_CHECKSUM);
+    } else {
         data.rsp = static_cast<VeDirectHexResponse>(AsciiHexLE2Int(buffer+1, 1));
 
         using Response = VeDirectHexResponse;

--- a/src/battery/victronsmartshunt/Stats.cpp
+++ b/src/battery/victronsmartshunt/Stats.cpp
@@ -32,7 +32,7 @@ void Stats::updateFrom(VeDirectShuntController::data_t const& shuntData) {
     _alarmLowSOC = shuntData.alarmReason_AR & 4;
     _alarmLowTemperature = shuntData.alarmReason_AR & 32;
     _alarmHighTemperature = shuntData.alarmReason_AR & 64;
-    _transmissionErrors = shuntData.transmissionErrors_Day;
+    _transmitErrors = shuntData.transmitErrors_Day;
 }
 
 void Stats::getLiveViewData(JsonVariant& root) const {
@@ -47,7 +47,7 @@ void Stats::getLiveViewData(JsonVariant& root) const {
     addLiveViewValue(root, "midpointVoltage", _midpointVoltage, "V", 2);
     addLiveViewValue(root, "midpointDeviation", _midpointDeviation, "%", 1);
     addLiveViewValue(root, "lastFullCharge", _lastFullCharge, "min", 0);
-    addLiveViewValue(root, "transmitError", _transmissionErrors, "1/d", 1);
+    addLiveViewValue(root, "transmitError", _transmitErrors, "1/d", 1);
 
     auto oTemperature = getTemperature();
     if (oTemperature) {

--- a/src/battery/victronsmartshunt/Stats.cpp
+++ b/src/battery/victronsmartshunt/Stats.cpp
@@ -32,6 +32,7 @@ void Stats::updateFrom(VeDirectShuntController::data_t const& shuntData) {
     _alarmLowSOC = shuntData.alarmReason_AR & 4;
     _alarmLowTemperature = shuntData.alarmReason_AR & 32;
     _alarmHighTemperature = shuntData.alarmReason_AR & 64;
+    _transmissionErrors = shuntData.transmissionErrors_Day;
 }
 
 void Stats::getLiveViewData(JsonVariant& root) const {
@@ -46,6 +47,7 @@ void Stats::getLiveViewData(JsonVariant& root) const {
     addLiveViewValue(root, "midpointVoltage", _midpointVoltage, "V", 2);
     addLiveViewValue(root, "midpointDeviation", _midpointDeviation, "%", 1);
     addLiveViewValue(root, "lastFullCharge", _lastFullCharge, "min", 0);
+    addLiveViewValue(root, "transmitError", _transmissionErrors, "1/d", 1);
 
     auto oTemperature = getTemperature();
     if (oTemperature) {

--- a/src/solarcharger/victron/Stats.cpp
+++ b/src/solarcharger/victron/Stats.cpp
@@ -251,7 +251,7 @@ void Stats::populateJsonWithInstanceStats(const JsonObject &root, const VeDirect
         device["MpptTemperature"]["u"] = "°C";
         device["MpptTemperature"]["d"] = "1";
     }
-    device["MpptTransmitError"]["v"] = mpptData.transmissionErrors_Day;
+    device["MpptTransmitError"]["v"] = mpptData.transmitErrors_Day;
     device["MpptTransmitError"]["u"] = "1/d";
     device["MpptTransmitError"]["d"] = "1";
 

--- a/src/solarcharger/victron/Stats.cpp
+++ b/src/solarcharger/victron/Stats.cpp
@@ -251,6 +251,9 @@ void Stats::populateJsonWithInstanceStats(const JsonObject &root, const VeDirect
         device["MpptTemperature"]["u"] = "°C";
         device["MpptTemperature"]["d"] = "1";
     }
+    device["MpptTransmitError"]["v"] = mpptData.transmissionErrors_Day;
+    device["MpptTransmitError"]["u"] = "1/d";
+    device["MpptTransmitError"]["d"] = "1";
 
     if (mpptData.ChargeCurrentLimit.first > 0) {
         if (mpptData.ChargeCurrentLimit.second == UINT16_MAX) {

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -201,7 +201,8 @@
             "ERR": "Fehlerbeschreibung",
             "HSDS": "Anzahl der Tage (0..364)",
             "MpptTemperature": "Ladereglertemperatur",
-            "ChargeCurrentLimit": "Ladestromlimit"
+            "ChargeCurrentLimit": "Ladestromlimit",
+            "MpptTransmitError": "Übertragungsfehler"
         },
         "section_output": "Ausgang (Batterie)",
         "output": {
@@ -1334,6 +1335,7 @@
         "full-access": "@:batteryadmin.zendure.controlModes.Full",
         "write-once": "Einmalig Schreiben",
         "read-only": "@:batteryadmin.zendure.controlModes.ReadOnly",
+        "transmitError": "Übertragungsfehler",
         "zendure": {
             "chargeThroughState": "Status Vollladezyklus",
             "chargeThroughStates": {

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -201,7 +201,8 @@
             "ERR": "Error code",
             "HSDS": "Day sequence number (0..364)",
             "MpptTemperature": "Charge controller temperature",
-            "ChargeCurrentLimit": "Charge current limit"
+            "ChargeCurrentLimit": "Charge current limit",
+            "MpptTransmitError": "Transmit errors"
         },
         "section_output": "Output (Battery)",
         "output": {
@@ -1337,6 +1338,7 @@
         "full-access": "@:batteryadmin.zendure.controlModes.Full",
         "write-once": "Write Once",
         "read-only": "@:batteryadmin.zendure.controlModes.ReadOnly",
+        "transmitError": "Transmit errors",
         "zendure": {
             "chargeThroughState": "Charge through state",
             "chargeThroughStates": {


### PR DESCRIPTION
I've implemented a transmission error log for the VE.Direct connections (charge controller, shunt). The Live View displays the recorded transmission errors for each device per day. This allows you to check the quality of your VE.Direct connection. 

![grafik](https://github.com/user-attachments/assets/1b1a7c96-c81e-4183-ba2c-4cfba8e6ba81)

Additionally, the log displays transmission errors in more detail every 60 seconds. You can see which errors (checksum, buffer overflow, etc.) were detected. 

23:13:09.079 > [VE.Direct MPPT 10/9] Average transmission errors per day: 0.0
23:13:09.079 > [VE.Direct MPPT 10/9]     Total Sum:  0, Frame Timeout:  0, Text Checksum:  0  
23:13:09.133 > [VE.Direct MPPT 10/9]  Hex Checksum:  0,    Hex Buffer:  0,    Nested Hex:  0  
23:13:09.133 > [VE.Direct MPPT 10/9]  Debug Buffer:  0,  Unknown Data:  0,  Invalid Char:  0 

For the sake of completeness, I should also mention:
- We cannot detect all errors (multiple errors with the correct checksum).
- Sometimes a transmission error triggers multiple individual errors.
- No average is calculated on day 1.
- When the total error reaches 50,000, all error counters are automatically reset.
