### PR TITLE
Improvement: rename huawei api endpoints

### DIFF
--- a/include/WebApi.h
+++ b/include/WebApi.h
@@ -30,7 +30,7 @@
 #include "WebApi_ws_solarcharger_live.h"
 #include "WebApi_solarcharger.h"
 #include "WebApi_ws_Huawei.h"
-#include "WebApi_Huawei.h"
+#include "WebApi_gridcharger.h"
 #include "WebApi_ws_battery.h"
 #include <ESPAsyncWebServer.h>
 #include <TaskSchedulerDeclarations.h>
@@ -81,7 +81,7 @@ private:
     WebApiWsLiveClass _webApiWsLive;
     WebApiWsSolarChargerLiveClass _webApiWsSolarChargerLive;
     WebApiSolarChargerlass _webApiSolarCharger;
-    WebApiHuaweiClass _webApiHuaweiClass;
+    WebApiGridChargerClass _webApiGridCharger;
     WebApiWsHuaweiLiveClass _webApiWsHuaweiLive;
     WebApiWsBatteryLiveClass _webApiWsBatteryLive;
 };

--- a/include/WebApi.h
+++ b/include/WebApi.h
@@ -29,7 +29,7 @@
 #include <AsyncJson.h>
 #include "WebApi_ws_solarcharger_live.h"
 #include "WebApi_solarcharger.h"
-#include "WebApi_ws_Huawei.h"
+#include "WebApi_ws_gridcharger.h"
 #include "WebApi_gridcharger.h"
 #include "WebApi_ws_battery.h"
 #include <ESPAsyncWebServer.h>
@@ -82,7 +82,7 @@ private:
     WebApiWsSolarChargerLiveClass _webApiWsSolarChargerLive;
     WebApiSolarChargerlass _webApiSolarCharger;
     WebApiGridChargerClass _webApiGridCharger;
-    WebApiWsHuaweiLiveClass _webApiWsHuaweiLive;
+    WebApiWsGridChargerLiveClass _webApiWsGridChargerLive;
     WebApiWsBatteryLiveClass _webApiWsBatteryLive;
 };
 

--- a/include/WebApi_gridcharger.h
+++ b/include/WebApi_gridcharger.h
@@ -5,7 +5,7 @@
 #include <TaskSchedulerDeclarations.h>
 #include <AsyncJson.h>
 
-class WebApiHuaweiClass {
+class WebApiGridChargerClass {
 public:
     void init(AsyncWebServer& server, Scheduler& scheduler);
     void getJsonData(JsonVariant& root);

--- a/include/WebApi_ws_gridcharger.h
+++ b/include/WebApi_ws_gridcharger.h
@@ -6,9 +6,9 @@
 #include <TaskSchedulerDeclarations.h>
 #include <mutex>
 
-class WebApiWsHuaweiLiveClass {
+class WebApiWsGridChargerLiveClass {
 public:
-    WebApiWsHuaweiLiveClass();
+    WebApiWsGridChargerLiveClass();
     void init(AsyncWebServer& server, Scheduler& scheduler);
     void reload();
 
@@ -22,7 +22,7 @@ private:
     AsyncAuthenticationMiddleware _simpleDigestAuth;
 
     std::mutex _mutex;
-    
+
     Task _wsCleanupTask;
     void wsCleanupTaskCb();
 

--- a/include/WebApi_ws_live.h
+++ b/include/WebApi_ws_live.h
@@ -32,7 +32,7 @@ private:
 
     uint32_t _lastPublishOnBatteryFull = 0;
     uint32_t _lastPublishSolarCharger = 0;
-    uint32_t _lastPublishHuawei = 0;
+    uint32_t _lastPublishGridCharger = 0;
     uint32_t _lastPublishBattery = 0;
     uint32_t _lastPublishPowerMeter = 0;
 

--- a/src/MqttHandleHuawei.cpp
+++ b/src/MqttHandleHuawei.cpp
@@ -6,7 +6,6 @@
 #include "MessageOutput.h"
 #include "MqttSettings.h"
 #include <gridcharger/huawei/Controller.h>
-#include "WebApi_Huawei.h"
 #include <ctime>
 
 MqttHandleHuaweiClass MqttHandleHuawei;

--- a/src/WebApi.cpp
+++ b/src/WebApi.cpp
@@ -41,7 +41,7 @@ void WebApiClass::init(Scheduler& scheduler)
     _webApiPowerLimiter.init(_server, scheduler);
     _webApiWsSolarChargerLive.init(_server, scheduler);
     _webApiSolarCharger.init(_server, scheduler);
-    _webApiWsHuaweiLive.init(_server, scheduler);
+    _webApiWsGridChargerLive.init(_server, scheduler);
     _webApiGridCharger.init(_server, scheduler);
     _webApiWsBatteryLive.init(_server, scheduler);
 
@@ -54,7 +54,7 @@ void WebApiClass::reload()
     _webApiWsLive.reload();
     _webApiWsBatteryLive.reload();
     _webApiWsSolarChargerLive.reload();
-    _webApiWsHuaweiLive.reload();
+    _webApiWsGridChargerLive.reload();
 }
 
 bool WebApiClass::checkCredentials(AsyncWebServerRequest* request)

--- a/src/WebApi.cpp
+++ b/src/WebApi.cpp
@@ -42,7 +42,7 @@ void WebApiClass::init(Scheduler& scheduler)
     _webApiWsSolarChargerLive.init(_server, scheduler);
     _webApiSolarCharger.init(_server, scheduler);
     _webApiWsHuaweiLive.init(_server, scheduler);
-    _webApiHuaweiClass.init(_server, scheduler);
+    _webApiGridCharger.init(_server, scheduler);
     _webApiWsBatteryLive.init(_server, scheduler);
 
     _server.begin();

--- a/src/WebApi_gridcharger.cpp
+++ b/src/WebApi_gridcharger.cpp
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2022-2024 Thomas Basler and others
  */
-#include "WebApi_Huawei.h"
+#include "WebApi_gridcharger.h"
 #include <gridcharger/huawei/Controller.h>
 #include "Configuration.h"
 #include "MessageOutput.h"
@@ -12,20 +12,20 @@
 #include <AsyncJson.h>
 #include <Hoymiles.h>
 
-void WebApiHuaweiClass::init(AsyncWebServer& server, Scheduler& scheduler)
+void WebApiGridChargerClass::init(AsyncWebServer& server, Scheduler& scheduler)
 {
     using std::placeholders::_1;
 
     _server = &server;
 
-    _server->on("/api/huawei/status", HTTP_GET, std::bind(&WebApiHuaweiClass::onStatus, this, _1));
-    _server->on("/api/huawei/config", HTTP_GET, std::bind(&WebApiHuaweiClass::onAdminGet, this, _1));
-    _server->on("/api/huawei/config", HTTP_POST, std::bind(&WebApiHuaweiClass::onAdminPost, this, _1));
-    _server->on("/api/huawei/limit", HTTP_POST, std::bind(&WebApiHuaweiClass::onLimitPost, this, _1));
-    _server->on("/api/huawei/power", HTTP_POST, std::bind(&WebApiHuaweiClass::onPowerPost, this, _1));
+    _server->on("/api/gridcharger/status", HTTP_GET, std::bind(&WebApiGridChargerClass::onStatus, this, _1));
+    _server->on("/api/gridcharger/config", HTTP_GET, std::bind(&WebApiGridChargerClass::onAdminGet, this, _1));
+    _server->on("/api/gridcharger/config", HTTP_POST, std::bind(&WebApiGridChargerClass::onAdminPost, this, _1));
+    _server->on("/api/gridcharger/limit", HTTP_POST, std::bind(&WebApiGridChargerClass::onLimitPost, this, _1));
+    _server->on("/api/gridcharger/power", HTTP_POST, std::bind(&WebApiGridChargerClass::onPowerPost, this, _1));
 }
 
-void WebApiHuaweiClass::onStatus(AsyncWebServerRequest* request)
+void WebApiGridChargerClass::onStatus(AsyncWebServerRequest* request)
 {
     if (!WebApi.checkCredentialsReadonly(request)) {
         return;
@@ -39,7 +39,7 @@ void WebApiHuaweiClass::onStatus(AsyncWebServerRequest* request)
     request->send(response);
 }
 
-void WebApiHuaweiClass::onLimitPost(AsyncWebServerRequest* request)
+void WebApiGridChargerClass::onLimitPost(AsyncWebServerRequest* request)
 {
     if (!WebApi.checkCredentials(request)) {
         return;
@@ -98,7 +98,7 @@ void WebApiHuaweiClass::onLimitPost(AsyncWebServerRequest* request)
     WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
 }
 
-void WebApiHuaweiClass::onPowerPost(AsyncWebServerRequest* request)
+void WebApiGridChargerClass::onPowerPost(AsyncWebServerRequest* request)
 {
     if (!WebApi.checkCredentials(request)) {
         return;
@@ -129,7 +129,7 @@ void WebApiHuaweiClass::onPowerPost(AsyncWebServerRequest* request)
     WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
 }
 
-void WebApiHuaweiClass::onAdminGet(AsyncWebServerRequest* request)
+void WebApiGridChargerClass::onAdminGet(AsyncWebServerRequest* request)
 {
     if (!WebApi.checkCredentials(request)) {
         return;
@@ -151,7 +151,7 @@ void WebApiHuaweiClass::onAdminGet(AsyncWebServerRequest* request)
     request->send(response);
 }
 
-void WebApiHuaweiClass::onAdminPost(AsyncWebServerRequest* request)
+void WebApiGridChargerClass::onAdminPost(AsyncWebServerRequest* request)
 {
     if (!WebApi.checkCredentials(request)) {
         return;

--- a/src/WebApi_ws_gridcharger.cpp
+++ b/src/WebApi_ws_gridcharger.cpp
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2022-2024 Thomas Basler and others
  */
-#include "WebApi_ws_Huawei.h"
+#include "WebApi_ws_gridcharger.h"
 #include "AsyncJson.h"
 #include "Configuration.h"
 #include <gridcharger/huawei/Controller.h>
@@ -11,12 +11,12 @@
 #include "WebApi.h"
 #include "defaults.h"
 
-WebApiWsHuaweiLiveClass::WebApiWsHuaweiLiveClass()
-    : _ws("/huaweilivedata")
+WebApiWsGridChargerLiveClass::WebApiWsGridChargerLiveClass()
+    : _ws("/gridchargerlivedata")
 {
 }
 
-void WebApiWsHuaweiLiveClass::init(AsyncWebServer& server, Scheduler& scheduler)
+void WebApiWsGridChargerLiveClass::init(AsyncWebServer& server, Scheduler& scheduler)
 {
     using std::placeholders::_1;
     using std::placeholders::_2;
@@ -26,19 +26,19 @@ void WebApiWsHuaweiLiveClass::init(AsyncWebServer& server, Scheduler& scheduler)
     using std::placeholders::_6;
 
     _server = &server;
-    _server->on("/api/huaweilivedata/status", HTTP_GET, std::bind(&WebApiWsHuaweiLiveClass::onLivedataStatus, this, _1));
+    _server->on("/api/gridchargerlivedata/status", HTTP_GET, std::bind(&WebApiWsGridChargerLiveClass::onLivedataStatus, this, _1));
 
     _server->addHandler(&_ws);
-    _ws.onEvent(std::bind(&WebApiWsHuaweiLiveClass::onWebsocketEvent, this, _1, _2, _3, _4, _5, _6));
+    _ws.onEvent(std::bind(&WebApiWsGridChargerLiveClass::onWebsocketEvent, this, _1, _2, _3, _4, _5, _6));
 
     scheduler.addTask(_wsCleanupTask);
-    _wsCleanupTask.setCallback(std::bind(&WebApiWsHuaweiLiveClass::wsCleanupTaskCb, this));
+    _wsCleanupTask.setCallback(std::bind(&WebApiWsGridChargerLiveClass::wsCleanupTaskCb, this));
     _wsCleanupTask.setIterations(TASK_FOREVER);
     _wsCleanupTask.setInterval(1 * TASK_SECOND);
     _wsCleanupTask.enable();
 
     scheduler.addTask(_sendDataTask);
-    _sendDataTask.setCallback(std::bind(&WebApiWsHuaweiLiveClass::sendDataTaskCb, this));
+    _sendDataTask.setCallback(std::bind(&WebApiWsGridChargerLiveClass::sendDataTaskCb, this));
     _sendDataTask.setIterations(TASK_FOREVER);
     _sendDataTask.setInterval(1 * TASK_SECOND);
     _sendDataTask.enable();
@@ -49,7 +49,7 @@ void WebApiWsHuaweiLiveClass::init(AsyncWebServer& server, Scheduler& scheduler)
     reload();
 }
 
-void WebApiWsHuaweiLiveClass::reload()
+void WebApiWsGridChargerLiveClass::reload()
 {
     _ws.removeMiddleware(&_simpleDigestAuth);
 
@@ -64,13 +64,13 @@ void WebApiWsHuaweiLiveClass::reload()
     _ws.enable(true);
 }
 
-void WebApiWsHuaweiLiveClass::wsCleanupTaskCb()
+void WebApiWsGridChargerLiveClass::wsCleanupTaskCb()
 {
     // see: https://github.com/me-no-dev/ESPAsyncWebServer#limiting-the-number-of-web-socket-clients
     _ws.cleanupClients();
 }
 
-void WebApiWsHuaweiLiveClass::sendDataTaskCb()
+void WebApiWsGridChargerLiveClass::sendDataTaskCb()
 {
     // do nothing if no WS client is connected
     if (_ws.count() == 0) {
@@ -91,18 +91,18 @@ void WebApiWsHuaweiLiveClass::sendDataTaskCb()
             _ws.textAll(buffer);
         }
     } catch (std::bad_alloc& bad_alloc) {
-        MessageOutput.printf("Calling /api/huaweilivedata/status has temporarily run out of resources. Reason: \"%s\".\r\n", bad_alloc.what());
+        MessageOutput.printf("Calling /api/gridchargerlivedata/status has temporarily run out of resources. Reason: \"%s\".\r\n", bad_alloc.what());
     } catch (const std::exception& exc) {
-            MessageOutput.printf("Unknown exception in /api/huaweilivedata/status. Reason: \"%s\".\r\n", exc.what());
+            MessageOutput.printf("Unknown exception in /api/gridchargerlivedata/status. Reason: \"%s\".\r\n", exc.what());
     }
 }
 
-void WebApiWsHuaweiLiveClass::generateCommonJsonResponse(JsonVariant& root)
+void WebApiWsGridChargerLiveClass::generateCommonJsonResponse(JsonVariant& root)
 {
     HuaweiCan.getJsonData(root);
 }
 
-void WebApiWsHuaweiLiveClass::onWebsocketEvent(AsyncWebSocket* server, AsyncWebSocketClient* client, AwsEventType type, void* arg, uint8_t* data, size_t len)
+void WebApiWsGridChargerLiveClass::onWebsocketEvent(AsyncWebSocket* server, AsyncWebSocketClient* client, AwsEventType type, void* arg, uint8_t* data, size_t len)
 {
     if (type == WS_EVT_CONNECT) {
         char str[64];
@@ -117,7 +117,7 @@ void WebApiWsHuaweiLiveClass::onWebsocketEvent(AsyncWebSocket* server, AsyncWebS
     }
 }
 
-void WebApiWsHuaweiLiveClass::onLivedataStatus(AsyncWebServerRequest* request)
+void WebApiWsGridChargerLiveClass::onLivedataStatus(AsyncWebServerRequest* request)
 {
     if (!WebApi.checkCredentialsReadonly(request)) {
         return;
@@ -132,10 +132,10 @@ void WebApiWsHuaweiLiveClass::onLivedataStatus(AsyncWebServerRequest* request)
         WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
 
     } catch (std::bad_alloc& bad_alloc) {
-        MessageOutput.printf("Calling /api/huaweilivedata/status has temporarily run out of resources. Reason: \"%s\".\r\n", bad_alloc.what());
+        MessageOutput.printf("Calling /api/gridchargerlivedata/status has temporarily run out of resources. Reason: \"%s\".\r\n", bad_alloc.what());
         WebApi.sendTooManyRequests(request);
     } catch (const std::exception& exc) {
-        MessageOutput.printf("Unknown exception in /api/huaweilivedata/status. Reason: \"%s\".\r\n", exc.what());
+        MessageOutput.printf("Unknown exception in /api/gridchargerlivedata/status. Reason: \"%s\".\r\n", exc.what());
         WebApi.sendTooManyRequests(request);
     }
 }

--- a/src/WebApi_ws_live.cpp
+++ b/src/WebApi_ws_live.cpp
@@ -113,18 +113,18 @@ void WebApiWsLiveClass::generateOnBatteryJsonResponse(JsonVariant& root, bool al
         if (!all) { _lastPublishSolarCharger = millis(); }
     }
 
-    if (all || (HuaweiCan.getDataPoints().getLastUpdate() - _lastPublishHuawei) < halfOfAllMillis ) {
-        auto huaweiObj = root["huawei"].to<JsonObject>();
-        huaweiObj["enabled"] = config.GridCharger.Enabled;
+    if (all || (HuaweiCan.getDataPoints().getLastUpdate() - _lastPublishGridCharger) < halfOfAllMillis ) {
+        auto gridChargerObj = root["gridcharger"].to<JsonObject>();
+        gridChargerObj["enabled"] = config.GridCharger.Enabled;
 
         if (config.GridCharger.Enabled) {
             auto const& dataPoints = HuaweiCan.getDataPoints();
             auto oInputPower = dataPoints.get<GridCharger::Huawei::DataPointLabel::InputPower>();
             float pwr = oInputPower.value_or(0.0f);
-            addTotalField(huaweiObj, "Power", pwr, "W", 2);
+            addTotalField(gridChargerObj, "Power", pwr, "W", 2);
         }
 
-        if (!all) { _lastPublishHuawei = millis(); }
+        if (!all) { _lastPublishGridCharger = millis(); }
     }
 
     auto spStats = Battery.getStats();

--- a/webapp/src/components/HuaweiView.vue
+++ b/webapp/src/components/HuaweiView.vue
@@ -403,7 +403,7 @@ export default defineComponent({
     },
     methods: {
         getInitialData() {
-            console.log('Get initalData for GridCharger');
+            console.log('Get initialData for GridCharger');
             this.dataLoading = true;
 
             fetch('/api/gridchargerlivedata/status', { headers: authHeader() })

--- a/webapp/src/components/HuaweiView.vue
+++ b/webapp/src/components/HuaweiView.vue
@@ -403,10 +403,10 @@ export default defineComponent({
     },
     methods: {
         getInitialData() {
-            console.log('Get initalData for Huawei');
+            console.log('Get initalData for GridCharger');
             this.dataLoading = true;
 
-            fetch('/api/huaweilivedata/status', { headers: authHeader() })
+            fetch('/api/gridchargerlivedata/status', { headers: authHeader() })
                 .then((response) => handleResponse(response, this.$emitter, this.$router))
                 .then((data) => {
                     this.huaweiData = data;
@@ -414,11 +414,11 @@ export default defineComponent({
                 });
         },
         initSocket() {
-            console.log('Starting connection to Huawei WebSocket Server');
+            console.log('Starting connection to GridCharger WebSocket Server');
 
             const { protocol, host } = location;
             const authString = authUrl();
-            const webSocketUrl = `${protocol === 'https:' ? 'wss' : 'ws'}://${authString}${host}/huaweilivedata`;
+            const webSocketUrl = `${protocol === 'https:' ? 'wss' : 'ws'}://${authString}${host}/gridchargerlivedata`;
 
             this.socket = new WebSocket(webSocketUrl);
 
@@ -431,7 +431,7 @@ export default defineComponent({
 
             this.socket.onopen = function (event) {
                 console.log(event);
-                console.log('Successfully connected to the Huawei websocket server...');
+                console.log('Successfully connected to the GridCharger websocket server...');
             };
 
             // Listen to window events , When the window closes , Take the initiative to disconnect websocket Connect

--- a/webapp/src/components/HuaweiView.vue
+++ b/webapp/src/components/HuaweiView.vue
@@ -487,7 +487,7 @@ export default defineComponent({
 
             console.log(this.targetLimitList);
 
-            fetch('/api/huawei/limit', {
+            fetch('/api/gridcharger/limit', {
                 method: 'POST',
                 headers: authHeader(),
                 body: formData,
@@ -508,7 +508,7 @@ export default defineComponent({
             const formData = new FormData();
             formData.append('data', JSON.stringify({ power }));
 
-            fetch('/api/huawei/power', {
+            fetch('/api/gridcharger/power', {
                 method: 'POST',
                 headers: authHeader(),
                 body: formData,

--- a/webapp/src/components/InverterTotalInfo.vue
+++ b/webapp/src/components/InverterTotalInfo.vue
@@ -182,7 +182,7 @@
             </CardElement>
         </div>
         <div class="col" v-if="gridChargerData.enabled">
-            <CardElement centerContent textVariant="text-bg-primary" :text="$t('invertertotalinfo.HuaweiPower')">
+            <CardElement centerContent textVariant="text-bg-primary" :text="$t('invertertotalinfo.GridChargerPower')">
                 <h2>
                     {{
                         $n(gridChargerData.Power.v, 'decimal', {

--- a/webapp/src/components/InverterTotalInfo.vue
+++ b/webapp/src/components/InverterTotalInfo.vue
@@ -181,16 +181,16 @@
                 </h2>
             </CardElement>
         </div>
-        <div class="col" v-if="huaweiData.enabled">
+        <div class="col" v-if="gridChargerData.enabled">
             <CardElement centerContent textVariant="text-bg-primary" :text="$t('invertertotalinfo.HuaweiPower')">
                 <h2>
                     {{
-                        $n(huaweiData.Power.v, 'decimal', {
-                            minimumFractionDigits: huaweiData.Power.d,
-                            maximumFractionDigits: huaweiData.Power.d,
+                        $n(gridChargerData.Power.v, 'decimal', {
+                            minimumFractionDigits: gridChargerData.Power.d,
+                            maximumFractionDigits: gridChargerData.Power.d,
                         })
                     }}
-                    <small class="text-muted">{{ huaweiData.Power.u }}</small>
+                    <small class="text-muted">{{ gridChargerData.Power.u }}</small>
                 </h2>
             </CardElement>
         </div>
@@ -200,7 +200,7 @@
 <script lang="ts">
 import BootstrapAlert from '@/components/BootstrapAlert.vue';
 import { BIconGear } from 'bootstrap-icons-vue';
-import type { Battery, Total, SolarCharger, Huawei, PowerMeter } from '@/types/LiveDataStatus';
+import type { Battery, Total, SolarCharger, GridCharger, PowerMeter } from '@/types/LiveDataStatus';
 import CardElement from './CardElement.vue';
 import { defineComponent, type PropType, useTemplateRef } from 'vue';
 
@@ -216,7 +216,7 @@ export default defineComponent({
         solarChargerData: { type: Object as PropType<SolarCharger>, required: true },
         totalBattData: { type: Object as PropType<Battery>, required: true },
         powerMeterData: { type: Object as PropType<PowerMeter>, required: true },
-        huaweiData: { type: Object as PropType<Huawei>, required: true },
+        gridChargerData: { type: Object as PropType<GridCharger>, required: true },
     },
     data() {
         return {

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -449,7 +449,7 @@
         "BatteryCharge": "Batterie Ladezustand",
         "BatteryPower": "Batterie Leistung",
         "HomePower": "Leistung / Netz",
-        "HuaweiPower": "Huawei AC Leistung"
+        "GridChargerPower": "Netzladegerät AC Leistung"
     },
     "inverterchannelproperty": {
         "Power": "Leistung",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -451,7 +451,7 @@
         "BatteryCharge": "Battery Charge",
         "BatteryPower": "Battery Power",
         "HomePower": "Grid Power",
-        "HuaweiPower": "Huawei AC Power"
+        "GridChargerPower": "Grid Charger AC Power"
     },
     "inverterchannelproperty": {
         "Power": "Power",

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -419,8 +419,7 @@
         "MpptTotalPower": "Puissance totale solaire",
         "BatteryCharge": "Battery Charge",
         "BatteryPower": "Battery Power",
-        "HomePower": "Grid Power",
-        "HuaweiPower": "Huawei AC Power"
+        "HomePower": "Grid Power"
     },
     "inverterchannelproperty": {
         "Power": "Puissance",

--- a/webapp/src/types/LiveDataStatus.ts
+++ b/webapp/src/types/LiveDataStatus.ts
@@ -69,7 +69,7 @@ export interface SolarCharger {
     yieldTotal?: ValueObject;
 }
 
-export interface Huawei {
+export interface GridCharger {
     enabled: boolean;
     Power: ValueObject;
 }
@@ -92,7 +92,7 @@ export interface LiveData {
     total: Total;
     hints: Hints;
     solarcharger: SolarCharger;
-    huawei: Huawei;
+    gridcharger: GridCharger;
     battery: Battery;
     power_meter: PowerMeter;
 }

--- a/webapp/src/views/AcChargerAdminView.vue
+++ b/webapp/src/views/AcChargerAdminView.vue
@@ -270,7 +270,7 @@ export default defineComponent({
     methods: {
         getChargerConfig() {
             this.dataLoading = true;
-            fetch('/api/huawei/config', { headers: authHeader() })
+            fetch('/api/gridcharger/config', { headers: authHeader() })
                 .then((response) => handleResponse(response, this.$emitter, this.$router))
                 .then((data) => {
                     this.acChargerConfigList = data;
@@ -283,7 +283,7 @@ export default defineComponent({
             const formData = new FormData();
             formData.append('data', JSON.stringify(this.acChargerConfigList));
 
-            fetch('/api/huawei/config', {
+            fetch('/api/gridcharger/config', {
                 method: 'POST',
                 headers: authHeader(),
                 body: formData,

--- a/webapp/src/views/HomeView.vue
+++ b/webapp/src/views/HomeView.vue
@@ -14,7 +14,7 @@
             :solarChargerData="liveData.solarcharger"
             :totalBattData="liveData.battery"
             :powerMeterData="liveData.power_meter"
-            :huaweiData="liveData.huawei"
+            :gridChargerData="liveData.gridcharger"
         />
         <div class="row gy-3 mt-0">
             <div class="col-sm-3 col-md-2" :style="[inverterData.length == 1 ? { display: 'none' } : {}]">
@@ -351,7 +351,7 @@
         </div>
         <SolarChargerView v-if="liveData.solarcharger.enabled" />
         <BatteryView v-if="liveData.battery.enabled" />
-        <HuaweiView v-if="liveData.huawei.enabled" />
+        <HuaweiView v-if="liveData.gridcharger.enabled" />
     </BasePage>
 
     <ModalDialog modalId="eventView" :title="$t('home.EventLog')" :loading="eventLogLoading">
@@ -718,8 +718,8 @@ export default defineComponent({
                     if (typeof newData.solarcharger !== 'undefined') {
                         Object.assign(this.liveData.solarcharger, newData.solarcharger);
                     }
-                    if (typeof newData.huawei !== 'undefined') {
-                        Object.assign(this.liveData.huawei, newData.huawei);
+                    if (typeof newData.gridcharger !== 'undefined') {
+                        Object.assign(this.liveData.gridcharger, newData.gridcharger);
                     }
                     if (typeof newData.battery !== 'undefined') {
                         Object.assign(this.liveData.battery, newData.battery);

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -81,7 +81,7 @@ export default defineConfig(({ command }) => { return {
         ws: true,
         changeOrigin: true
       },
-      '^/huaweilivedata': {
+      '^/gridchargerlivedata': {
         target: 'ws://' + proxy_target,
         ws: true,
         changeOrigin: true


### PR DESCRIPTION
This pull request focuses on renaming and refactoring the Huawei-related components to GridCharger components across various files. The most important changes include renaming classes, updating file names, and modifying API endpoints.

Renaming and refactoring:

* [`include/WebApi.h`](diffhunk://#diff-7e7cded3bc3ede892da59704e2a5f1b18110e2d3a6cea4ffcba26ed4747d5e79L32-R33): Replaced Huawei includes and class members with GridCharger equivalents. [[1]](diffhunk://#diff-7e7cded3bc3ede892da59704e2a5f1b18110e2d3a6cea4ffcba26ed4747d5e79L32-R33) [[2]](diffhunk://#diff-7e7cded3bc3ede892da59704e2a5f1b18110e2d3a6cea4ffcba26ed4747d5e79L84-R85)
* `include/WebApi_gridcharger.h` and `include/WebApi_ws_gridcharger.h`: Renamed from Huawei equivalents and updated class names. [[1]](diffhunk://#diff-cd7dadb2422b85418edc17d36940e9a8c377a32a46831391ad523e1ec8b3bc96L8-R8) [[2]](diffhunk://#diff-9921b6bf8b50e93f73944dfdf2b66beacade73354ab62dc650285ab946bd751cL9-R11)
* `src/WebApi_gridcharger.cpp` and `src/WebApi_ws_gridcharger.cpp`: Renamed from Huawei equivalents, updated class names, and modified API endpoints. [[1]](diffhunk://#diff-2297bc649297d26139a45ffb86f9f3e9c9161735fdf90e21b087f8fb6f3c528aL5-R5) [[2]](diffhunk://#diff-cd71b6fe6e3b07dce939a3afbce0c2913568670ea0574a99c47b592b0f867178L5-R5)
* [`src/WebApi.cpp`](diffhunk://#diff-cafcc38f9e958c1205db608c071ae2c8bd151edeca75c6a908c7436244f64228L44-R45): Updated initialization and reload methods to use GridCharger classes. [[1]](diffhunk://#diff-cafcc38f9e958c1205db608c071ae2c8bd151edeca75c6a908c7436244f64228L44-R45) [[2]](diffhunk://#diff-cafcc38f9e958c1205db608c071ae2c8bd151edeca75c6a908c7436244f64228L57-R57)
* [`webapp/src/components/HuaweiView.vue`](diffhunk://#diff-94f6d93b594077c8d55faf2d2eb27eb7a1d0bdfe560d60dfb65a896020287a0eL406-R421): Updated to reflect GridCharger naming and API endpoints. [[1]](diffhunk://#diff-94f6d93b594077c8d55faf2d2eb27eb7a1d0bdfe560d60dfb65a896020287a0eL406-R421) [[2]](diffhunk://#diff-94f6d93b594077c8d55faf2d2eb27eb7a1d0bdfe560d60dfb65a896020287a0eL434-R434) [[3]](diffhunk://#diff-94f6d93b594077c8d55faf2d2eb27eb7a1d0bdfe560d60dfb65a896020287a0eL490-R490) [[4]](diffhunk://#diff-94f6d93b594077c8d55faf2d2eb27eb7a1d0bdfe560d60dfb65a896020287a0eL511-R511)

Based on #1855 