### PR TITLE
Fix: en-/disable DTU verbose logging w/o restart

### DIFF
--- a/src/WebApi_dtu.cpp
+++ b/src/WebApi_dtu.cpp
@@ -28,6 +28,7 @@ void WebApiDtuClass::applyDataTaskCb()
 {
     // Execute stuff in main thread to avoid busy SPI bus
     auto const& config = Configuration.get();
+    Hoymiles.setVerboseLogging(config.Dtu.VerboseLogging);
     Hoymiles.getRadioNrf()->setPALevel((rf24_pa_dbm_e)config.Dtu.Nrf.PaLevel);
     Hoymiles.getRadioCmt()->setPALevel(config.Dtu.Cmt.PaLevel);
     Hoymiles.getRadioNrf()->setDtuSerial(config.Dtu.Serial);


### PR DESCRIPTION
Call `Hoymiles.setVerboseLoggin` when the config is saved via the web api.

Fixes #1741