### PR TITLE
fix: R48xx: increase stack size to prevent crashes

### DIFF
--- a/src/gridcharger/huawei/HardwareInterface.cpp
+++ b/src/gridcharger/huawei/HardwareInterface.cpp
@@ -33,7 +33,7 @@ void HardwareInterface::staticLoopHelper(void* context)
 
 bool HardwareInterface::startLoop()
 {
-    uint32_t constexpr stackSize = 3072;
+    uint32_t constexpr stackSize = 4096;
     return pdPASS == xTaskCreate(HardwareInterface::staticLoopHelper,
             "HuaweiHwIfc", stackSize, this, 16/*prio*/, &_taskHandle);
 }

--- a/src/gridcharger/huawei/MCP2515.cpp
+++ b/src/gridcharger/huawei/MCP2515.cpp
@@ -109,7 +109,7 @@ bool MCP2515::init()
         return false;
     }
 
-    uint32_t constexpr stackSize = 1536;
+    uint32_t constexpr stackSize = 2048;
     if (pdPASS != xTaskCreate(MCP2515::queueMessages,
             "HuaweiMCP2515", stackSize, this, 20/*prio*/, &sIsrTaskHandle)) {
         DTU_LOGE("failed to create queueing task");

--- a/src/gridcharger/huawei/TWAI.cpp
+++ b/src/gridcharger/huawei/TWAI.cpp
@@ -84,7 +84,7 @@ bool TWAI::init()
         return false;
     }
 
-    uint32_t constexpr stackSize = 1536;
+    uint32_t constexpr stackSize = 2048;
     return pdPASS == xTaskCreate(TWAI::pollAlerts,
             "HuaweiTwai", stackSize, this, 20/*prio*/, &_pollingTaskHandle);
 


### PR DESCRIPTION
This pull request increases the stack size for two tasks in the Huawei grid charger codebase to ensure sufficient memory allocation and prevent potential stack overflows.

Changes to task stack sizes:

* [`src/gridcharger/huawei/HardwareInterface.cpp`](diffhunk://#diff-17b69bac303c91a8af26dbe3de3aa3a0289e743b1206cf834537a23268e5874fL36-R36): Increased the stack size for the `HardwareInterface::staticLoopHelper` task from 3072 to 4096.
* [`src/gridcharger/huawei/MCP2515.cpp`](diffhunk://#diff-9998eaad13ddfe7d18ae615693235abd43a98bf5fe5167c5c7702dec69004a89L112-R112): Increased the stack size for the `MCP2515::queueMessages` task from 1536 to 2048.