### PR TITLE
SolarCharger: MQTT: accept negative values for output_current and output_power

### DIFF
--- a/include/solarcharger/Stats.h
+++ b/include/solarcharger/Stats.h
@@ -11,7 +11,9 @@ public:
     // the last time *any* data was updated
     virtual uint32_t getAgeMillis() const;
 
-    // total output of all MPPT charge controllers in Watts
+    // Total output of all MPPT charge controllers in Watts.
+    // This value can be negative if a charge controller with a load output is used
+    // and the load is consuming more power than the charge controller is producing.
     virtual std::optional<float> getOutputPowerWatts() const;
 
     // minimum of all MPPT charge controllers' output voltages in V

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -761,8 +761,8 @@ uint16_t PowerLimiterClass::getSolarPassthroughPower() const
 
     std::optional<float> oSolarChargerOutput = SolarCharger.getStats()->getOutputPowerWatts();
 
-    // do not trust this value to be positive. in particular, the MQTT solar
-    // provider happily processes negative values as well.
+    // This value can be negative if a charge controller with a load output is used
+    // and the load is consuming more power than the charge controller is producing.
     return std::max<float>(0, oSolarChargerOutput.value_or(0));
 }
 

--- a/src/solarcharger/mqtt/Provider.cpp
+++ b/src/solarcharger/mqtt/Provider.cpp
@@ -109,11 +109,6 @@ void Provider::onMqttMessageOutputPower(espMqttClientTypes::MessageProperties co
             break;
     }
 
-    if (*outputPower < 0) {
-        DTU_LOGW("Implausible output_power '%.1f' in topic '%s'", *outputPower, topic);
-        return;
-    }
-
     _stats->setOutputPowerWatts(*outputPower);
 
     DTU_LOGD("Updated output_power to %.1f from '%s'", *outputPower, topic);
@@ -179,11 +174,6 @@ void Provider::onMqttMessageOutputCurrent(espMqttClientTypes::MessageProperties 
     }
 
     _stats->setOutputCurrent(*outputCurrent);
-
-    if (*outputCurrent < 0) {
-        DTU_LOGW("Implausible output_current '%.2f' in topic '%s'", *outputCurrent, topic);
-        return;
-    }
 
     DTU_LOGD("Updated output_current to %.2f from '%s'", *outputCurrent, topic);
 }


### PR DESCRIPTION
Due to the load-output on solar chargers like the Victron 100/20 it is possible that the output_current and output_power are negative.

As discovered in https://github.com/hoylabs/OpenDTU-OnBattery/discussions/2139