### PR TITLE
Fix:  get only the first off reason as readable text.

### DIFF
--- a/lib/VeDirectFrameHandler/VeDirectData.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectData.cpp
@@ -289,7 +289,9 @@ frozen::string const& veMpptStruct::getErrAsString() const
 }
 
 /*
- * This function returns the off reason (OR) as readable text.
+ * This function returns the first off reason (OR) as readable text.
+ * Further off reasons are not handled as readable text.
+ * For further information, please refer to the logging. Search for "Text Data 'OR' = "
  */
 frozen::string const& veMpptStruct::getOrAsString() const
 {
@@ -306,7 +308,12 @@ frozen::string const& veMpptStruct::getOrAsString() const
 		{ 0x00000100, "Analysing input voltage" }
 	};
 
-	return getAsString(values, offReason_OR);
+    for (uint32_t bitCheck = 0x00000001; bitCheck <= values.rbegin()->first; bitCheck = bitCheck<<1 ) {
+        if ((offReason_OR & bitCheck) != 0) {
+            return getAsString(values, bitCheck);
+        }
+    }
+	return getAsString(values, offReason_OR); // in case of 0x00000000 or not found
 }
 
 frozen::string const& VeDirectHexData::getResponseAsString() const


### PR DESCRIPTION
Fix of #1945 
Life view will display "???" in case of multiple off reasons.

Tested with combination with:

- At night, No sun energy, OR = 0x00000001
- Charger off, Done with Victron app, OR = 0x00000004

Result:
[VE.Direct MPPT 11/12] Text Data 'OR' = '0X00000005'

Life view:
![grafik](https://github.com/user-attachments/assets/85cf1a15-6728-4d96-a857-d5071283d436)


