### PR TITLE
add Waveshare ESP32-S3-ETH with ethernet

### DIFF
--- a/docs/DeviceProfiles/waveshare-esp32-s3-eth.json
+++ b/docs/DeviceProfiles/waveshare-esp32-s3-eth.json
@@ -1,0 +1,19 @@
+[
+    {
+        "name": "Waveshare ESP32 S3-ETH",
+        "links": [
+            {
+                "name": "Datasheet",
+                "url": "https://www.waveshare.com/esp32-s3-eth.htm?sku=28972"
+            }
+        ],
+        "w5500": {
+            "sclk": 13,
+            "mosi": 11,
+            "miso": 12,
+            "cs": 14,
+            "int": 10,
+            "rst": 9
+        }
+    }
+]


### PR DESCRIPTION
A new device profile for the Waveshare ESP32-S3-ETH board.