### PR TITLE
Feature: Zendure: Add support for AB1000S

### DIFF
--- a/include/battery/zendure/Stats.h
+++ b/include/battery/zendure/Stats.h
@@ -280,6 +280,9 @@ class PackStats {
                 if (serial.startsWith("AO4H")) {
                     return std::make_shared<PackStats>(PackStats(serial, "AB1000", 960));
                 }
+                if (serial.startsWith("BO4N")) {
+                    return std::make_shared<PackStats>(PackStats(serial, "AB1000S", 960));
+                }
                 if (serial.startsWith("CO4H")) {
                     return std::make_shared<PackStats>(PackStats(serial, "AB2000", 1920));
                 }


### PR DESCRIPTION
Added serial number of AB1000S to battery detection - closes #2157 