### PR TITLE
Improvement: Battery: unify charge current limit handling across providers

### DIFF
--- a/include/battery/Stats.h
+++ b/include/battery/Stats.h
@@ -32,6 +32,9 @@ public:
     float getDischargeCurrentLimit() const { return _dischargeCurrentLimit; };
     uint32_t getDischargeCurrentLimitAgeSeconds() const { return (millis() - _lastUpdateDischargeCurrentLimit) / 1000; }
 
+    float getChargeCurrentLimit() const { return _chargeCurrentLimit; };
+    uint32_t getChargeCurrentLimitAgeSeconds() const { return (millis() - _lastUpdateChargeCurrentLimit) / 1000; }
+
     // convert stats to JSON for web application live view
     virtual void getLiveViewData(JsonVariant& root) const;
 
@@ -45,12 +48,11 @@ public:
     bool isVoltageValid() const { return _lastUpdateVoltage > 0; }
     bool isCurrentValid() const { return _lastUpdateCurrent > 0; }
     bool isDischargeCurrentLimitValid() const { return _lastUpdateDischargeCurrentLimit > 0; }
+    bool isChargeCurrentLimitValid() const { return _lastUpdateChargeCurrentLimit > 0; }
 
     // returns true if the battery reached a critically low voltage/SoC,
     // such that it is in need of charging to prevent degredation.
     virtual bool getImmediateChargingRequest() const { return false; };
-
-    virtual float getChargeCurrentLimitation() const { return FLT_MAX; };
 
     virtual bool supportsAlarmsAndWarnings() const { return true; };
 
@@ -77,6 +79,11 @@ protected:
     void setDischargeCurrentLimit(float dischargeCurrentLimit, uint32_t timestamp) {
         _dischargeCurrentLimit = dischargeCurrentLimit;
         _lastUpdateDischargeCurrentLimit = _lastUpdate = timestamp;
+    }
+
+    void setChargeCurrentLimit(float chargeCurrentLimit, uint32_t timestamp) {
+        _chargeCurrentLimit = chargeCurrentLimit;
+        _lastUpdateChargeCurrentLimit = _lastUpdate = timestamp;
     }
 
     void setManufacturer(const String& m);
@@ -180,6 +187,8 @@ private:
 
     float _dischargeCurrentLimit = 0;
     uint32_t _lastUpdateDischargeCurrentLimit = 0;
+    float _chargeCurrentLimit = FLT_MAX;
+    uint32_t _lastUpdateChargeCurrentLimit = 0;
 };
 
 } // namespace Batteries

--- a/include/battery/pylontech/Stats.h
+++ b/include/battery/pylontech/Stats.h
@@ -12,13 +12,11 @@ public:
     void getLiveViewData(JsonVariant& root) const final;
     void mqttPublish() const final;
     bool getImmediateChargingRequest() const { return _chargeImmediately; } ;
-    float getChargeCurrentLimitation() const { return _chargeCurrentLimitation; } ;
 
 private:
     void setLastUpdate(uint32_t ts) { _lastUpdate = ts; }
 
     float _chargeVoltage;
-    float _chargeCurrentLimitation;
     float _dischargeVoltageLimitation;
     uint16_t _stateOfHealth;
     float _temperature;

--- a/include/battery/pytes/Stats.h
+++ b/include/battery/pytes/Stats.h
@@ -12,7 +12,6 @@ public:
     void getLiveViewData(JsonVariant& root) const final;
     void mqttPublish() const final;
     bool getImmediateChargingRequest() const { return _chargeImmediately; };
-    float getChargeCurrentLimitation() const { return _chargeCurrentLimit; };
 
 private:
     void setLastUpdate(uint32_t ts) { _lastUpdate = ts; }
@@ -26,7 +25,6 @@ private:
     String _serialPart2 = "";
 
     float _chargeVoltageLimit;
-    float _chargeCurrentLimit;
     float _dischargeVoltageLimit;
 
     uint16_t _stateOfHealth;

--- a/include/battery/sbs/Stats.h
+++ b/include/battery/sbs/Stats.h
@@ -11,13 +11,11 @@ friend class Provider;
 public:
     void getLiveViewData(JsonVariant& root) const final;
     void mqttPublish() const final;
-    float getChargeCurrentLimitation() const { return _chargeCurrentLimitation; } ;
 
 private:
     void setLastUpdate(uint32_t ts) { _lastUpdate = ts; }
 
     float _chargeVoltage;
-    float _chargeCurrentLimitation;
     uint16_t _stateOfHealth;
     float _temperature;
 

--- a/src/battery/Stats.cpp
+++ b/src/battery/Stats.cpp
@@ -60,6 +60,10 @@ void Stats::getLiveViewData(JsonVariant& root) const
         addLiveViewValue(root, "dischargeCurrentLimitation", _dischargeCurrentLimit, "A", 1);
     }
 
+    if (isChargeCurrentLimitValid()) {
+        addLiveViewValue(root, "chargeCurrentLimitation", _chargeCurrentLimit, "A", 1);
+    }
+
     root["showIssues"] = supportsAlarmsAndWarnings();
 }
 
@@ -110,6 +114,10 @@ void Stats::mqttPublish() const
 
     if (isDischargeCurrentLimitValid()) {
         MqttSettings.publish("battery/settings/dischargeCurrentLimitation", String(_dischargeCurrentLimit));
+    }
+
+    if (isChargeCurrentLimitValid()) {
+        MqttSettings.publish("battery/settings/chargeCurrentLimitation", String(_chargeCurrentLimit));
     }
 }
 

--- a/src/battery/pylontech/Provider.cpp
+++ b/src/battery/pylontech/Provider.cpp
@@ -23,13 +23,13 @@ void Provider::onMessage(twai_message_t rx_message)
     switch (rx_message.identifier) {
         case 0x351: {
             _stats->_chargeVoltage = this->scaleValue(this->readUnsignedInt16(rx_message.data), 0.1);
-            _stats->_chargeCurrentLimitation = this->scaleValue(this->readSignedInt16(rx_message.data + 2), 0.1);
+            _stats->setChargeCurrentLimit(this->scaleValue(this->readSignedInt16(rx_message.data + 2), 0.1), millis());
             _stats->setDischargeCurrentLimit(this->scaleValue(this->readSignedInt16(rx_message.data + 4), 0.1), millis());
             _stats->_dischargeVoltageLimitation = this->scaleValue(this->readUnsignedInt16(rx_message.data + 6), 0.1);
 
             DTU_LOGD("chargeVoltage: %f chargeCurrentLimitation: %f "
                     "dischargeCurrentLimitation: %f dischargeVoltageLimitation: %f",
-                    _stats->_chargeVoltage, _stats->_chargeCurrentLimitation,
+                    _stats->_chargeVoltage, _stats->getChargeCurrentLimit(),
                     _stats->getDischargeCurrentLimit(), _stats->_dischargeVoltageLimitation);
             break;
         }
@@ -152,7 +152,7 @@ void Provider::dummyData()
     _stats->setManufacturer("Pylontech US3000C");
     _stats->setSoC(42, 0/*precision*/, millis());
     _stats->_chargeVoltage = dummyFloat(50);
-    _stats->_chargeCurrentLimitation = dummyFloat(33);
+    _stats->setChargeCurrentLimit(dummyFloat(33), millis());
     _stats->setDischargeCurrentLimit(dummyFloat(12), millis());
     _stats->_dischargeVoltageLimitation = dummyFloat(46);
     _stats->_stateOfHealth = 99;

--- a/src/battery/pylontech/Stats.cpp
+++ b/src/battery/pylontech/Stats.cpp
@@ -10,7 +10,6 @@ void Stats::getLiveViewData(JsonVariant& root) const
 
     // values go into the "Status" card of the web application
     addLiveViewValue(root, "chargeVoltage", _chargeVoltage, "V", 1);
-    addLiveViewValue(root, "chargeCurrentLimitation", _chargeCurrentLimitation, "A", 1);
     addLiveViewValue(root, "dischargeVoltageLimitation", _dischargeVoltageLimitation, "V", 1);
     addLiveViewValue(root, "stateOfHealth", _stateOfHealth, "%", 0);
     addLiveViewValue(root, "temperature", _temperature, "°C", 1);
@@ -48,7 +47,6 @@ void Stats::mqttPublish() const
     ::Batteries::Stats::mqttPublish();
 
     MqttSettings.publish("battery/settings/chargeVoltage", String(_chargeVoltage));
-    MqttSettings.publish("battery/settings/chargeCurrentLimitation", String(_chargeCurrentLimitation));
     MqttSettings.publish("battery/settings/dischargeVoltageLimitation", String(_dischargeVoltageLimitation));
     MqttSettings.publish("battery/stateOfHealth", String(_stateOfHealth));
     MqttSettings.publish("battery/temperature", String(_temperature));

--- a/src/battery/pytes/Provider.cpp
+++ b/src/battery/pytes/Provider.cpp
@@ -38,13 +38,13 @@ void Provider::onMessage(twai_message_t rx_message)
         case 0x351:
         case 0x400: {
             _stats->_chargeVoltageLimit = this->scaleValue(this->readUnsignedInt16(rx_message.data), 0.1);
-            _stats->_chargeCurrentLimit = this->scaleValue(this->readUnsignedInt16(rx_message.data + 2), 0.1);
+            _stats->setChargeCurrentLimit(this->scaleValue(this->readUnsignedInt16(rx_message.data + 2), 0.1), millis());
             _stats->setDischargeCurrentLimit(this->scaleValue(this->readUnsignedInt16(rx_message.data + 4), 0.1), millis());
             _stats->_dischargeVoltageLimit = this->scaleValue(this->readSignedInt16(rx_message.data + 6), 0.1);
 
             DTU_LOGD("chargeVoltageLimit: %f chargeCurrentLimit: "
                     "%f dischargeCurrentLimit: %f dischargeVoltageLimit: %f",
-                    _stats->_chargeVoltageLimit, _stats->_chargeCurrentLimit,
+                    _stats->_chargeVoltageLimit, _stats->getChargeCurrentLimit(),
                     _stats->getDischargeCurrentLimit(), _stats->_dischargeVoltageLimit);
             break;
         }

--- a/src/battery/pytes/Stats.cpp
+++ b/src/battery/pytes/Stats.cpp
@@ -10,7 +10,6 @@ void Stats::getLiveViewData(JsonVariant& root) const
 
     // values go into the "Status" card of the web application
     addLiveViewValue(root, "chargeVoltage", _chargeVoltageLimit, "V", 1);
-    addLiveViewValue(root, "chargeCurrentLimitation", _chargeCurrentLimit, "A", 1);
     addLiveViewValue(root, "dischargeVoltageLimitation", _dischargeVoltageLimit, "V", 1);
     addLiveViewValue(root, "stateOfHealth", _stateOfHealth, "%", 0);
     if (_chargeCycles != -1) {
@@ -87,7 +86,6 @@ void Stats::mqttPublish() const
     ::Batteries::Stats::mqttPublish();
 
     MqttSettings.publish("battery/settings/chargeVoltage", String(_chargeVoltageLimit));
-    MqttSettings.publish("battery/settings/chargeCurrentLimitation", String(_chargeCurrentLimit));
     MqttSettings.publish("battery/settings/dischargeVoltageLimitation", String(_dischargeVoltageLimit));
 
     MqttSettings.publish("battery/stateOfHealth", String(_stateOfHealth));

--- a/src/battery/sbs/Provider.cpp
+++ b/src/battery/sbs/Provider.cpp
@@ -79,11 +79,11 @@ void Provider::onMessage(twai_message_t rx_message)
         }
 
         case 0x640: {
-            _stats->_chargeCurrentLimitation = (this->readSignedInt24(rx_message.data + 3) * 0.001);
+            _stats->setChargeCurrentLimit(this->readSignedInt24(rx_message.data + 3) * 0.001, millis());
             _stats->setDischargeCurrentLimit(this->readSignedInt24(rx_message.data) * 0.001, millis());
 
             DTU_LOGD("1600 Currents  %f, %f",
-                    _stats->_chargeCurrentLimitation, _stats->getDischargeCurrentLimit());
+                    _stats->getChargeCurrentLimit(), _stats->getDischargeCurrentLimit());
             break;
         }
 
@@ -145,7 +145,7 @@ void Provider::dummyData()
     _stats->setManufacturer("SBS Unipower XL");
     _stats->setSoC(42, 0/*precision*/, millis());
     _stats->_chargeVoltage = dummyFloat(50);
-    _stats->_chargeCurrentLimitation = dummyFloat(33);
+    _stats->setChargeCurrentLimit(dummyFloat(33), millis());
     _stats->setDischargeCurrentLimit(dummyFloat(12), millis());
     _stats->_stateOfHealth = 99;
     _stats->setVoltage(48.67, millis());

--- a/src/battery/sbs/Stats.cpp
+++ b/src/battery/sbs/Stats.cpp
@@ -10,7 +10,6 @@ void Stats::getLiveViewData(JsonVariant& root) const
 
     // values go into the "Status" card of the web application
     addLiveViewValue(root, "chargeVoltage", _chargeVoltage, "V", 1);
-    addLiveViewValue(root, "chargeCurrentLimitation", _chargeCurrentLimitation, "A", 1);
     addLiveViewValue(root, "stateOfHealth", _stateOfHealth, "%", 0);
     addLiveViewValue(root, "temperature", _temperature, "°C", 1);
     addLiveViewTextValue(root, "chargeEnabled", (_chargeEnabled?"yes":"no"));
@@ -31,7 +30,6 @@ void Stats::mqttPublish() const
     ::Batteries::Stats::mqttPublish();
 
     MqttSettings.publish("battery/settings/chargeVoltage", String(_chargeVoltage));
-    MqttSettings.publish("battery/settings/chargeCurrentLimitation", String(_chargeCurrentLimitation));
     MqttSettings.publish("battery/stateOfHealth", String(_stateOfHealth));
     MqttSettings.publish("battery/temperature", String(_temperature));
     MqttSettings.publish("battery/alarm/underVoltage", String(_alarmUnderVoltage));

--- a/src/gridcharger/huawei/Controller.cpp
+++ b/src/gridcharger/huawei/Controller.cpp
@@ -259,7 +259,7 @@ void Controller::loop()
                 float calculatedCurrent = efficiency * (newPowerLimit / *oOutputVoltage);
 
                 // Limit output current to value requested by BMS
-                float permissableCurrent = stats->getChargeCurrentLimitation() - (stats->getChargeCurrent() - *oOutputCurrent); // BMS current limit - current from other sources, e.g. Victron MPPT charger
+                float permissableCurrent = stats->getChargeCurrentLimit() - (stats->getChargeCurrent() - *oOutputCurrent); // BMS current limit - current from other sources, e.g. Victron MPPT charger
                 float outputCurrent = std::min(calculatedCurrent, permissableCurrent);
                 outputCurrent= outputCurrent > 0 ? outputCurrent : 0;
 


### PR DESCRIPTION
Extracted from #1658 

This pull request introduces changes to the battery management system codebase, primarily focusing on replacing the `getChargeCurrentLimitation` method and `_chargeCurrentLimitation` member with `getChargeCurrentLimit` and `_chargeCurrentLimit`. This refactor improves consistency across the codebase and enhances functionality by adding timestamp tracking for charge current limits. The most important changes are grouped by theme below.

### Core Functionality Enhancements:
* Added `getChargeCurrentLimit` and `getChargeCurrentLimitAgeSeconds` methods to the `Stats` class for retrieving charge current limits and their age.
* Introduced `setChargeCurrentLimit` method in the `Stats` class to update charge current limits with timestamps.
* Replaced `_chargeCurrentLimitation` with `_chargeCurrentLimit` in the `Stats` class, including initialization to `FLT_MAX`.

### Code Refactoring:
* Removed `getChargeCurrentLimitation` method and `_chargeCurrentLimitation` member across multiple battery-specific `Stats` classes (`pylontech`, `pytes`, `sbs`). [[1]](diffhunk://#diff-da9ed4119c531e0ba59a37785457a354dbc6af59772d93bbfaf67671d08fdd59L15-L21) [[2]](diffhunk://#diff-d6e94e8059e945b1af68981a0a4486cf4b76331b2b6a85d1d298584bc976e6abL15) [[3]](diffhunk://#diff-9f00fd11bf4f85c89324bd5ca4f29aeba90c4c68f2e1c612fb8f2ddc57a4e796L14-L20)
* Updated references to `_chargeCurrentLimitation` in provider classes to use `setChargeCurrentLimit` and `getChargeCurrentLimit`. [[1]](diffhunk://#diff-b8a970da82fff5970acb9518cad32876ac534020293535bcfc6f6aeafaab3435L26-R32) [[2]](diffhunk://#diff-ca135c62c8ecb5c0cf0a8d68ee34c7b7ba9c6b8ade4f87a2811316b20913baf1L41-R47) [[3]](diffhunk://#diff-07a691f0c05fd672ac35cee0b1a7b1f8150f1c29dedee28179f2c2c055a6fe0cL82-R86)

### Live View and MQTT Publishing Updates:
* Modified `getLiveViewData` and `mqttPublish` methods in various `Stats` classes to use `_chargeCurrentLimit` instead of `_chargeCurrentLimitation`. [[1]](diffhunk://#diff-750be5db5e20d78d439c4b82a75ee2bc96811ef17bf4fc67755e51918bc8dcdbR63-R66) [[2]](diffhunk://#diff-750be5db5e20d78d439c4b82a75ee2bc96811ef17bf4fc67755e51918bc8dcdbR118-R121) [[3]](diffhunk://#diff-e879c5619cfccfa4786f758d3581bcf103ad1124dd6b824647fa2fe328d5df9eL13) [[4]](diffhunk://#diff-b1deb70587b50b8526ff7c1df310bbe810a78448b2759149851b4e17fec6455dL13) [[5]](diffhunk://#diff-a81d1e3ceb672679a236ef16a316b03df85eb3c9c129332e172b7153c9d03bf1L13)

### Grid Charger Integration:
* Updated `Controller::loop` logic to use `getChargeCurrentLimit` for calculating permissible current, replacing `getChargeCurrentLimitation`.

These changes collectively enhance the codebase by improving clarity, consistency, and functionality, while ensuring compatibility across different battery management system components.