### PR TITLE
Huawei namespace and class naming

### DIFF
--- a/include/gridcharger/huawei/Controller.h
+++ b/include/gridcharger/huawei/Controller.h
@@ -9,7 +9,7 @@
 #include <gridcharger/huawei/HardwareInterface.h>
 #include <gridcharger/huawei/DataPoints.h>
 
-namespace GridCharger::Huawei {
+namespace GridChargers::Huawei {
 
 // Modes of operation
 #define HUAWEI_MODE_OFF 0
@@ -76,6 +76,6 @@ private:
     bool _batteryEmergencyCharging = false;
 };
 
-} // namespace GridCharger::Huawei
+} // namespace GridChargers::Huawei
 
-extern GridCharger::Huawei::Controller HuaweiCan;
+extern GridChargers::Huawei::Controller HuaweiCan;

--- a/include/gridcharger/huawei/DataPoints.h
+++ b/include/gridcharger/huawei/DataPoints.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <DataPoints.h>
 
-namespace GridCharger::Huawei {
+namespace GridChargers::Huawei {
 
 enum class DataPointLabel : uint8_t {
     // board properties message
@@ -81,12 +81,12 @@ LABEL_TRAIT(InputTemperature,   float,       "°C");
 LABEL_TRAIT(OutputCurrent,      float,       "A");
 #undef LABEL_TRAIT
 
-} // namespace GridCharger::Huawei
+} // namespace GridChargers::Huawei
 
 template class DataPointContainer<DataPoint<float, std::string, uint8_t, bool>,
-                                  GridCharger::Huawei::DataPointLabel,
-                                  GridCharger::Huawei::DataPointLabelTraits>;
+                                  GridChargers::Huawei::DataPointLabel,
+                                  GridChargers::Huawei::DataPointLabelTraits>;
 
-namespace GridCharger::Huawei {
+namespace GridChargers::Huawei {
     using DataPointContainer = DataPointContainer<DataPoint<float, std::string, uint8_t, bool>, DataPointLabel, DataPointLabelTraits>;
-} // namespace GridCharger::Huawei
+} // namespace GridChargers::Huawei

--- a/include/gridcharger/huawei/HardwareInterface.h
+++ b/include/gridcharger/huawei/HardwareInterface.h
@@ -11,7 +11,7 @@
 #include <cstdint>
 #include <gridcharger/huawei/DataPoints.h>
 
-namespace GridCharger::Huawei {
+namespace GridChargers::Huawei {
 
 class HardwareInterface {
 public:
@@ -112,4 +112,4 @@ private:
     void enqueueParameter(Setting setting, float val);
 };
 
-} // namespace GridCharger::Huawei
+} // namespace GridChargers::Huawei

--- a/include/gridcharger/huawei/MCP2515.h
+++ b/include/gridcharger/huawei/MCP2515.h
@@ -7,7 +7,7 @@
 #include <SpiManager.h>
 #include <gridcharger/huawei/HardwareInterface.h>
 
-namespace GridCharger::Huawei {
+namespace GridChargers::Huawei {
 
 class MCP2515 : public HardwareInterface {
 public:
@@ -30,4 +30,4 @@ private:
     gpio_num_t _huaweiIrq; // IRQ pin
 };
 
-} // namespace GridCharger::Huawei
+} // namespace GridChargers::Huawei

--- a/include/gridcharger/huawei/TWAI.h
+++ b/include/gridcharger/huawei/TWAI.h
@@ -4,7 +4,7 @@
 #include <atomic>
 #include <gridcharger/huawei/HardwareInterface.h>
 
-namespace GridCharger::Huawei {
+namespace GridChargers::Huawei {
 
 class TWAI : public HardwareInterface {
 public:
@@ -24,4 +24,4 @@ private:
     static void pollAlerts(void* context);
 };
 
-} // namespace GridCharger::Huawei
+} // namespace GridChargers::Huawei

--- a/src/MqttHandleHuawei.cpp
+++ b/src/MqttHandleHuawei.cpp
@@ -80,7 +80,7 @@ void MqttHandleHuaweiClass::loop()
 
 #define PUB(l, t) \
     { \
-        auto oDataPoint = dataPoints.get<GridCharger::Huawei::DataPointLabel::l>(); \
+        auto oDataPoint = dataPoints.get<GridChargers::Huawei::DataPointLabel::l>(); \
         if (oDataPoint) { \
             MqttSettings.publish("huawei/" t, String(*oDataPoint)); \
         } \
@@ -103,7 +103,7 @@ void MqttHandleHuaweiClass::loop()
 
 #define PUBACK(l, t) \
     { \
-        auto oDataPoint = dataPoints.get<GridCharger::Huawei::DataPointLabel::l>(); \
+        auto oDataPoint = dataPoints.get<GridChargers::Huawei::DataPointLabel::l>(); \
         if (oDataPoint) { \
             MqttSettings.publish("huawei/acks/" t, String(*oDataPoint)); \
         } \
@@ -122,7 +122,7 @@ void MqttHandleHuaweiClass::loop()
 
 #define PUBSTR(l, t) \
     { \
-        auto oDataPoint = dataPoints.get<GridCharger::Huawei::DataPointLabel::l>(); \
+        auto oDataPoint = dataPoints.get<GridChargers::Huawei::DataPointLabel::l>(); \
         if (oDataPoint) { \
             MqttSettings.publish("huawei/" t, String(oDataPoint->c_str())); \
         } \
@@ -136,7 +136,7 @@ void MqttHandleHuaweiClass::loop()
     PUBSTR(ProductDescription, "product_description");
 #undef PUBSTR
 
-    auto const& oReachable = dataPoints.get<GridCharger::Huawei::DataPointLabel::Reachable>();
+    auto const& oReachable = dataPoints.get<GridChargers::Huawei::DataPointLabel::Reachable>();
     if (oReachable) {
         MqttSettings.publish("huawei/reachable", String(*oReachable?1:0));
     }
@@ -164,8 +164,8 @@ void MqttHandleHuaweiClass::onMqttMessage(Topic enumTopic,
     }
 
     std::lock_guard<std::mutex> mqttLock(_mqttMutex);
-    using Controller = GridCharger::Huawei::Controller;
-    using Setting = GridCharger::Huawei::HardwareInterface::Setting;
+    using Controller = GridChargers::Huawei::Controller;
+    using Setting = GridChargers::Huawei::HardwareInterface::Setting;
 
     auto validateAndSetParameter = [this, payload_val](float min, float max,
             Setting setting, const char* paramName, const char* unit) -> bool {

--- a/src/WebApi_gridcharger.cpp
+++ b/src/WebApi_gridcharger.cpp
@@ -53,7 +53,7 @@ void WebApiGridChargerClass::onLimitPost(AsyncWebServerRequest* request)
 
     auto& retMsg = response->getRoot();
 
-    using Setting = GridCharger::Huawei::HardwareInterface::Setting;
+    using Setting = GridChargers::Huawei::HardwareInterface::Setting;
 
     auto applySetting = [&](const char* key, float min, float max, WebApiError error, Setting setting) -> bool {
         if (!root[key].is<float>()) { return true; }
@@ -73,7 +73,7 @@ void WebApiGridChargerClass::onLimitPost(AsyncWebServerRequest* request)
         return true;
     };
 
-    using Controller = GridCharger::Huawei::Controller;
+    using Controller = GridChargers::Huawei::Controller;
 
     if (!applySetting("voltage",
         Controller::MIN_ONLINE_VOLTAGE,
@@ -185,7 +185,7 @@ void WebApiGridChargerClass::onAdminPost(AsyncWebServerRequest* request)
         return;
     }
 
-    using Controller = GridCharger::Huawei::Controller;
+    using Controller = GridChargers::Huawei::Controller;
 
     auto isValidRange = [&](const char* valueName, float min, float max, WebApiError error) -> bool {
         if (root["huawei"][valueName].as<float>() < min || root["huawei"][valueName].as<float>() > max) {

--- a/src/WebApi_ws_live.cpp
+++ b/src/WebApi_ws_live.cpp
@@ -119,7 +119,7 @@ void WebApiWsLiveClass::generateOnBatteryJsonResponse(JsonVariant& root, bool al
 
         if (config.GridCharger.Enabled) {
             auto const& dataPoints = HuaweiCan.getDataPoints();
-            auto oInputPower = dataPoints.get<GridCharger::Huawei::DataPointLabel::InputPower>();
+            auto oInputPower = dataPoints.get<GridChargers::Huawei::DataPointLabel::InputPower>();
             float pwr = oInputPower.value_or(0.0f);
             addTotalField(gridChargerObj, "Power", pwr, "W", 2);
         }

--- a/src/gridcharger/huawei/Controller.cpp
+++ b/src/gridcharger/huawei/Controller.cpp
@@ -14,9 +14,9 @@
 #include <functional>
 #include <algorithm>
 
-GridCharger::Huawei::Controller HuaweiCan;
+GridChargers::Huawei::Controller HuaweiCan;
 
-namespace GridCharger::Huawei {
+namespace GridChargers::Huawei {
 
 // Wait time/current before shuting down the PSU / charger
 // This is set to allow the fan to run for some time
@@ -393,7 +393,7 @@ void Controller::getJsonData(JsonVariant& root) const
 {
     root["data_age"] = millis() - _dataPoints.getLastUpdate();
 
-    using Label = GridCharger::Huawei::DataPointLabel;
+    using Label = GridChargers::Huawei::DataPointLabel;
 
     auto oReachable = _dataPoints.get<Label::Reachable>();
     root["reachable"] = oReachable.value_or(false);
@@ -445,4 +445,4 @@ void Controller::getJsonData(JsonVariant& root) const
 #undef VAL
 }
 
-} // namespace GridCharger::Huawei
+} // namespace GridChargers::Huawei

--- a/src/gridcharger/huawei/HardwareInterface.cpp
+++ b/src/gridcharger/huawei/HardwareInterface.cpp
@@ -5,7 +5,7 @@
 #include <MessageOutput.h>
 #include <gridcharger/huawei/HardwareInterface.h>
 
-namespace GridCharger::Huawei {
+namespace GridChargers::Huawei {
 
 void HardwareInterface::staticLoopHelper(void* context)
 {
@@ -597,4 +597,4 @@ std::unique_ptr<DataPointContainer> HardwareInterface::getCurrentData()
     return std::move(upData);
 }
 
-} // namespace GridCharger::Huawei
+} // namespace GridChargers::Huawei

--- a/src/gridcharger/huawei/MCP2515.cpp
+++ b/src/gridcharger/huawei/MCP2515.cpp
@@ -7,7 +7,7 @@
 #include "PinMapping.h"
 #include "Configuration.h"
 
-namespace GridCharger::Huawei {
+namespace GridChargers::Huawei {
 
 TaskHandle_t sIsrTaskHandle = nullptr;
 
@@ -143,4 +143,4 @@ bool MCP2515::sendMessage(uint32_t canId, std::array<uint8_t, 8> const& data)
     return _upCAN->sendMsgBuf(canId, 1, 8, rwData) == CAN_OK;
 }
 
-} // namespace GridCharger::Huawei
+} // namespace GridChargers::Huawei

--- a/src/gridcharger/huawei/TWAI.cpp
+++ b/src/gridcharger/huawei/TWAI.cpp
@@ -8,7 +8,7 @@
 #include "Configuration.h"
 #include <driver/twai.h>
 
-namespace GridCharger::Huawei {
+namespace GridChargers::Huawei {
 
 TWAI::~TWAI()
 {
@@ -147,4 +147,4 @@ bool TWAI::sendMessage(uint32_t canId, std::array<uint8_t, 8> const& data)
     return twai_transmit(&txMsg, pdMS_TO_TICKS(1000)) == ESP_OK;
 }
 
-} // namespace GridCharger::Huawei
+} // namespace GridChargers::Huawei


### PR DESCRIPTION
@schlimmchen while i was working at making the GridCharger implementation generic I saw that the name Huawei is still used in a lot of places and that the namespace does not work for having `GridCharger` as the single controller name that should be used across the codebase.

Feel free to drop commits if you don't want them in you PR or close this PR if you don't want to increase the scope of your PR even further.

## Copilot

This pull request refactors the `GridCharger::Huawei` namespace and related classes to use a new namespace, `GridChargers::Huawei`, and renames the `Controller` class to `Provider`. It also updates all references to these changes across multiple files to ensure consistency.

### Namespace Refactoring
* Updated the namespace from `GridCharger::Huawei` to `GridChargers::Huawei` in all relevant files, including `DataPoints.h`, `HardwareInterface.h`, `MCP2515.h`, `TWAI.h`, and others. This change ensures a consistent naming convention. [[1]](diffhunk://#diff-ce3afea3467c07e954c91414970f4ef0ee99122015f843ee3b834314c4d7b0bdL6-R6) [[2]](diffhunk://#diff-db63062cf22eabe901b32f9e335c7f4855ae7951e28a62ced39c2056123e20f4L14-R14) [[3]](diffhunk://#diff-665be31d5b8ee12935e5809db77ad81efa53f1704b3ad6fa35fd29c21aed1f73L10-R10) [[4]](diffhunk://#diff-973064a3b39c8b88124f3df2c19ab16644a6411f6929d700f772cd0b9a13c601L7-R7)

### Class Renaming
* Renamed the `Controller` class to `Provider` and updated all corresponding references in the codebase, including in `Provider.h` (formerly `Controller.h`), `MqttHandleHuawei.cpp`, `PowerLimiter.cpp`, and `WebApi_gridcharger.cpp`. This change reflects the updated role of the class. [[1]](diffhunk://#diff-af228ac42ff93092201b93b5414e38fcc118aec28672e54aa96e700c1281ea1dL12-R20) [[2]](diffhunk://#diff-08f3d3caf7a798e466514bc493c53bf577e0d30e2bd9e82975c25fc59660ae60L8-R8) [[3]](diffhunk://#diff-c502fa72d03eefad0a66ed1345a8f70eded4c8f0303ee7b38bb2a32094dbcc91L13-R13) [[4]](diffhunk://#diff-2297bc649297d26139a45ffb86f9f3e9c9161735fdf90e21b087f8fb6f3c528aL6-R6)

### Code Updates for Namespace and Class Changes
* Adjusted all method calls, type definitions, and object references to align with the new namespace and class name, such as `GridCharger` being replaced with `GridChargers` and `HuaweiCan` being replaced with `GridCharger`. [[1]](diffhunk://#diff-08f3d3caf7a798e466514bc493c53bf577e0d30e2bd9e82975c25fc59660ae60L79-R83) [[2]](diffhunk://#diff-08f3d3caf7a798e466514bc493c53bf577e0d30e2bd9e82975c25fc59660ae60L167-R168) [[3]](diffhunk://#diff-2297bc649297d26139a45ffb86f9f3e9c9161735fdf90e21b087f8fb6f3c528aL36-R36) [[4]](diffhunk://#diff-2297bc649297d26139a45ffb86f9f3e9c9161735fdf90e21b087f8fb6f3c528aL202-R204)

### File Renaming
* Renamed `Controller.h` to `Provider.h` to match the updated class name. This change ensures the file name aligns with its contained class.

### Functional Updates
* Updated all logic in `MqttHandleHuawei.cpp`, `PowerLimiter.cpp`, and `WebApi_gridcharger.cpp` to use the new `Provider` class and `GridChargers` namespace, ensuring compatibility with the refactored structure. [[1]](diffhunk://#diff-08f3d3caf7a798e466514bc493c53bf577e0d30e2bd9e82975c25fc59660ae60L106-R106) [[2]](diffhunk://#diff-c502fa72d03eefad0a66ed1345a8f70eded4c8f0303ee7b38bb2a32094dbcc91L676-R676) [[3]](diffhunk://#diff-2297bc649297d26139a45ffb86f9f3e9c9161735fdf90e21b087f8fb6f3c528aL220-R220)