### PR TITLE
Fix: DPL: ignore hysteresis when inverter should be shutdown

### DIFF
--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -602,7 +602,10 @@ uint16_t PowerLimiterClass::updateInverterLimits(uint16_t powerRequested,
                 (plural?"s":""), producing, diff, hysteresis);
     }
 
-    if (std::abs(diff) < static_cast<int32_t>(hysteresis)) { return producing; }
+    // if 0 W are requested, we ignore the hysteresis to allow
+    // battery-powered inverters to go into standby and avoid that the battery
+    // gets fully discharged.
+    if (powerRequested != 0 && std::abs(diff) < static_cast<int32_t>(hysteresis)) { return producing; }
 
     uint16_t covered = 0;
 


### PR DESCRIPTION
This pull request includes a change to the `PowerLimiterClass::updateInverterLimits` method in the `src/PowerLimiter.cpp` file. The change modifies the logic to handle cases where 0 W are requested, allowing battery-powered inverters to go into standby and prevent the battery from being fully discharged.

* [`src/PowerLimiter.cpp`](diffhunk://#diff-c502fa72d03eefad0a66ed1345a8f70eded4c8f0303ee7b38bb2a32094dbcc91L605-R608): Added a condition to ignore the hysteresis when 0 W are requested, enabling battery-powered inverters to go into standby mode and avoid full battery discharge.

(Summary generated by Copilot AI)

Closes #1784