### PR TITLE
Fix: remove duplicated square brackets from VE.Direct log messages

### DIFF
--- a/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
+++ b/lib/VeDirectFrameHandler/VeDirectFrameHandler.cpp
@@ -71,7 +71,7 @@ void VeDirectFrameHandler<T>::init(char const* who, gpio_num_t rx, gpio_num_t tx
 	_debugIn = 0;
 	_startUpPassed = false; // to obtain a complete dataset after a new start or restart
 	_dataValid = false;     // data is not valid on start or restart
-	snprintf(_logId, sizeof(_logId), "[%s %d/%d]", who, rx, tx);
+	snprintf(_logId, sizeof(_logId), "%s %d/%d", who, rx, tx);
 	DTU_LOGI("init complete");
 }
 


### PR DESCRIPTION
Was:

```
D (87704) veDirect: [[MPPT 10/9]] Text Data 'FW' = '164'
```

Now:

```
D (87704) veDirect: [MPPT 10/9] Text Data 'FW' = '164'
```

That's because the SUBTAG is already enclosed in square brackets.