### PR TITLE
Feature: DPL: make standby configurable for battery-powered inverters

### DIFF
--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -642,6 +642,15 @@ uint16_t PowerLimiterClass::updateInverterLimits(uint16_t powerRequested,
 
     if (matchingInverters.empty()) { return 0; }
 
+    // if we update battery-powered inverters and the battery is in the STOP state,
+    // we must put all battery-powered inverters into standby mode,
+    // regardless of whether the standby option is enabled or not.
+    if ((matchingInverters[0]->isBatteryPowered()) && (_batteryState == BatteryState::STOP)) {
+        for (auto pInv : matchingInverters) { pInv->standby(); }
+        DTU_LOGD("battery is in STOP state, all battery-powered inverters are put into standby.");
+        return 0;
+    }
+
     int32_t diff = powerRequested - producing;
 
     auto const& config = Configuration.get();

--- a/src/PowerLimiterBatteryInverter.cpp
+++ b/src/PowerLimiterBatteryInverter.cpp
@@ -9,7 +9,7 @@ uint16_t PowerLimiterBatteryInverter::getMaxReductionWatts(bool allowStandby) co
 
     if (!isProducing()) { return 0; }
 
-    if (allowStandby) { return getCurrentOutputAcWatts(); }
+    if (allowStandby && _config.AllowStandby) { return getCurrentOutputAcWatts(); }
 
     if (getCurrentOutputAcWatts() <= _config.LowerPowerLimit) { return 0; }
 
@@ -44,7 +44,7 @@ uint16_t PowerLimiterBatteryInverter::applyReduction(uint16_t reduction, bool al
 
     auto low = std::min(getCurrentLimitWatts(), getCurrentOutputAcWatts());
     if (low <= _config.LowerPowerLimit) {
-        if (allowStandby) {
+        if (allowStandby && _config.AllowStandby) {
             standby();
             return std::min(reduction, getCurrentOutputAcWatts());
         }
@@ -56,7 +56,7 @@ uint16_t PowerLimiterBatteryInverter::applyReduction(uint16_t reduction, bool al
         return reduction;
     }
 
-    if (allowStandby) {
+    if (allowStandby && _config.AllowStandby) {
         standby();
         return std::min(reduction, getCurrentOutputAcWatts());
     }

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -732,7 +732,7 @@
         "UpperPowerLimit": "Maximales Leistungslimit",
         "UpperPowerLimitHint": "Der Wechselrichter wird stets so eingestellt, dass höchstens diese Ausgangsleistung erreicht wird. Dieser Wert muss so gewählt werden, dass die Strombelastbarkeit der AC-Anschlussleitungen eingehalten wird.",
         "AllowStandby": "Standby erlauben",
-        "AllowStandbyHint": "Erlaubt dem Wechselrichter in Standby zu gehen, wenn das berechnete Leistungslimit unter dem minimalen Leistungslimit liegt.",
+        "AllowStandbyHint": "Erlaubt dem Wechselrichter in Standby zu gehen, wenn das berechnete Leistungslimit unter dem minimalen Leistungslimit liegt. Ansonsten wird der Wechselrichter auf das minimale Leistungslimit gesetzt.",
         "SocThresholds": "Batterie State of Charge (SoC) Schwellwerte",
         "IgnoreSoc": "Nur Spannungs-Schwellwerte nutzen",
         "IgnoreSocHint": "Falls aktiviert werden nur die Spannungs-Schwellwerte berücksichtigt. Deaktiviere diesen Schalter, um Batterie State of Charge (SoC) Schwellwerte zu konfigurieren (nicht empfohlen, da der SoC-Wert häufig ungenau ist).",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -732,7 +732,7 @@
         "UpperPowerLimit": "Maximum Power Limit",
         "UpperPowerLimitHint": "The inverter is always set such that no more than this output power is achieved. This value must be selected to comply with the current carrying capacity of the AC connection cables.",
         "AllowStandby": "Allow Standby",
-        "AllowStandbyHint": "Allow the inverter to go into standby if the calculated power limit is below the minimum power limit.",
+        "AllowStandbyHint": "Allow the inverter to go into standby if the calculated power limit is below the minimum power limit. Otherwise, the inverter will be set to the minimum power limit.",
         "SocThresholds": "Battery State of Charge (SoC) Thresholds",
         "IgnoreSoc": "Use Voltage Thresholds Only",
         "IgnoreSocHint": "When enabled, only voltage thresholds are considered. Disable this switch to configure and use battery State of Charge (SoC) thresholds (not recommended as the SoC value is often inaccurate).",

--- a/webapp/src/views/PowerLimiterAdminView.vue
+++ b/webapp/src/views/PowerLimiterAdminView.vue
@@ -161,7 +161,7 @@
                         <InputElement
                             :label="$t('powerlimiteradmin.AllowStandby')"
                             :tooltip="$t('powerlimiteradmin.AllowStandbyHint')"
-                            v-if="inv.power_source == 2"
+                            v-if="inv.power_source == 2 || inv.power_source == 0"
                             v-model="inv.allow_standby"
                             type="checkbox"
                             wide


### PR DESCRIPTION
This PR makes the "Allow Standby" option, already available for smart battery-powered inverters, available for battery-powered inverters as well. **More precise... make the deactivation of "Allow Standby" configurable.** 

- When "Allow Standby" is enabled, the inverter will enter standby mode when the minimum inverter power is undershot.
- When "Allow Standby" is **disabled**, the inverter will be set to its minimum inverter power when the minimum inverter power is undershot.

"Allow Standby" is enabled by default. After a software update, the inverters' behavior will not initially change.
Only actively modifying the DPL configuration can alter the inverters' behavior.
This option is particularly useful for problems like "124 Switched off by remote control." Further information can be found here: #2321 

Disabling "Allow Standby" is not recommended, if the minimum inverter output is higher than the minimum power consumption.
For systems with multiple inverters, you should also consider whether it is wise to disable the option for all inverters.

Important:
There are other events that can put battery inverters into standby mode, such as:

- Disabling DPL
- Battery below stop threshold

These standby events are not affected or modified by this option!

<img width="600" height="160" alt="grafik" src="https://github.com/user-attachments/assets/69b2e15d-efdc-4071-a3bd-1d25f7383e0c" />
