### PR TITLE
Fix: Stack canary watchpoint triggered (PM:HTTP+JSON)

### DIFF
--- a/src/powermeter/json/http/Provider.cpp
+++ b/src/powermeter/json/http/Provider.cpp
@@ -64,7 +64,7 @@ void Provider::loop()
     _stopPolling = false;
     lock.unlock();
 
-    uint32_t constexpr stackSize = 3072;
+    uint32_t constexpr stackSize = 4096;
     xTaskCreate(Provider::pollingLoopHelper, "PM:HTTP+JSON",
             stackSize, this, 1/*prio*/, &_taskHandle);
 }


### PR DESCRIPTION
Fix #1989 

Increase stack size from 3k to 4k.
Tests done with 2 active power meter (HTTP-JSON)

![grafik](https://github.com/user-attachments/assets/a0380a40-727c-4afb-be18-ab65a2c30317)

