### PR TITLE
Fix: DPL: output threshold 80% up to including 16% limit

### DIFF
--- a/src/PowerLimiterOverscalingInverter.cpp
+++ b/src/PowerLimiterOverscalingInverter.cpp
@@ -12,9 +12,9 @@ float PowerLimiterOverscalingInverter::calculateRequiredOutputThreshold(uint16_t
     // above 15% we can apply our simple 97% percent rule
     float threshold = 0.97;
 
-    // if the limit is 15% or below, we use a lower threshold
+    // if the limit is 16% or below, we use a lower threshold
     // of 80% to compensate for the lower efficiency at low power.
-    if (limitWatts <= getInverterMaxPowerWatts() * 0.15) {
+    if (limitWatts <= getInverterMaxPowerWatts() * 0.16) {
         threshold = 0.8;
     }
 


### PR DESCRIPTION
This pull request includes a minor adjustment to the power threshold calculation logic in the `PowerLimiterOverscalingInverter` class. The change slightly increases the power limit threshold for applying a lower efficiency compensation.

* [`src/PowerLimiterOverscalingInverter.cpp`](diffhunk://#diff-ad1d906f31f8c639a53393ae13fd7cf0f7cf653e4d462a2a422d7de7d08eeee1L12-R14): Updated the condition to use a limit of 16% (previously 15%) of the inverter's maximum power for applying the lower threshold of 80%, ensuring better alignment with efficiency considerations at low power.