### PR TITLE
Fix: DPL: really ignore hysteresis when inverter should be shutdown

### DIFF
--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -620,10 +620,14 @@ uint16_t PowerLimiterClass::updateInverterLimits(uint16_t powerRequested,
             powerRequested, matchingInverters.size(), filterExpression.c_str(),
             (plural?"s":""), producing, diff, hysteresis);
 
-    // if 0 W are requested, we ignore the hysteresis to allow
-    // battery-powered inverters to go into standby and avoid that the battery
-    // gets fully discharged.
-    if (powerRequested != 0 && std::abs(diff) < static_cast<int32_t>(hysteresis)) { return producing; }
+    // if 0 W are requested, we set hysteresis to 0 to basically ignore it
+    // which allows battery-powered inverters to go into standby and avoid
+    // that the battery gets fully discharged.
+    if (powerRequested == 0) {
+        hysteresis = 0;
+    }
+
+    if (std::abs(diff) < static_cast<int32_t>(hysteresis)) { return producing; }
 
     uint16_t covered = 0;
 


### PR DESCRIPTION
In https://github.com/hoylabs/OpenDTU-OnBattery/pull/1818, which was my previous attempt to fix this issue, i overlooked that hysteresis is used on line 651 to check if the new inverter limit should actually be set... with this fix i set hysteresis to 0 when inverters should be shutdown.