### PR TITLE
Improvement: workflow: automatically create comment with links to artifacts on pull-requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: OpenDTU-OnBattery Build
 
+permissions:
+  pull-requests: write # For commenting on PRs
+  actions: read # For listing artifacts
+
 on:
   push:
     paths-ignore:
@@ -131,6 +135,68 @@ jobs:
             .pio/build/${{ matrix.environment }}/opendtu-onbattery-${{ matrix.environment }}.bin
             !.pio/build/generic_esp32_4mb_no_ota/opendtu-onbattery-generic_esp32_4mb_no_ota.bin
             .pio/build/${{ matrix.environment }}/opendtu-onbattery-${{ matrix.environment }}.factory.bin
+
+  # This snippet is public-domain, taken from
+  # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
+  pr_artifacts_comment:
+    name: Comment on PR with links to artifacts
+    needs: build
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            async function upsertComment(owner, repo, issue_number, purpose, body) {
+              const {data: comments} = await github.rest.issues.listComments(
+                {owner, repo, issue_number});
+              const marker = `<!-- bot: ${purpose} -->`;
+              body = marker + "\n" + body;
+              const existing = comments.filter((c) => c.body.includes(marker));
+              if (existing.length > 0) {
+                const last = existing[existing.length - 1];
+                core.info(`Updating comment ${last.id}`);
+                await github.rest.issues.updateComment({
+                  owner, repo,
+                  body,
+                  comment_id: last.id,
+                });
+              } else {
+                core.info(`Creating a comment in PR #${issue_number}`);
+                await github.rest.issues.createComment({issue_number, body, owner, repo});
+              }
+            }
+
+            const {owner, repo} = context.repo;
+            const pr_number = context.issue.number;
+
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner,
+                repo,
+                run_id: context.runId
+              }
+            );
+
+            if (!artifacts.length) {
+              return core.error(`No artifacts found`);
+            }
+
+            let body = `### Build Artifacts\n\nFirmware built from this pull request's code:\n`;
+            for (const art of artifacts) {
+              body += `\n* [${art.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
+            }
+
+            const build_run_url = `https://github.com/hoylabs/OpenDTU-OnBattery/actions/runs/${context.runId}`;
+
+            body += `\n\n### Notice\n`
+              + `* These artifacts are ZIP files containing the factory update binary as well as the OTA update binary.\n`
+              + `  Extract the binaries from the ZIP files first. Do not use the ZIP files themselves to perform an update.\n`
+              + `* These links point to artifacts of the latest [**successful** build run](${build_run_url}).\n`
+              + `* The linked artifacts were built from ${context.sha}.`;
+
+            await upsertComment(owner, repo, pr_number, "build-artifacts", body);
 
   release:
     name: Create Release


### PR DESCRIPTION
This step will post a comment on a PR with links to the firmware artifacts created by the build action of this PR. The comment will be updated when a new build was triggered.

I stumbled across [nightly.link](https://github.com/oprypin/nightly.link) and remembered that you can only download artifacts when logged in to github, additionally i thought that it might be cool to have a self updating comment on each PR that links to the latest build artifact.

Inspired by https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml

As you can see with the comment that github-actions posted below, it is getting updated with every run of the build step.

![Screenshot 2025-04-17 at 16 46 03](https://github.com/user-attachments/assets/f56eda18-0a5a-4711-b474-98989c34b0f7)


## Copilots summary

This pull request introduces a new workflow job in the `.github/workflows/build.yml` file to automatically comment on pull requests with links to build artifacts. This enhancement improves visibility and accessibility of build outputs for contributors.

### Workflow Enhancements:

* **New `pr_artifacts_comment` Job**: Added a job to post a comment on pull requests containing download links for build artifacts. This job is triggered only for pull request events and depends on the `build` job. It uses the `actions/github-script` action to dynamically create or update a comment with artifact links.