### PR TITLE
Fix: make getDischargeCurrentLimit() return the configuredLimit even when no BMS is setup

### DIFF
--- a/src/battery/Controller.cpp
+++ b/src/battery/Controller.cpp
@@ -132,10 +132,10 @@ float Controller::getDischargeCurrentLimit()
         }
 
         bool voltageValid = spStats->getVoltageAgeSeconds() <= 60;
-        if (!voltageValid) { return FLT_MAX; }
-
-        auto threshold = config.Battery.DischargeCurrentLimitBelowVoltage;
-        if (spStats->getVoltage() >= threshold) { return FLT_MAX; }
+        if (voltageValid) {
+            auto threshold = config.Battery.DischargeCurrentLimitBelowVoltage;
+            if (spStats->getVoltage() >= threshold) { return FLT_MAX; }
+        }
 
         return configuredLimit;
     };


### PR DESCRIPTION
In #2051 we discovered that the configured discharge current limit is not applied when BMS data is not available.

This pull request modifies the logic in the `getDischargeCurrentLimit` method of the `Controller` class to improve the handling of voltage validity checks.

### Logic improvement in voltage validity check:

* [`src/battery/Controller.cpp`](diffhunk://#diff-8f004d1f603f67e6b49d15dd7410841921ae136e277a7e21a78afe578ed9b465L135-R138): Adjusted the conditional structure for `voltageValid` to ensure that the discharge current limit is only checked when the voltage is valid, improving code clarity and correctness.