### PR TITLE
Improvement: Add DPL settings HASS autodiscovery

### DIFF
--- a/src/MqttHandlePowerLimiterHass.cpp
+++ b/src/MqttHandlePowerLimiterHass.cpp
@@ -64,7 +64,7 @@ void MqttHandlePowerLimiterHassClass::publishConfig()
     }
 
     publishSelect("DPL Mode", "mdi:gauge", "config", "mode", "mode");
-    publishNumber("Upper Power Limit", "mdi:speedometer", "config", "upper_power_limit", "upper_power_limit", "W", 0, 32767, 1);
+    publishNumber("Total Upper Power Limit", "mdi:speedometer", "config", "upper_power_limit", "upper_power_limit", "W", 0, 32767, 1);
     publishNumber("Target Power Consumption", "mdi:target", "config", "target_power_consumption", "target_power_consumption", "W", -32768, 32767, 1);
 
     if (!PowerLimiter.usesBatteryPoweredInverter()) {

--- a/src/MqttHandlePowerLimiterHass.cpp
+++ b/src/MqttHandlePowerLimiterHass.cpp
@@ -64,6 +64,8 @@ void MqttHandlePowerLimiterHassClass::publishConfig()
     }
 
     publishSelect("DPL Mode", "mdi:gauge", "config", "mode", "mode");
+    publishNumber("Upper Power Limit", "mdi:speedometer", "config", "upper_power_limit", "upper_power_limit", "W", 0, 32767, 1);
+    publishNumber("Target Power Consumption", "mdi:target", "config", "target_power_consumption", "target_power_consumption", "W", -32768, 32767, 1);
 
     if (!PowerLimiter.usesBatteryPoweredInverter()) {
         return;


### PR DESCRIPTION
Fixing that UpperPowerLimit and TargetPowerConsumption are available via MQTT, but not auto discovered by Home Assistant.
see https://github.com/hoylabs/OpenDTU-OnBattery/issues/1178

So kann man durch eine einfache Home Assistant Automatisation das Target Tagsüber z.B. auf -400W setzen und nachts auf 0W damit nicht zu viel vom Akku eingespeist wird