### PR TITLE
Fix: allow negative output power also when ve direct network input power is used

### DIFF
--- a/src/solarcharger/victron/Stats.cpp
+++ b/src/solarcharger/victron/Stats.cpp
@@ -54,7 +54,9 @@ std::optional<float> Stats::getOutputPowerWatts() const
 
         efficiencies.push_back(data.mpptEfficiency_Percent);
         accountedInputPower += data.panelPower_PPV_W;
-        accountedOutputPower += std::max<int16_t>(0, data.batteryOutputPower_W);
+
+        // NOTE: batteryOutputPower_W can be negative if the load output is in use
+        accountedOutputPower += data.batteryOutputPower_W;
     }
 
     if (oNetworkPower.has_value()) {


### PR DESCRIPTION
Negative output power is possible for MPPTs with a load output, as they can draw electricity from both the solar input and the battery.

Resolves the concern raised by @SW-Niko: https://github.com/hoylabs/OpenDTU-OnBattery/pull/1817#issuecomment-2787194467