### PR TITLE
DPL: Full-Solar-Passthrough: Respect DC loads

### DIFF
--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -95,9 +95,13 @@ private:
     uint16_t updateInverterLimits(uint16_t powerRequested, inverter_filter_t filter, std::string const& filterExpression);
     uint16_t calcPowerBusUsage(uint16_t powerRequested) const;
     bool updateInverters();
+
+    uint16_t getSolarOutputPower() const;
     uint16_t getSolarPassthroughPower() const;
+
     std::optional<uint16_t> getBatteryDischargeLimit() const;
     float getBatteryInvertersOutputAcWatts() const;
+    float getBatteryInvertersInputDcWatts() const;
 
     bool testThreshold(float socThreshold, float voltThreshold,
             std::function<bool(float, float)> compare) const;

--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -97,11 +97,10 @@ private:
     bool updateInverters();
 
     uint16_t getSolarOutputPower() const;
-    uint16_t getSolarPassthroughPower() const;
-
     std::optional<uint16_t> getBatteryDischargeLimit() const;
     float getBatteryInvertersOutputAcWatts() const;
-    float getBatteryInvertersInputDcWatts() const;
+    float getBatteryInvertersInputDcWatts() const;;
+    uint16_t getDcLoadsPowerDc() const;
 
     bool testThreshold(float socThreshold, float voltThreshold,
             std::function<bool(float, float)> compare) const;

--- a/include/PowerLimiterInverter.h
+++ b/include/PowerLimiterInverter.h
@@ -68,6 +68,7 @@ public:
 
     float getGridVoltage() const;
     float getDcVoltage(uint8_t input);
+    float getCurrentDcInputWatts() const;
     bool isSendingCommandsEnabled() const { return _spInverter->getEnableCommands(); }
     bool isReachable() const { return _spInverter->isReachable(); }
     bool isProducing() const { return _spInverter->isProducing(); }

--- a/include/battery/Stats.h
+++ b/include/battery/Stats.h
@@ -28,6 +28,7 @@ public:
 
     float getChargeCurrent() const { return _current; };
     uint8_t getChargeCurrentPrecision() const { return _currentPrecision; }
+    uint32_t getChargeCurrentAgeSeconds() const { return (millis() - _lastUpdateCurrent) / 1000; }
 
     float getDischargeCurrentLimit() const { return _dischargeCurrentLimit; };
     uint32_t getDischargeCurrentLimitAgeSeconds() const { return (millis() - _lastUpdateDischargeCurrentLimit) / 1000; }

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -750,32 +750,38 @@ uint16_t PowerLimiterClass::calcPowerBusUsage(uint16_t powerRequested) const
         return 0;
     }
 
-    auto solarPassthroughPowerDc = getSolarPassthroughPower();
-    auto solarPassthroughPowerAc = dcPowerBusToInverterAc(solarPassthroughPowerDc);
-    if (isFullSolarPassthroughActive() && solarPassthroughPowerAc > powerRequested) {
-        DTU_LOGD("using %u/%u W DC/AC from DC power bus (full solar-passthrough)",
-                solarPassthroughPowerDc, solarPassthroughPowerAc);
-
-        return solarPassthroughPowerAc;
-    }
 
     auto solarOutputDc = getSolarOutputPower();
     auto solarOutputAc = dcPowerBusToInverterAc(solarOutputDc);
 
+    auto dcLoadsPowerDc = getDcLoadsPowerDc();
+    auto solarPassthroughPowerDc = solarOutputDc - dcLoadsPowerDc;
+    auto solarPassthroughPowerAc = dcPowerBusToInverterAc(solarPassthroughPowerDc);
+    if (isFullSolarPassthroughActive() && solarPassthroughPowerAc > powerRequested) {
+        DTU_LOGD("using %u/%u W DC/AC from DC power bus, solar power is %u/%u W DC/AC, "
+                 "dc loads are %u W DC (full solar-passthrough)",
+                solarPassthroughPowerDc, solarPassthroughPowerAc,
+                solarOutputDc, solarOutputAc,
+                dcLoadsPowerDc);
+
+        return solarPassthroughPowerAc;
+    }
+
     auto oBatteryDischargeLimit = getBatteryDischargeLimit();
     if (!oBatteryDischargeLimit) {
         DTU_LOGD("granting %d W from DC power bus (no battery discharge "
-                "limit), solar power is %u/%u W DC/AC",
-                powerRequested, solarOutputDc, solarOutputAc);
+                "limit), solar power is %u/%u W DC/AC, dc loads are %u W DC",
+                powerRequested, solarOutputDc, solarOutputAc, dcLoadsPowerDc);
         return powerRequested;
     }
 
     auto batteryAllowanceAc = dcPowerBusToInverterAc(*oBatteryDischargeLimit);
 
     DTU_LOGD("battery allowance is %u/%u W DC/AC, solar power is %u/%u W DC/AC, "
-            "requested are %u W AC",
+            "dc loads are %u W DC, requested are %u W AC",
             *oBatteryDischargeLimit, batteryAllowanceAc,
-            solarOutputDc, solarOutputAc, powerRequested);
+            solarOutputDc, solarOutputAc,
+            dcLoadsPowerDc, powerRequested);
 
     uint16_t allowance = batteryAllowanceAc + solarOutputAc;
     return std::min(powerRequested, allowance);
@@ -820,12 +826,10 @@ uint16_t PowerLimiterClass::getSolarOutputPower() const
 // battery-powered inverters without pulling from the battery. We compute
 // the current DC loads on the power bus (excluding the inverters), then
 // subtract those from the solar output.
-uint16_t PowerLimiterClass::getSolarPassthroughPower() const
+uint16_t PowerLimiterClass::getDcLoadsPowerDc() const
 {
-    // Current solar charger DC output (already clamped to >= 0)
     uint16_t solarOutputDc = getSolarOutputPower();
-
-    if (solarOutputDc <= 0.0f) { return 0; }
+    if (solarOutputDc == 0) { return 0; }
 
     auto stats = Battery.getStats();
     if (!stats->isCurrentValid() || stats->getChargeCurrentAgeSeconds() >= 60) { return 0; }
@@ -842,17 +846,9 @@ uint16_t PowerLimiterClass::getSolarPassthroughPower() const
 
     // Other DC loads connected to the DC bus (e.g., DC consumers connected to the charge controller)
     // Balance on DC bus: solar + batteryDischarge = inverterDcDraw + otherLoads + batteryCharge
-    float otherLoads = solarOutputDc + batteryDischarge - inverterDcPower - batteryCharge;
-    if (otherLoads < 0.0f) {
-        // no other loads, we can use the full solar output power
-        return solarOutputDc;
-    }
+    float dcLoads = solarOutputDc + batteryDischarge - inverterDcPower - batteryCharge;
 
-    // Solar power that can be passed through to inverters without drawing from the battery
-    float availableForPassthrough = solarOutputDc - otherLoads;
-    if (availableForPassthrough < 0.0f) { availableForPassthrough = 0.0f; }
-
-    return static_cast<uint16_t>(availableForPassthrough);
+    return std::max<float>(0.0f, dcLoads);
 }
 
 float PowerLimiterClass::getBatteryInvertersInputDcWatts() const

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -750,14 +750,17 @@ uint16_t PowerLimiterClass::calcPowerBusUsage(uint16_t powerRequested) const
         return 0;
     }
 
-    auto solarOutputDc = getSolarPassthroughPower();
-    auto solarOutputAc = dcPowerBusToInverterAc(solarOutputDc);
-    if (isFullSolarPassthroughActive() && solarOutputAc > powerRequested) {
+    auto solarPassthroughPowerDc = getSolarPassthroughPower();
+    auto solarPassthroughPowerAc = dcPowerBusToInverterAc(solarPassthroughPowerDc);
+    if (isFullSolarPassthroughActive() && solarPassthroughPowerAc > powerRequested) {
         DTU_LOGD("using %u/%u W DC/AC from DC power bus (full solar-passthrough)",
-                solarOutputDc, solarOutputAc);
+                solarPassthroughPowerDc, solarPassthroughPowerAc);
 
-        return solarOutputAc;
+        return solarPassthroughPowerAc;
     }
+
+    auto solarOutputDc = getSolarOutputPower();
+    auto solarOutputAc = dcPowerBusToInverterAc(solarOutputDc);
 
     auto oBatteryDischargeLimit = getBatteryDischargeLimit();
     if (!oBatteryDischargeLimit) {
@@ -800,17 +803,68 @@ bool PowerLimiterClass::updateInverters()
     return busy;
 }
 
-uint16_t PowerLimiterClass::getSolarPassthroughPower() const
+uint16_t PowerLimiterClass::getSolarOutputPower() const
 {
     if (!isSolarPassThroughEnabled() || isBelowStopThreshold()) {
         return 0;
     }
 
-    std::optional<float> oSolarChargerOutput = SolarCharger.getStats()->getOutputPowerWatts();
+    float solarChargerOutput = SolarCharger.getStats()->getOutputPowerWatts().value_or(0);
 
     // This value can be negative if a charge controller with a load output is used
     // and the load is consuming more power than the charge controller is producing.
-    return std::max<float>(0, oSolarChargerOutput.value_or(0));
+    return std::max<float>(0, solarChargerOutput);
+}
+
+// Determine how much of the present solar DC power can be passed to the
+// battery-powered inverters without pulling from the battery. We compute
+// the current DC loads on the power bus (excluding the inverters), then
+// subtract those from the solar output.
+uint16_t PowerLimiterClass::getSolarPassthroughPower() const
+{
+    // Current solar charger DC output (already clamped to >= 0)
+    uint16_t solarOutputDc = getSolarOutputPower();
+
+    if (solarOutputDc <= 0.0f) { return 0; }
+
+    auto stats = Battery.getStats();
+    if (!stats->isCurrentValid() || stats->getChargeCurrentAgeSeconds() >= 60) { return 0; }
+
+    float batteryVoltage = getBatteryVoltage();
+    if (batteryVoltage <= 0.0f) { return 0; }
+
+    // Determine battery power (positive when charging, negative when discharging)
+    float batteryPower = batteryVoltage * stats->getChargeCurrent();
+    float batteryCharge = std::max(0.0f, batteryPower);
+    float batteryDischarge = std::max(0.0f, -batteryPower);
+
+    float inverterDcPower = getBatteryInvertersInputDcWatts();
+
+    // Other DC loads connected to the DC bus (e.g., DC consumers connected to the charge controller)
+    // Balance on DC bus: solar + batteryDischarge = inverterDcDraw + otherLoads + batteryCharge
+    float otherLoads = solarOutputDc + batteryDischarge - inverterDcPower - batteryCharge;
+    if (otherLoads < 0.0f) {
+        // no other loads, we can use the full solar output power
+        return solarOutputDc;
+    }
+
+    // Solar power that can be passed through to inverters without drawing from the battery
+    float availableForPassthrough = solarOutputDc - otherLoads;
+    if (availableForPassthrough < 0.0f) { availableForPassthrough = 0.0f; }
+
+    return static_cast<uint16_t>(availableForPassthrough);
+}
+
+float PowerLimiterClass::getBatteryInvertersInputDcWatts() const
+{
+    float res = 0;
+
+    for (auto const& upInv : _inverters) {
+        if (!upInv->isBatteryPowered()) { continue; }
+        res += upInv->getCurrentDcInputWatts();
+    }
+
+    return res;
 }
 
 float PowerLimiterClass::getBatteryInvertersOutputAcWatts() const

--- a/src/PowerLimiterInverter.cpp
+++ b/src/PowerLimiterInverter.cpp
@@ -344,6 +344,19 @@ float PowerLimiterInverter::getDcVoltage(uint8_t input)
             static_cast<ChannelNum_t>(input), FLD_UDC);
 }
 
+float PowerLimiterInverter::getCurrentDcInputWatts() const
+{
+    float dcPower = 0;
+    auto pStats = _spInverter->Statistics();
+    std::vector<ChannelNum_t> dcChannels = _spInverter->getChannelsDC();
+
+    for (auto& c : dcChannels) {
+        dcPower += pStats->getChannelFieldValue(TYPE_DC, c, FLD_PDC);
+    }
+
+    return dcPower;
+}
+
 uint16_t PowerLimiterInverter::getCurrentLimitWatts() const
 {
     auto currentLimitPercent = _spInverter->SystemConfigPara()->getLimitPercent();


### PR DESCRIPTION
This pull request introduces enhancements to the solar and battery power management logic, focusing on more accurate calculation and reporting of available DC and AC power, as well as improving the tracking of battery and inverter statistics. The main changes involve refactoring how solar output and passthrough power are computed, adding new methods to expose internal state, and increasing the precision of battery statistics.

**Power calculation and reporting improvements:**

* Refactored the logic in `PowerLimiterClass::calcPowerBusUsage` and related methods to distinguish between solar passthrough power and total solar output, improving clarity and accuracy in power allocation.
* Added new methods to `PowerLimiterClass` for retrieving solar output power, solar passthrough power, and battery inverter DC output, enabling more granular control and reporting of power flows. [[1]](diffhunk://#diff-cb60056e42296ea4d5fc84853afbb8ae2b377c4523e06242fe19d2c615faf952R94-R100) [[2]](diffhunk://#diff-c502fa72d03eefad0a66ed1345a8f70eded4c8f0303ee7b38bb2a32094dbcc91L757-R821)

**Inverter statistics enhancements:**

* Implemented `PowerLimiterInverter::getCurrentDcPower` to calculate the total DC power output for each inverter, supporting more precise measurement of inverter contributions to the power bus. [[1]](diffhunk://#diff-14b556140354c69bbde38e3cd5de8046fc47991ae73a775ac4b036682f962db2R71) [[2]](diffhunk://#diff-274fe3babc323e1fbc1ca920b4b76b7b835dccf1b1d977754d68b64a77e45753R347-R359)

**Battery statistics improvements:**

* Added methods to `Stats` for retrieving the age (in seconds) of charge current and discharge current limit readings, improving the reliability of decisions based on battery data freshness.