### PR TITLE
Fix: split artifacts comment in two workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,5 @@
 name: OpenDTU-OnBattery Build
 
-permissions:
-  pull-requests: write # For commenting on PRs
-  actions: read # For listing artifacts
-
 on:
   push:
     paths-ignore:
@@ -138,35 +134,21 @@ jobs:
 
   # This snippet is public-domain, taken from
   # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
-  pr_artifacts_comment:
-    name: Comment on PR with links to artifacts
+  # and modified to store the comment as an artifact instead of posting it because
+  # the action does not have sufficient permissions to post a comment when triggered
+  # by a forked repository.
+  # source: https://github.com/live-codes/pr-comment-from-artifact/blob/main/action.yml
+  generate_pr_artifacts_comment:
+    name: Generate PR artifacts comment and store it as artifact
     needs: build
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/github-script@v7
+      - name: Generate PR artifacts comment
+        id: generate_pr_artifacts_comment
+        uses: actions/github-script@v7
         with:
           script: |
-            async function upsertComment(owner, repo, issue_number, purpose, body) {
-              const {data: comments} = await github.rest.issues.listComments(
-                {owner, repo, issue_number});
-              const marker = `<!-- bot: ${purpose} -->`;
-              body = marker + "\n" + body;
-              const existing = comments.filter((c) => c.body.includes(marker));
-              if (existing.length > 0) {
-                const last = existing[existing.length - 1];
-                core.info(`Updating comment ${last.id}`);
-                await github.rest.issues.updateComment({
-                  owner, repo,
-                  body,
-                  comment_id: last.id,
-                });
-              } else {
-                core.info(`Creating a comment in PR #${issue_number}`);
-                await github.rest.issues.createComment({issue_number, body, owner, repo});
-              }
-            }
-
             const {owner, repo} = context.repo;
             const pr_number = context.issue.number;
 
@@ -195,8 +177,21 @@ jobs:
               + `  Extract the binaries from the ZIP files first. Do not use the ZIP files themselves to perform an update.\n`
               + `* These links point to artifacts of the latest [**successful** build run](${build_run_url}).\n`
               + `* The linked artifacts were built from ${context.sha}.`;
+            core.setOutput("message", body);
 
-            await upsertComment(owner, repo, pr_number, "build-artifacts", body);
+      - name: Save output and PR number
+        shell: bash
+        run: |
+          mkdir -p ./pr
+          echo "${{ steps.generate_pr_artifacts_comment.outputs.message }}" > ./pr/${{ github.event.number }}.md
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr
+          path: pr/
+          retention-days: 1
+          overwrite: true
 
   release:
     name: Create Release

--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -1,0 +1,83 @@
+name: Comment on pull request
+# This workflow is based on the following source:
+# https://github.com/live-codes/pr-comment-from-artifact/blob/main/action.yml
+on:
+  workflow_run:
+    workflows: ["OpenDTU-OnBattery Build"] # the workflow that created the artifact
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+    - name: "Download artifact"
+      uses: actions/github-script@v7
+      with:
+        script: |
+          var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+          });
+          var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == "pr";
+          })[0];
+          var download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+          });
+          var fs = require('fs');
+          fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+
+    - name: "Extract artifact"
+      run: |
+        mkdir -p pr
+        unzip pr.zip -d pr
+      shell: bash
+
+    - name: "Comment on PR"
+      id: comment
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require("fs");
+          const removeExtension = (path) => path.split(".").slice(0, -1).join(".");
+
+          const fileName = fs.readdirSync("./pr")?.[0];
+          if (!fileName) {
+            core.setFailed("No artifact found");
+            return;
+          }
+          const issue_number = removeExtension(fileName);
+          const body = fs.readFileSync(`./pr/${fileName}`, "utf8");
+
+          async function upsertComment(owner, repo, issue_number, purpose, body) {
+              const {data: comments} = await github.rest.issues.listComments(
+                {owner, repo, issue_number});
+              const marker = `<!-- bot: ${purpose} -->`;
+              body = marker + "\n" + body;
+              const existing = comments.filter((c) => c.body.includes(marker));
+              if (existing.length > 0) {
+                const last = existing[existing.length - 1];
+                core.info(`Updating comment ${last.id}`);
+                await github.rest.issues.updateComment({
+                  owner, repo,
+                  body,
+                  comment_id: last.id,
+                });
+              } else {
+                core.info(`Creating a comment in PR #${issue_number}`);
+                await github.rest.issues.createComment({issue_number, body, owner, repo});
+              }
+            }
+
+          await upsertComment(owner, repo, issue_number, "build-artifacts", body);


### PR DESCRIPTION
This is needed because a action run from a pull-requests coming from a fork does not have the required permissions to add and modify a comment. By splitting the workflows in two we can generate and store the comment data within the pull-request action and let another workflow run afterwards that has elevated permissions.