### PR TITLE
webapp: fix: return log level for more than 5 modules

### DIFF
--- a/src/WebApi_logging.cpp
+++ b/src/WebApi_logging.cpp
@@ -42,7 +42,7 @@ void WebApiLoggingClass::onLoggingAdminGet(AsyncWebServerRequest* request)
 
         int8_t idx = Configuration.getIndexForLogModule(availModule);
         // Set to inherit if unknown
-        logModule["level"] = idx < 0 || idx > ESP_LOG_VERBOSE ? -1 : config.Logging.Modules[idx].Level;
+        logModule["level"] = idx < 0 || idx >= LOG_MODULE_COUNT ? -1 : config.Logging.Modules[idx].Level;
     }
 
     WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);


### PR DESCRIPTION
@tbnobody you might want to cherry pick this

This pull request includes a minor but important bug fix in the `WebApiLoggingClass::onLoggingAdminGet` method to ensure proper bounds checking for log module levels.

### Bug fix:
* [`src/WebApi_logging.cpp`](diffhunk://#diff-6b60c65749605006f05e8539fddeb5edea310c95d841db31a2f5e6231b3bddeeL45-R45): Updated the condition for determining the logging level to use `LOG_MODULE_COUNT` instead of `ESP_LOG_VERBOSE` for proper bounds checking. This ensures the index does not exceed the actual number of log modules.