### PR TITLE
Enable full power range of battery-powered HM-xxx inverter on 24VDC

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -437,6 +437,17 @@ struct CONFIG_T {
         PowerMeterUdpVictronConfig UdpVictron;
     } PowerMeter;
 
+    struct InverterMeterConfig {
+        bool Enabled;
+        uint32_t Source;
+        uint64_t Serial;
+        PowerMeterMqttConfig Mqtt;
+        PowerMeterSerialSdmConfig SerialSdm;
+        PowerMeterHttpJsonConfig HttpJson;
+        PowerMeterHttpSmlConfig HttpSml;
+        PowerMeterUdpVictronConfig UdpVictron;
+    } InverterMeter;
+
     PowerLimiterConfig PowerLimiter;
 
     BatteryConfig Battery;

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -149,6 +149,7 @@ struct POWERLIMITER_INVERTER_CONFIG_T {
     bool IsBehindPowerMeter;
     bool UseOverscaling;
     bool AllowStandby;
+    bool UseATF;
     uint16_t LowerPowerLimit;
     uint16_t UpperPowerLimit;
 

--- a/include/InverterATF.h
+++ b/include/InverterATF.h
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+ * Locking policy:
+ * - Public getters having the prefix 'get' take a shared lock internally.
+ * - Public mutating methods take an exclusive lock internally.
+ * - Private getters having the prefix 'g' do not take a lock.
+ * - Private methods are called with the appropriate lock held by the public methods.
+ * - Fetching external data is done before acquiring _mutex. The only exception is data from the configuration or
+ *   data used just for visualization.
+ * - Flags marked as atomic may be read lock-free.
+ */
+
+#pragma once
+#include <Arduino.h>
+#include <shared_mutex>
+#include <atomic>
+#include <ArduinoJson.h>
+
+
+class InverterATF {
+    public:
+        InverterATF() = default;
+        ~InverterATF() = default;
+        InverterATF(const InverterATF&) = delete;
+        InverterATF& operator=(const InverterATF&) = delete;
+        InverterATF(InverterATF&&) = delete;
+        InverterATF& operator=(InverterATF&&) = delete;
+
+
+        // indicates whether ATF is actually active
+        bool isATFActive() const { return _useATF.load(); }
+
+        // activate the ATF data structure
+        // use a unique lock when calling this method
+        bool activateATF(uint16_t const nomPower);
+
+        // deactivate the ATF data structure
+        // use a unique lock when calling this method
+        void deactivateATF(void);
+
+        // update the ATF data with the current power and limit pair
+        // use a unique lock when calling this method
+        void setATFData(float const power, float const limit);
+
+        // deserialize the ATF data from the runtime data file
+        // use a unique lock when calling this method
+        void deserializeATFData(JsonObject obj);
+
+        // serialize the ATF data to the runtime data file
+        // use a shared lock when calling this method
+        void serializeATFData(JsonObject obj) const;
+
+        // print the ATF report to the log
+        // use a shared lock when calling this method
+        void printATFReport(char const* serialStr) const;
+
+        // returns the power for the given limit according to the ATF
+        // use a shared/unique lock when calling this method
+        uint16_t getATFPower(float const limit) const;
+
+        // returns the limit for the given power according to the ATF
+        // use a shared/unique lock when calling this method
+        float getATFLimit(uint16_t const power) const;
+
+    private:
+        float makeAveragePower(float newValue, float const oldValue);
+        enum class State : uint8_t { OFF, DEFAULT_INIT, RTD_INIT };
+
+        std::atomic<bool> _useATF = false;              // false: ATF inactive and no memory allocated for the data array
+        State _state = State::OFF;                      // state of the ATF data array
+        static constexpr uint8_t _size = 101;           // Fixed size of the ATF data array, never NEVER change the size!
+        std::unique_ptr<float[]> _realPower = nullptr;  // ATF data array, index 0-100%
+
+        uint16_t _nomInvPower = 0;                      // Inverter nominal power [W]
+        uint16_t _maxInvPower = 0;                      // Inverter maximum power (nominal power * MAX_OVERDRIVE_FACTOR) [W]
+        uint16_t _absDiffPower = 0;                     // maximum absolute difference, used for power value checks [W]
+        mutable std::pair<uint16_t, float> _cache;      // cache to avoid recalculations, first = power, second = limit
+        mutable std::shared_mutex _mutex;               // mutex to protect the shared data
+
+        uint16_t _linearFault = 0;                      // counts the number of range check faults
+        uint16_t _averageWarning = 0;                   // counts the number of average warnings
+        std::pair<uint16_t, float> _linearPairFault;    // buffer the maximum range check fault
+        std::pair<float, float> _averagePairWarning;    // buffer the maximum average check warning
+};

--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -34,6 +34,7 @@ public:
         InverterStatsPending,
         UnconditionalSolarPassthrough,
         Stable,
+        InverterPowerMeterPending,
     };
 
     void init(Scheduler& scheduler);

--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -57,6 +57,9 @@ public:
     // used to interlock Huawei R48xx grid charger against battery-powered inverters
     bool isGovernedBatteryPoweredInverterProducing() const;
 
+    void serializeRTD(JsonObject const& obj) const;
+    void deserializeRTD(JsonObject const& obj);
+
 private:
     void loop();
 
@@ -73,8 +76,12 @@ private:
 
     std::deque<std::unique_ptr<PowerLimiterInverter>> _inverters;
     std::deque<std::unique_ptr<PowerLimiterInverter>> _retirees;
-    bool _batteryDischargeEnabled = false;
-    bool _nighttimeDischarging = false;
+
+    enum class BatteryState : uint8_t { STOP = 0, NO_DISCHARGE = 1, DISCHARGE_ALLOWED = 2, DISCHARGE_NIGHT = 3 };
+    BatteryState _batteryState = BatteryState::STOP;
+    bool _fromStart = false;
+    bool _oneStopPerNightDone = false;
+
     std::pair<bool, uint32_t> _nextInverterRestart = { false, 0 };
     bool _fullSolarPassThroughActive = false;
     float _loadCorrectedVoltage = 0.0f;

--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -61,6 +61,12 @@ public:
     void serializeRTD(JsonObject const& obj) const;
     void deserializeRTD(JsonObject const& obj);
 
+    // ATF: used for the ATF functionality
+    bool initATF(void);
+    void serializeATFtoRTD(JsonVariant obj) const;
+    void deserializeRTDtoATF(JsonVariant obj);
+    std::optional<uint16_t> getATFInverterPower(uint64_t inverterSerial, float limit) const;
+
 private:
     void loop();
 
@@ -86,6 +92,10 @@ private:
     std::pair<bool, uint32_t> _nextInverterRestart = { false, 0 };
     bool _fullSolarPassThroughActive = false;
     float _loadCorrectedVoltage = 0.0f;
+
+    // ATF: used for the ATF functionality
+    bool _checkATF = true;
+    uint32_t _lastATFPrint = 0;
 
     frozen::string const& getStatusText(Status status) const;
     void announceStatus(Status status);

--- a/include/PowerLimiterInverter.h
+++ b/include/PowerLimiterInverter.h
@@ -37,6 +37,8 @@ public:
     // upper power limit (additionally restricted by inverter's absolute max)
     uint16_t getConfiguredMaxPowerWatts() const;
 
+    // returns the current amount of AC output power
+    // either as per inverter stats or preferred from the external power meter
     uint16_t getCurrentOutputAcWatts() const;
 
     // this differs from current output power if new limit was assigned
@@ -71,6 +73,12 @@ public:
     bool isSendingCommandsEnabled() const { return _spInverter->getEnableCommands(); }
     bool isReachable() const { return _spInverter->isReachable(); }
     bool isProducing() const { return _spInverter->isProducing(); }
+
+    // sets the AC value measured by the external power meter
+    // compares the timestamp of the external power meter with the timestamp of the inverter stats
+    // returns true if the value is accepted or if further waiting makes no sense
+    // returns false if we want to wait longer for a newer value
+    bool setCurrentOutputAcWatts(float power, uint32_t timestamp);
 
     uint64_t getSerial() const { return _config.Serial; }
     char const* getSerialStr() const { return _serialStr; }
@@ -134,6 +142,9 @@ private:
     std::optional<uint16_t> _oTargetPowerLimitWatts = std::nullopt;
     std::optional<bool> _oTargetPowerState = std::nullopt;
     mutable std::optional<uint32_t> _oStatsMillis = std::nullopt;
+
+    // the external power meter value if available and recent enough
+    std::optional<float> _oInverterMeterPower = std::nullopt;
 
     // the expected AC output (possibly is different from the target limit)
     uint16_t _expectedOutputAcWatts = 0;

--- a/include/PowerLimiterInverter.h
+++ b/include/PowerLimiterInverter.h
@@ -5,8 +5,9 @@
 #include <Hoymiles.h>
 #include <optional>
 #include <memory>
+#include "InverterATF.h"
 
-class PowerLimiterInverter {
+class PowerLimiterInverter  : public InverterATF {
 public:
     static std::unique_ptr<PowerLimiterInverter> create(PowerLimiterInverterConfig const& config);
 
@@ -79,6 +80,21 @@ public:
     // returns true if the value is accepted or if further waiting makes no sense
     // returns false if we want to wait longer for a newer value
     bool setCurrentOutputAcWatts(float power, uint32_t timestamp);
+
+    // indicates whether ATF is enabled in the configuration
+    // use isATFActive() to check whether ATF is actually active
+    bool isATFEnabled(void) const { return _config.UseATF; }
+
+    // update the ATF data with the current power and limit pair
+    // just call this method after getting new stats from the inverter
+    // because the values must be in sync
+    void setATFData(void) { InverterATF::setATFData(getCurrentOutputAcWatts(), _spInverter->SystemConfigPara()->getLimitPercent()); }
+
+    // print the ATF report to the log
+    void printATFReport(void) const { InverterATF::printATFReport(getSerialStr()); }
+
+    // todo: delete after testing
+    uint16_t getATFConfigPower(void) const { return _config.UpperPowerLimit; }
 
     uint64_t getSerial() const { return _config.Serial; }
     char const* getSerialStr() const { return _serialStr; }

--- a/include/RuntimeData.h
+++ b/include/RuntimeData.h
@@ -18,7 +18,7 @@ public:
 
     void init(Scheduler& scheduler);
     bool read(void);
-    bool write(uint16_t const freezeTime);
+    bool write(uint16_t const freezeMinutes = 10); // do not write if last write operation was less than freezeMinutes ago
 
     uint16_t getWriteCount(void) const;
     time_t getWriteEpochTime(void) const;

--- a/include/RuntimeData.h
+++ b/include/RuntimeData.h
@@ -19,6 +19,7 @@ public:
     void init(Scheduler& scheduler);
     bool read(void);
     bool write(uint16_t const freezeMinutes = 10); // do not write if last write operation was less than freezeMinutes ago
+    void requestWriteOnNextTaskLoop(void) { _writeNow = true; }; // use this member function to store data on demand
 
     uint16_t getWriteCount(void) const;
     time_t getWriteEpochTime(void) const;
@@ -33,6 +34,7 @@ private:
     Task _loopTask;
     std::atomic<bool> _readOK = false;      // true if the last read operation was successful
     std::atomic<bool> _writeOK = false;     // true if the last write operation was successful
+    std::atomic<bool> _writeNow = false;    // if true, the data is stored in the next loop()
     mutable std::mutex _mutex;              // to protect the shared data below
     bool _lastTrigger = false;              // auxiliary value to prevent multiple triggering on the same day
     uint16_t _writeVersion = 0;             // shared data: version of the runtime data

--- a/include/RuntimeData.h
+++ b/include/RuntimeData.h
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <ArduinoJson.h>
+#include <TaskSchedulerDeclarations.h>
+#include <mutex>
+#include <atomic>
+
+
+class RuntimeClass {
+public:
+    explicit RuntimeClass(uint16_t version) : _writeVersion(version) {};
+    ~RuntimeClass() = default;
+    RuntimeClass(const RuntimeClass&) = delete;
+    RuntimeClass& operator=(const RuntimeClass&) = delete;
+    RuntimeClass(RuntimeClass&&) = delete;
+    RuntimeClass& operator=(RuntimeClass&&) = delete;
+
+    void init(Scheduler& scheduler);
+    bool read(void);
+    bool write(void);
+
+    uint16_t getWriteCount(void) const;
+    time_t getWriteEpochTime(void) const;
+    bool getReadState(void) const { return _readOK; }
+    bool getWriteState(void) const { return _writeOK; }
+    String getWriteCountAndTimeString(void) const;
+
+private:
+    void loop(void);
+    bool getWriteTrigger(void) const;
+
+    Task _loopTask;
+    std::atomic<bool> _readOK = false;      // true if the last read/write operation was successful
+    std::atomic<bool> _writeOK = false;     // true if the last read/write operation was successful
+    mutable std::mutex _mutex;              // to protect the shared data below
+    uint16_t _writeVersion = 0;             // shared data: version of the runtime data
+    uint16_t _writeCount = 0;               // shared data: number of times the data was written
+    time_t _writeEpoch = 0;                 // shared data: epoch time when the data was written
+};
+
+extern RuntimeClass RuntimeData;

--- a/include/RuntimeData.h
+++ b/include/RuntimeData.h
@@ -18,7 +18,7 @@ public:
 
     void init(Scheduler& scheduler);
     bool read(void);
-    bool write(void);
+    bool write(uint16_t const freezeTime);
 
     uint16_t getWriteCount(void) const;
     time_t getWriteEpochTime(void) const;

--- a/include/RuntimeData.h
+++ b/include/RuntimeData.h
@@ -28,14 +28,15 @@ public:
 
 private:
     void loop(void);
-    bool getWriteTrigger(void) const;
+    bool getWriteTrigger(void);
 
     Task _loopTask;
-    std::atomic<bool> _readOK = false;      // true if the last read/write operation was successful
-    std::atomic<bool> _writeOK = false;     // true if the last read/write operation was successful
+    std::atomic<bool> _readOK = false;      // true if the last read operation was successful
+    std::atomic<bool> _writeOK = false;     // true if the last write operation was successful
     mutable std::mutex _mutex;              // to protect the shared data below
+    bool _lastTrigger = false;              // auxiliary value to prevent multiple triggering on the same day
     uint16_t _writeVersion = 0;             // shared data: version of the runtime data
-    uint16_t _writeCount = 0;               // shared data: number of times the data was written
+    uint16_t _writeCount = 0;               // shared data: number of write operations
     time_t _writeEpoch = 0;                 // shared data: epoch time when the data was written
 };
 

--- a/include/RuntimeData.h
+++ b/include/RuntimeData.h
@@ -17,9 +17,11 @@ public:
     RuntimeClass& operator=(RuntimeClass&&) = delete;
 
     void init(Scheduler& scheduler);
-    bool read(void);
-    bool write(uint16_t const freezeMinutes = 10); // do not write if last write operation was less than freezeMinutes ago
-    void requestWriteOnNextTaskLoop(void) { _writeNow = true; }; // use this member function to store data on demand
+    enum class ReadMode : uint8_t { START_UP, ON_DEMAND };
+    bool read(ReadMode const mode = ReadMode::START_UP);            // read runtime data
+    bool write(uint16_t const freezeMinutes = 10);                  // do not write if last write operation was less than freezeMinutes ago
+    void requestWriteOnNextTaskLoop(void) { _writeNow = true; };    // use this member function to store data on demand
+    void requestReadOnNextTaskLoop(void) { _readNow = true; };      // use this member function to read data on demand
 
     uint16_t getWriteCount(void) const;
     time_t getWriteEpochTime(void) const;
@@ -34,6 +36,7 @@ private:
     Task _loopTask;
     std::atomic<bool> _readOK = false;      // true if the last read operation was successful
     std::atomic<bool> _writeOK = false;     // true if the last write operation was successful
+    std::atomic<bool> _readNow = false;     // if true, the data is read in the next loop()
     std::atomic<bool> _writeNow = false;    // if true, the data is stored in the next loop()
     mutable std::mutex _mutex;              // to protect the shared data below
     bool _lastTrigger = false;              // auxiliary value to prevent multiple triggering on the same day

--- a/include/WebApi.h
+++ b/include/WebApi.h
@@ -20,6 +20,7 @@
 #include "WebApi_ntp.h"
 #include "WebApi_power.h"
 #include "WebApi_powermeter.h"
+#include "WebApi_invertermeter.h"
 #include "WebApi_powerlimiter.h"
 #include "WebApi_prometheus.h"
 #include "WebApi_security.h"
@@ -74,6 +75,7 @@ private:
     WebApiNtpClass _webApiNtp;
     WebApiPowerClass _webApiPower;
     WebApiPowerMeterClass _webApiPowerMeter;
+    WebApiInverterMeterClass _webApiInverterMeter;
     WebApiPowerLimiterClass _webApiPowerLimiter;
     WebApiPrometheusClass _webApiPrometheus;
     WebApiSecurityClass _webApiSecurity;

--- a/include/WebApi_invertermeter.h
+++ b/include/WebApi_invertermeter.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <ESPAsyncWebServer.h>
+#include <TaskSchedulerDeclarations.h>
+#include <ArduinoJson.h>
+#include "Configuration.h"
+
+class WebApiInverterMeterClass {
+public:
+    void init(AsyncWebServer& server, Scheduler& scheduler);
+
+private:
+    void onStatus(AsyncWebServerRequest* request);
+    void onAdminGet(AsyncWebServerRequest* request);
+    void onAdminPost(AsyncWebServerRequest* request);
+    void onTestHttpJsonRequest(AsyncWebServerRequest* request);
+    void onTestHttpSmlRequest(AsyncWebServerRequest* request);
+
+    AsyncWebServer* _server;
+};

--- a/include/invertermeter/Controller.h
+++ b/include/invertermeter/Controller.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+/*
+ * Locking policy:
+ * - Public getters having the prefix 'get' take a shared lock internally.
+ * - Public mutating methods take an exclusive lock internally.
+ * - Private getters having the prefix 'g' do not take a lock.
+ * - Private methods are called with the appropriate lock held by the public methods.
+ * - Fetching external data is done before acquiring _mutex. The only exception is data from the configuration or
+ *   data used just for visualization.
+ * - Flags marked as atomic may be read lock-free.
+ */
+
+#include <powermeter/Provider.h>
+#include <TaskSchedulerDeclarations.h>
+#include <memory>
+#include <mutex>
+
+namespace InverterMeters {
+
+class Controller {
+public:
+    void init(Scheduler& scheduler);
+    void updateSettings();
+
+    // todo: consider removing getPowerTotal in favor of getPower with inverterID
+    float getPowerTotal() const;
+    uint32_t getLastUpdate() const;
+
+    // returns true if the data is not older than 30 seconds
+    bool isDataValid() const;
+
+    // returns power for the given inverter ID if available
+    std::optional<float> getPower(uint64_t inverterID) const;
+
+    // returns the time of the last update for the given inverter serial number
+    uint32_t getTime(uint64_t inverterSN) const;
+
+    // returns the time of the measurement request in milliseconds
+    uint32_t getRequestTime() const;
+
+private:
+    void loop();
+
+    Task _loopTask;
+    mutable std::mutex _mutex;
+    std::unique_ptr<PowerMeters::Provider> _upProvider = nullptr;
+};
+
+} // namespace InverterMeters
+
+extern InverterMeters::Controller InverterMeter;

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -429,6 +429,26 @@ bool ConfigurationClass::write()
     JsonObject powermeter_udp_victron = powermeter["udp_victron"].to<JsonObject>();
     serializePowerMeterUdpVictronConfig(config.PowerMeter.UdpVictron, powermeter_udp_victron);
 
+    JsonObject invertermeter = doc["invertermeter"].to<JsonObject>();
+    invertermeter["enabled"] = config.InverterMeter.Enabled;
+    invertermeter["source"] = config.InverterMeter.Source;
+    invertermeter["serial"] = config.InverterMeter.Serial;
+
+    JsonObject invertermeter_mqtt = invertermeter["mqtt"].to<JsonObject>();
+    serializePowerMeterMqttConfig(config.InverterMeter.Mqtt, invertermeter_mqtt);
+
+    JsonObject invertermeter_serial_sdm = invertermeter["serial_sdm"].to<JsonObject>();
+    serializePowerMeterSerialSdmConfig(config.InverterMeter.SerialSdm, invertermeter_serial_sdm);
+
+    JsonObject invertermeter_http_json = invertermeter["http_json"].to<JsonObject>();
+    serializePowerMeterHttpJsonConfig(config.InverterMeter.HttpJson, invertermeter_http_json);
+
+    JsonObject invertermeter_http_sml = invertermeter["http_sml"].to<JsonObject>();
+    serializePowerMeterHttpSmlConfig(config.InverterMeter.HttpSml, invertermeter_http_sml);
+
+    JsonObject invertermeter_udp_victron = invertermeter["udp_victron"].to<JsonObject>();
+    serializePowerMeterUdpVictronConfig(config.InverterMeter.UdpVictron, invertermeter_udp_victron);
+
     JsonObject powerlimiter = doc["powerlimiter"].to<JsonObject>();
     serializePowerLimiterConfig(config.PowerLimiter, powerlimiter);
 
@@ -898,6 +918,16 @@ bool ConfigurationClass::read()
     deserializePowerMeterHttpSmlConfig(powermeter["http_sml"], config.PowerMeter.HttpSml);
 
     deserializePowerMeterUdpVictronConfig(powermeter["udp_victron"], config.PowerMeter.UdpVictron);
+
+    JsonObject invertermeter = doc["invertermeter"];
+    config.InverterMeter.Enabled = invertermeter["enabled"] | false;
+    config.InverterMeter.Source =  invertermeter["source"] | POWERMETER_SOURCE;
+    config.InverterMeter.Serial =  invertermeter["serial"] | 0ULL;
+    deserializePowerMeterMqttConfig(invertermeter["mqtt"], config.InverterMeter.Mqtt);
+    deserializePowerMeterSerialSdmConfig(invertermeter["serial_sdm"], config.InverterMeter.SerialSdm);
+    deserializePowerMeterHttpJsonConfig(invertermeter["http_json"], config.InverterMeter.HttpJson);
+    deserializePowerMeterHttpSmlConfig(invertermeter["http_sml"], config.InverterMeter.HttpSml);
+    deserializePowerMeterUdpVictronConfig(invertermeter["udp_victron"], config.InverterMeter.UdpVictron);
 
     deserializePowerLimiterConfig(doc["powerlimiter"], config.PowerLimiter);
 

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -224,6 +224,7 @@ void ConfigurationClass::serializePowerLimiterConfig(PowerLimiterConfig const& s
         t["power_source"] = s.PowerSource;
         t["use_overscaling_to_compensate_shading"] = s.UseOverscaling;
         t["allow_standby"] = s.AllowStandby;
+        t["use_atf"] = s.UseATF;
         t["lower_power_limit"] = s.LowerPowerLimit;
         t["upper_power_limit"] = s.UpperPowerLimit;
     }
@@ -672,6 +673,7 @@ void ConfigurationClass::deserializePowerLimiterConfig(JsonObject const& source,
         inv.PowerSource = s["power_source"] | PowerLimiterInverterConfig::InverterPowerSource::Battery;
         inv.UseOverscaling = s["use_overscaling_to_compensate_shading"] | POWERLIMITER_USE_OVERSCALING;
         inv.AllowStandby = s["allow_standby"] | POWERLIMITER_ALLOW_STANDBY;
+        inv.UseATF = s["use_atf"] | false;
         inv.LowerPowerLimit = s["lower_power_limit"] | POWERLIMITER_LOWER_POWER_LIMIT;
         inv.UpperPowerLimit = s["upper_power_limit"] | POWERLIMITER_UPPER_POWER_LIMIT;
     }

--- a/src/Datastore.cpp
+++ b/src/Datastore.cpp
@@ -5,6 +5,7 @@
 #include "Datastore.h"
 #include "Configuration.h"
 #include <Hoymiles.h>
+#include "invertermeter/Controller.h"
 
 DatastoreClass Datastore;
 
@@ -91,10 +92,16 @@ void DatastoreClass::loop()
             }
         }
 
-        for (auto& c : inv->Statistics()->getChannelsByType(TYPE_AC)) {
-            if (inv->getEnablePolling()) {
-                _totalAcPowerEnabled += inv->Statistics()->getChannelFieldValue(TYPE_AC, c, FLD_PAC);
-                _totalAcPowerDigits = max<unsigned int>(_totalAcPowerDigits, inv->Statistics()->getChannelFieldDigits(TYPE_AC, c, FLD_PAC));
+        auto oACPower = InverterMeter.getPower(inv->serial());
+        if (oACPower.has_value()) {
+            _totalAcPowerEnabled += *oACPower;
+            _totalAcPowerDigits = max<unsigned int>(_totalAcPowerDigits,  1);
+        } else {
+            for (auto& c : inv->Statistics()->getChannelsByType(TYPE_AC)) {
+                if (inv->getEnablePolling()) {
+                    _totalAcPowerEnabled += inv->Statistics()->getChannelFieldValue(TYPE_AC, c, FLD_PAC);
+                    _totalAcPowerDigits = max<unsigned int>(_totalAcPowerDigits, inv->Statistics()->getChannelFieldDigits(TYPE_AC, c, FLD_PAC));
+                }
             }
         }
 

--- a/src/InverterATF.cpp
+++ b/src/InverterATF.cpp
@@ -1,0 +1,429 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/* Inverter transfer function correction / InverterATF (Inverter Adaptive Transfer Function)
+ *
+ * The linear transfer function "Limit = m * Power" of the inverter is not always linear. Especially at low power values
+ * (below 10%) and high power values (above 90%) in combination with 24VDC, the inverter often shows a non linear behavior.
+ * The negative effects are: Oscillations of the power, reduced efficiency and forcing the inverter into standby mode.
+ * The problem can be solved with an adaptive transfer function (ATF).
+ *
+ * 30.01.2025 - 0.1 - First version
+ * 06.03.2025 - 0.2 - Double search to find the left and right value and keep the array increasing
+ * 30.10.2025 - 0.3 - Use 'Runtime Data' to store the correction table, add shared mutex for thread safety
+ * 27.11.2025 - 0.4 - Improved range checks and averaging of new values
+ */
+
+#include <LogHelper.h>
+#include "InverterATF.h"
+
+#undef TAG
+static const char* TAG = "dynamicPowerLimiter";
+static const char* SUBTAG = "ATF";
+
+static constexpr float MAX_OVERDRIVE_FACTOR = 1.07f; // 7% maximum overdrive factor, on 600W inverters 642W are possible
+static constexpr float MAX_POWER_TOLL = 1.15f;       // maximum factor [%] for the power value compared to the correction table
+static constexpr float MAX_LINEAR_DIFF_P = 1.50f;    // 50% maximum difference of the measured power value compared to the linear value
+static constexpr float MAX_LINEAR_DIFF_A = 0.05f;    // 5% of nominal power maximum difference compared to the linear value
+
+
+// activate the following line to enable debug
+// Hint: And also disable the DPL
+//#define DEBUG_LOGGING
+
+
+/*
+ * activate ATF data array with linear values
+ */
+bool InverterATF::activateATF(uint16_t const nomPower) {
+
+    std::unique_lock<std::shared_mutex> lock(_mutex);
+
+    if (nomPower == 0) { return false; }
+    if (_realPower != nullptr) { return true; } // already initialized
+
+    // allocate memory for the ATF data array
+    _realPower = std::make_unique<float[]>(_size);
+    if (_realPower == nullptr) {
+        DTU_LOGE("Unable to allocate memory for ATF data array");
+        return false;
+    }
+
+    _nomInvPower = nomPower;
+    _maxInvPower = _nomInvPower * MAX_OVERDRIVE_FACTOR;
+    _absDiffPower = static_cast<uint16_t>( _nomInvPower * MAX_LINEAR_DIFF_A);
+    _linearFault = 0;
+    _averageWarning = 0;
+    _averagePairWarning = { 0.0f, 0.0f };
+    _linearPairFault = { 0, 0.0f };
+    _cache = { 0, 0.0f };
+
+    // init the ATF data array with 1% power steps
+    auto powerStep = static_cast<float>( _nomInvPower ) / (_size - 1);
+    for (auto idx = 0; idx < _size; ++idx) {
+        _realPower[idx] = powerStep * idx;
+    }
+
+    _state = State::DEFAULT_INIT;
+    _useATF.store(true);
+    return true;
+}
+
+
+/*
+ * deactivate ATF
+ */
+void InverterATF::deactivateATF() {
+
+    std::unique_lock<std::shared_mutex> lock(_mutex);
+
+    _realPower.reset();
+    _nomInvPower = 0;
+
+    _state = State::OFF;
+    _useATF.store(false);
+}
+
+
+/*
+ * Update the correction array with a new pair, power [W] and limit [%].
+ * Checks whether the values ​​are valid, calculates an average value, and ensures the consistency of the data.
+ */
+void InverterATF::setATFData(float const power, float const limit) {
+
+    if (!_useATF.load()) { return; }
+
+    std::unique_lock<std::shared_mutex> lock(_mutex);
+
+    // basic range checks
+    if ((limit <= 0.0f) || (limit > 100.0f) || (power <= 0.0f) || (power > _maxInvPower )) { return; }
+
+    // validation check, values must be in an range of +/-35% or +/-12W compared to the linear value
+    auto linearPower = (_nomInvPower / 100.0f) * limit;
+    auto minLinPower = linearPower / MAX_LINEAR_DIFF_P;
+    auto maxLinPower = linearPower * MAX_LINEAR_DIFF_P;
+    if (((power < minLinPower) || (power > maxLinPower)) && (fabs(power - linearPower) > _absDiffPower)) {
+
+        // logging of the biggest difference compared to linear value
+        _linearFault++;
+        if (fabs(power - linearPower) > fabs((_nomInvPower / 100.0f * _linearPairFault.second) - _linearPairFault.first)) {
+            _linearPairFault = { static_cast<uint16_t>(power), limit };
+        }
+        return; // out of range, ignore the new values
+    }
+
+    _cache = { power, limit } ; // fill the cache
+    auto idxL = static_cast<uint8_t>(limit); // remove decimal part
+    auto idxR = idxL;
+    if  ((limit - idxL) != 0.0f) { idxR = idxL + 1; } // we are between two indexes
+
+    // Note: additional range checks are not necessary, because limit is between 0.1% and 100%
+    // so idxL is between 0 and 100, and idxR is between 1 and 100
+    auto powerL = _realPower[idxL];
+    auto powerR = _realPower[idxR];
+    auto newL = power;
+
+    #ifdef DEBUG_LOGGING
+    DTU_LOGI("Limit: %0.1f%%, Power: %0.1fW", limit, power);
+    DTU_LOGI("Old values left: %u%%, %0.1fW, Old values right: %u%%, %0.1fW", idxL, powerL, idxR, powerR);
+    #endif
+
+    if (idxL != idxR ) {
+        // we are between two indexes, so we calculate the new power values for the left and right index
+        float oldPower = powerL + (powerR - powerL) * (limit - idxL);
+        if (oldPower <= 0.0f) { oldPower = 1.0f; } // avoid division by zero
+        auto diffFactor = power / oldPower - 1.0f;
+
+        // we calculate the index values (left and right)
+        if (powerL > 1.0f) {
+            newL = powerL * ( 1.0f + diffFactor * (1.0f - (limit - idxL)));
+        } else {
+            if (idxL != 0) { newL = power / 2; } // if the left power is too small, we just set it to half of the new power
+        }
+        auto newR = powerR * ( 1.0f + diffFactor * (1.0f - (idxR - limit)));
+
+        _realPower[idxR] = makeAveragePower(newR, _realPower[idxR]);
+    }
+    _realPower[idxL] = makeAveragePower(newL, _realPower[idxL]);
+
+    #ifdef DEBUG_LOGGING
+    DTU_LOGI("New values left: %u%%, %0.1fW, New values right: %u%%, %0.1fW", idxL, _realPower[idxL], idxR, _realPower[idxR]);
+    #endif
+
+    // we keep the array in an equal or increasing order to avoid problems if we calculate
+    // the limit from the power. We check the left and the right side of the array
+    // beginning from the closer changed index
+    auto idxStart = ((limit - idxL) <= 0.5f) ? idxL : idxR;
+
+    #ifdef DEBUG_LOGGING
+    DTU_LOGI("Array check start index: %u%%", idxStart);
+    #endif
+
+    // check if the right side from the start index is equal or increasing
+    for (auto idx = idxStart; idx + 1 < _size; ++idx) {
+        if (_realPower[idx] > _realPower[idx + 1]) {
+            _realPower[idx + 1] = _realPower[idx];
+        } else {
+            if (idx > idxStart + 1) { break; } // we can stop if we are at least 2 indexes away from the start
+        }
+    }
+
+    // check if the left side from the start index is equal or decreasing
+    for (auto idx = idxStart; idx > 0; --idx) {
+        if (_realPower[idx - 1] > _realPower[idx]) {
+            _realPower[idx - 1] = _realPower[idx];
+        } else {
+            if (idx < idxStart - 1) { break; } // we can stop if we are at least 2 indexes away from the start
+        }
+    }
+}
+
+
+/*
+ * Check and limit the new value to +/- 15% of the current value
+ */
+float InverterATF::makeAveragePower(float newValue, float const oldValue) {
+    float minValue = oldValue / MAX_POWER_TOLL;
+    float maxValue = oldValue * MAX_POWER_TOLL;
+
+    auto actWarning = _averageWarning;
+    if (newValue < minValue) {
+        newValue = minValue;
+        _averageWarning++;
+    } else if (newValue > maxValue) {
+        newValue = maxValue;
+        _averageWarning++;
+    }
+
+    if (_averageWarning > actWarning) {
+        auto faultOld = std::abs(_averagePairWarning.first - _averagePairWarning.second);
+        auto faultNew = std::abs(newValue - oldValue);
+        if (faultNew > faultOld) {
+            _averagePairWarning = { newValue, oldValue };
+        }
+    }
+
+    auto back = (newValue + oldValue) / 2.0f;
+    if (back > _maxInvPower) { back = static_cast<float>(_maxInvPower); }
+    return back; // return the average
+}
+
+
+/*
+ * Get the power [W] of the given limit [%]
+ * If the limit is between two values, then we do a linear interpolation
+ */
+uint16_t InverterATF::getATFPower(float const limit) const {
+
+    if (!_useATF.load()) { return 0; }
+
+    {
+        std::shared_lock<std::shared_mutex> slock(_mutex);
+
+        if (limit <= 0.0f) { return 0; }
+        if (limit >= 100.0f) { return static_cast<uint16_t>(_realPower[_size - 1]); }
+
+        // shortcut, check the cache, if the new limit is the same as the last limit
+        if (limit == _cache.second) { return _cache.first; }
+
+    } // end of shared lock
+
+    // cache miss -> unique lock to compute and update cache
+    std::unique_lock<std::shared_mutex> lock(_mutex);
+
+    // re-check under exclusive lock
+    if (limit == _cache.second) { return _cache.first; }
+
+    _cache.second = limit; // store the new limit in the cache
+    auto idx = static_cast<uint8_t>(limit); // remove decimal part
+
+    // idx is between 0 and 99, so idx+1 is between 1 and 100, safe to access the array without further range check
+    float power = 0.0f;
+    if (limit == static_cast<float>(idx)) {
+        power = _realPower[idx]; // exact match
+    } else {
+        float m = (_realPower[idx + 1] - _realPower[idx]);   // 1% step
+        power = _realPower[idx] + m * (limit - static_cast<float>(idx));
+    }
+
+    #ifdef DEBUG_LOGGING
+    DTU_LOGI("Given limit: %0.1f%% --> Calculated power: %0.0fW", limit, power);
+    #endif
+
+    _cache.first = static_cast<uint16_t>(power + 0.5f); // round to nearest integer
+    return _cache.first;
+}
+
+
+/*
+ * Get the limit [%] of the given power [W]
+ * If the limit is between two values, then we do a linear interpolation
+ */
+float InverterATF::getATFLimit(uint16_t const power) const {
+
+    if (!_useATF.load()) { return 0.0f; }
+
+    {
+        std::shared_lock<std::shared_mutex> slock(_mutex);
+
+        if (power <= 0) { return 0.0f; }
+        if (power >= static_cast<uint16_t>(_realPower[_size - 1])) { return 100.0f; }
+
+        // shortcut, check the cache, if the new power is the same as the last power
+        if (power == _cache.first) { return _cache.second; }
+
+    } // end of shared lock
+
+    // cache miss -> unique lock to compute and update cache
+    std::unique_lock<std::shared_mutex> lock(_mutex);
+
+    // re-check under exclusive lock
+    if (power == _cache.first) { return _cache.second; }
+
+    _cache.first = power; // store the new power value in the cache
+
+    // search from 0W to max W (index 1 to 100) to find the left value
+    auto fPower = static_cast<float>(power);
+    uint8_t idxLeft = 0;
+    for (uint8_t idx = 1; idx < _size; ++idx) {
+        if (fPower <= _realPower[idx]) {
+            idxLeft = idx - 1;
+            break;
+        }
+    }
+    if (idxLeft >= _size) { idxLeft = _size - 1; } // safety check
+    auto limit = static_cast<float>(idxLeft);
+
+    // linear interpolation is not necessary if
+    // the left power value matches the given power or if we reached the end of the array
+    if ((power != static_cast<uint16_t>(_realPower[idxLeft] + 0.5f)) && (idxLeft < _size - 1)) {
+
+        // linear interpolation between the left and right value
+        auto const& powLeft = _realPower[idxLeft];
+        auto const& powRight = _realPower[idxLeft + 1];
+
+        // safety check to avoid division by zero and use of invalid values
+        if ( powLeft < powRight) {
+            auto m = 1.0f / (powRight - powLeft);
+            limit = limit + m * (power - powLeft);
+            if (limit < 0.0f) { limit = 0.0f; }
+            if (limit > 100.0f) { limit = 100.0f; }
+        }
+    }
+
+    #ifdef DEBUG_LOGGING
+    DTU_LOGI("Given power: %iW --> Calculated limit: %0.1f%%", power, limit);
+    #endif
+
+    _cache.second = roundf(limit * 10.0f) / 10.0f; // round to 1 decimal place
+    return _cache.second;
+}
+
+
+/*
+ * Serialize the ATF data array to be written into the runtime file
+ */
+void InverterATF::serializeATFData(JsonObject obj) const {
+
+    if (!_useATF.load()) { return; }
+
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+
+    JsonArray data = obj["data"].to<JsonArray>();
+    for (auto idx = 0; idx < _size; ++idx) {
+	    data.add(roundf(_realPower[idx] * 10.0f) / 10.0f); // round to 1 decimal place
+    }
+}
+
+
+/*
+ * Deserialize ATF data array from the runtime file
+ */
+void InverterATF::deserializeATFData(JsonObject obj) {
+
+    if (!_useATF.load()) { return; }
+
+    std::unique_lock<std::shared_mutex> lock(_mutex);
+
+    if (_state == State::RTD_INIT) { return; } // already initialized from runtime file
+
+    // if the data from the runtime file does not exist or the size is not identical,
+    // then we do not copy any values and keep the default values
+    JsonArray data = obj["data"];
+    if (data.size() == _size) {
+        auto idx = 0;
+        for (JsonVariantConst value : data) {
+            float newValue = value.as<float>();
+
+            // range checks
+            if (newValue < 0.0f) { newValue = 0.0f; }
+            if (newValue > _maxInvPower) { newValue = _maxInvPower; }
+
+            #ifndef DEBUG_LOGGING
+            _realPower[idx] = newValue;
+            #endif
+
+            ++idx;
+        }
+        _state = State::RTD_INIT;
+    }
+}
+
+
+/*
+ * Print the correction report to the log
+ */
+void InverterATF::printATFReport(char const* serialStr) const {
+
+    if (!_useATF.load()) { return; }
+
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+
+    DTU_LOGI("");
+    DTU_LOGI("------------------------- ATF Report --------------------------");
+    DTU_LOGI("Inverter serial: %s, Nominal power: %uW", serialStr, _nomInvPower);
+    DTU_LOGI("Data state: %s", (_state == State::RTD_INIT) ? "Initialized by runtime values" : "Initialized by default values");
+    DTU_LOGI("Data out of range faults: %i [Limit: %0.1f%%, AFT: %uW, Linear: %uW]", _linearFault, _linearPairFault.second,
+        _linearPairFault.first, static_cast<uint16_t>(_nomInvPower / 100.0f * _linearPairFault.second));
+    DTU_LOGI("Data average warnings: %i [New: %0.1fW, Old: %0.1fW]", _averageWarning, _averagePairWarning.first, _averagePairWarning.second);
+
+    bool error = false;
+    for (auto idx = 1; idx < _size; ++idx) {
+        if (_realPower[idx-1] > _realPower[idx]) { error = true; break; }
+    }
+    DTU_LOGI("Data array %s increasing", error ? "is not" : "is");
+    DTU_LOGI("");
+
+    size_t constexpr columnWidth = 5;
+    size_t constexpr columnMaxNr = 20;
+    size_t constexpr rowMaxNr = 5;
+    char cBuffer[columnMaxNr * columnWidth + 10];
+
+    for (auto row = 0; row < rowMaxNr; ++row) {
+        for (auto kind = 0; kind < 2; ++kind) {
+            char *cBuf = cBuffer;
+            auto remaining = sizeof(cBuffer);
+            for (auto idx = 1; idx <= columnMaxNr; ++idx) {
+                auto globalIdx = row * columnMaxNr + idx;
+                if (kind == 0) {
+                    if (globalIdx < _size) {
+                        snprintf(cBuf, remaining, " %2i%%,", static_cast<int>(globalIdx)); // Limit
+                    } else {
+                        snprintf(cBuf, remaining, "   ,");
+                    }
+                } else {
+                    if (globalIdx < _size) {
+                        snprintf(cBuf, remaining, " %3.0f,", _realPower[globalIdx]); // Power
+                    } else {
+                        snprintf(cBuf, remaining, "   ,");
+                    }
+                }
+                cBuf += columnWidth;
+                remaining -= columnWidth;
+            }
+            DTU_LOGI("%s", cBuffer);
+        }
+    }
+
+    DTU_LOGI("---------------------------------------------------------------");
+    DTU_LOGI("");
+}

--- a/src/InverterATF.cpp
+++ b/src/InverterATF.cpp
@@ -358,9 +358,7 @@ void InverterATF::deserializeATFData(JsonObject obj) {
             if (newValue < 0.0f) { newValue = 0.0f; }
             if (newValue > _maxInvPower) { newValue = _maxInvPower; }
 
-            #ifndef DEBUG_LOGGING
             _realPower[idx] = newValue;
-            #endif
 
             ++idx;
         }
@@ -396,7 +394,9 @@ void InverterATF::printATFReport(char const* serialStr) const {
     size_t constexpr columnWidth = 5;
     size_t constexpr columnMaxNr = 20;
     size_t constexpr rowMaxNr = 5;
-    char cBuffer[columnMaxNr * columnWidth + 10];
+    static constexpr size_t  kTableWidth = columnMaxNr * columnWidth + 10;
+
+    char cBuffer[kTableWidth];
 
     for (auto row = 0; row < rowMaxNr; ++row) {
         for (auto kind = 0; kind < 2; ++kind) {

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -645,6 +645,14 @@ uint16_t PowerLimiterClass::updateInverterLimits(uint16_t powerRequested,
 
     if (matchingInverters.empty()) { return 0; }
 
+    // if we have battery-powered inverters and the battery is below the stop threshold,
+    // we set all into standby
+    if ((matchingInverters[0]->isBatteryPowered()) && (_batteryState == BatteryState::STOP)) {
+        for (auto pInv : matchingInverters) { pInv->standby(); }
+        DTU_LOGD("battery below stop threshold, all battery-powered inverters are stopped");
+        return 0;
+    }
+
     int32_t diff = powerRequested - producing;
 
     auto const& config = Configuration.get();

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -336,15 +336,6 @@ void PowerLimiterClass::loop()
 
     _loadCorrectedVoltage = getLoadCorrectedVoltage();
     _batteryState = getBatteryState();
-
-    // todo: Remove debug logs
-    if (_batteryState == BatteryState::DISCHARGE_ALLOWED) { DTU_LOGI("SW-Nico: Battery State: %s", "Discharge allowed"); }
-    else if (_batteryState == BatteryState::NO_DISCHARGE) { DTU_LOGI("SW-Nico: Battery State: %s", "No discharge"); }
-    else if (_batteryState == BatteryState::DISCHARGE_NIGHT) { DTU_LOGI("SW-Nico: Battery State: %s", "Discharge at night"); }
-    else { DTU_LOGI("SW-Nico: Battery State: %s", "Stopped"); }
-    DTU_LOGI("SW-Nico: Battery come from: %s", (_fromStart)?"start":"stop");
-    DTU_LOGI("SW-Nico: One battery stop per night done: %s", (_oneStopPerNightDone)?"yes":"no");
-
     _fullSolarPassThroughActive = getFullSolarPassthrough();
 
     DTU_LOGD("up %lu s, it is %s, next inverter restart at %d s (set to %d)",

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -19,6 +19,7 @@
 #include <frozen/map.h>
 #include "SunPosition.h"
 #include <LogHelper.h>
+#include "RuntimeData.h"
 
 #undef TAG
 static const char* TAG = "dynamicPowerLimiter";
@@ -142,6 +143,7 @@ void PowerLimiterClass::reloadConfig()
 
     calcNextInverterRestart();
 
+    _checkATF = true; // ATF: re-check ATF initialization on next loop
     _reloadConfigFlag = false;
 }
 
@@ -195,6 +197,9 @@ void PowerLimiterClass::loop()
 
         latestInverterStats = std::max(*oStatsMillis, latestInverterStats);
     }
+
+    // ATF, we do this here because we need inverter max power info to initialize the ATF
+    if (_checkATF) { _checkATF = !initATF(); }
 
     // note that we can only perform unconditional full solar-passthrough or any
     // calculation at all after surviving the loop above, which ensures that we
@@ -392,6 +397,21 @@ void PowerLimiterClass::loop()
         DTU_LOGD("total max AC power is %u W, conduction losses are %u %%",
             config.PowerLimiter.TotalUpperPowerLimit,
             config.PowerLimiter.ConductionLosses);
+    }
+
+    // ATF: Check if it is time to print the ATF report
+    bool printReport = false;
+    if (millis() - _lastATFPrint > 60*1000) {
+        printReport = true;
+        _lastATFPrint = millis();
+    }
+
+    // ATF: Update the adaptive transfer function with the current power and limit
+    for (auto& upInv : _inverters) {
+        if (!upInv->isATFActive()) { continue; }
+        upInv->setATFData();
+
+        if (printReport) { upInv->printATFReport(); }
     }
 
     uint16_t inverterTotalPower = calcTargetOutput();
@@ -1004,4 +1024,104 @@ void PowerLimiterClass::deserializeRTD(JsonObject const& obj)
     // Note: Up to now the PowerLimiterClass does not use a mutex
     // Use of atomic<bool> would be an solution but I want to avoid the overhead
     _fromStart =  obj["battery_from_start"] | false;
+}
+
+/*
+ * Initialize or deinitialize the Adaptive Transfer Function (ATF) data structure
+ * We need late initialization because it cannot be done directly after starting the DPL:
+ * - we need the power limiter inverter class
+ * - we need inverter stats about the inverter max power to initialize the ATF data
+ * - we must check if the runtime file contains already ATF data
+ */
+bool PowerLimiterClass::initATF(void) {
+
+    bool allDone = true;
+    uint16_t counter = 0;
+    for (auto const& upInv : _inverters) {
+        if (!upInv->isBatteryPowered()) { continue; } // ATF only for battery-powered inverters
+        if (counter >= 1) { continue; }               // limit to 1 inverters for now
+
+        if (!upInv->isEligible()) {
+            allDone = false; // inverter not reachable yet, that is normal short after DPL start
+            continue;
+        }
+
+        if (upInv->isATFEnabled() && !upInv->isATFActive()) {
+
+            auto maxPower = upInv->getInverterMaxPowerWatts();
+            //if (maxPower == 0) { maxPower = upInv->getATFConfigPower(); } // todo: delete after testing
+            if (maxPower == 0) {
+                //DTU_LOGW("cannot initialize ATF: inverter max power unknown");
+                allDone = false;
+                continue;
+            }
+            if (!upInv->activateATF(maxPower)) {
+                //DTU_LOGW("cannot initialize ATF: activate data structure");
+                allDone = false;
+                continue;
+            }
+
+            // trigger read of ATF data from the runtime data file
+            RuntimeData.requestReadOnNextTaskLoop();
+            ++counter;
+
+        } else if (!upInv->isATFEnabled() && upInv->isATFActive()) {
+            upInv->deactivateATF();
+        }
+    }
+
+    return allDone;
+}
+
+/*
+ * Serialize the Adaptive Transfer Function (ATF) data to/from the runtime data file (RTD)
+ */
+void PowerLimiterClass::serializeATFtoRTD(JsonVariant var) const {
+
+    auto arr = var["inverter_atf"].to<JsonArray>();
+
+    // serialize ATF data for every inverter with active ATF
+    for (auto const& upInv : _inverters) {
+        if (!upInv->isATFActive()) { continue; }
+
+        auto inv = arr.add<JsonObject>();
+        inv["serial"] = upInv->getSerialStr();  // human-readable serial number
+        upInv->serializeATFData(inv);
+    }
+}
+
+/*
+ * Deserialize the Adaptive Transfer Function (ATF) data from the runtime data file (RTD)
+ */
+void PowerLimiterClass::deserializeRTDtoATF(JsonVariant var) {
+
+    for (JsonObject inv : var["inverter_atf"].as<JsonArray>()) {
+
+        // Interpret the string as a hex value and convert it to uint64_t
+        const uint64_t serial = strtoll(inv["serial"].as<String>().c_str(), NULL, 16);
+        if (serial == 0ULL) { continue; }
+
+        for (auto& upInv : _inverters) {
+
+            // we use the serial to find the matching inverter
+            if (upInv->getSerial() != serial) { continue; }
+            upInv->deserializeATFData(inv);
+        }
+    }
+}
+
+/*
+ * Get the power limit from the Adaptive Transfer Function (ATF) for a given inverter
+ * Used to show the ATF calculated power in the webapp-UI
+ */
+std::optional<uint16_t> PowerLimiterClass::getATFInverterPower(uint64_t inverterSerial, float limit) const {
+    for (auto& upInv : _inverters) {
+        if (!upInv->isATFActive()) { continue; }
+        if (upInv->getSerial() != inverterSerial) { continue; }
+
+        // found matching inverter, get power from its ATF
+        auto power = upInv->getATFPower(limit);
+        if (power != 0) { return power; }
+    }
+    return std::nullopt;
 }

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -6,6 +6,7 @@
 #include <battery/Controller.h>
 #include <battery/Stats.h>
 #include <powermeter/Controller.h>
+#include <invertermeter/Controller.h>
 #include "PowerLimiter.h"
 #include "Configuration.h"
 #include "MqttSettings.h"
@@ -55,7 +56,7 @@ frozen::string const& PowerLimiterClass::getStatusText(PowerLimiterClass::Status
 {
     static const frozen::string missing = "programmer error: missing status text";
 
-    static const frozen::map<Status, frozen::string, 11> texts = {
+    static const frozen::map<Status, frozen::string, 12> texts = {
         { Status::Initializing, "initializing (should not see me)" },
         { Status::DisabledByConfig, "disabled by configuration" },
         { Status::DisabledByMqtt, "disabled by MQTT" },
@@ -67,6 +68,7 @@ frozen::string const& PowerLimiterClass::getStatusText(PowerLimiterClass::Status
         { Status::InverterStatsPending, "waiting for sufficiently recent inverter data" },
         { Status::UnconditionalSolarPassthrough, "unconditionally passing through all solar power (MQTT override)" },
         { Status::Stable, "the system is stable, the last power limit is still valid" },
+        { Status::InverterPowerMeterPending, "waiting for sufficiently recent inverter power meter data" },
     };
 
     auto iter = texts.find(status);
@@ -201,13 +203,19 @@ void PowerLimiterClass::loop()
         return unconditionalFullSolarPassthrough();
     }
 
-    // if the power meter is being used, i.e., if its data is valid, we want to
-    // wait for a new reading after adjusting the inverter limit. otherwise, we
-    // proceed as we will use a fallback limit independent of the power meter.
-    // the power meter reading is expected to be at most 2 seconds old when it
-    // arrives. this can be the case for readings provided by networked meter
-    // readers, where a packet needs to travel through the network for some
-    // time after the actual measurement was done by the reader.
+    // if an external inverter power meter is being used, i.e., if its data is valid, we want to
+    // wait a certain time for a new reading after adjusting the inverter limit.
+    // however, if the time is over, we proceed and use the internal inverter measurement.
+    if (config.InverterMeter.Enabled) {
+        for (auto& upInv : _inverters) {
+            auto power = InverterMeter.getPower(upInv->getSerial()).value_or(0.0f);
+            auto time = InverterMeter.getTime(upInv->getSerial());
+            if (!upInv->setCurrentOutputAcWatts(power, time)) {
+                return announceStatus(Status::InverterPowerMeterPending);
+            }
+        }
+    }
+
     if (PowerMeter.isDataValid() && PowerMeter.getLastUpdate() <= (latestInverterStats + 2000)) {
         return announceStatus(Status::PowerMeterPending);
     }

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -237,38 +237,71 @@ void PowerLimiterClass::loop()
 
     autoRestartInverters();
 
-    auto getBatteryPower = [this,&config]() -> bool {
-        if (!usesBatteryPoweredInverter()) { return false; }
+    auto getBatteryState = [this,&config]() -> BatteryState {
 
-        auto isDayPeriod = SunPosition.isDayPeriod();
+        // State machine for the battery
+        // Conditions:          we use 'Below Stop Threshold', 'Above Start Threshold', 'Solar-Passthrough', 'Use Battery at night',
+        //                      'Night/Day' and 'From which direction did we enter the stop-start zone' to determine the state.
+        //
+        // states               description
+        // --------------------------------------------------------------------------------------------------------------------------------
+        // STOP:                we must stop the inverter, because the battery is below the stop threshold
+        // NO_DISCHARGE:        we can use the inverter, but we do not allow to discharge the battery, A requirement from 'Solar-Passthrough'
+        // DISCHARGE_ALLOWED:   we can use the inverter and we allow discharging of the battery
+        // DISCHARGE_NIGHT:     we can use the inverter and we allow discharging of a partial charged battery at night.
+        //                      A requirement from 'Use Battery at night'
+        //
+        // Notes: The combination of 'Use Battery at night' and use of 'voltage thresholds' can leads to oscillation between the states
+        // STOP and DISCHARGE_NIGHT. To avoid this problem, we allow only one transmission from STOP to DISCHARGE_NIGHT per night.
+        // In case of restart or power-cycle, we accept that the inverter may start discharging at night once again.
+        // Start-Up can be tricky, because data from the battery provider may not be available. As fallback we use the not very
+        // accurate inverter voltage and this can lead to the wrong state. Especially if we use the runtime file to save the state.
 
-        if (_nighttimeDischarging && isDayPeriod) {
-            _nighttimeDischarging = false;
-            return isStartThresholdReached();
+        // check if have a battery powered inverter
+        if (!usesBatteryPoweredInverter()) { return BatteryState::STOP; }
+
+        // check the stop condition
+        auto day = SunPosition.isDayPeriod();
+        if (isStopThresholdReached()) {
+            _fromStart = false;
+            _oneStopPerNightDone = day ? false : true;
+            return BatteryState::STOP;
         }
 
-        if (isStopThresholdReached()) { return false; }
-
-        if (isStartThresholdReached()) { return true; }
-
-        // start a nighttime discharge cycle on a partially charged battery if
-        //   1. the respective switch/setting is enabled
-        //   2. it is now after sunset, i.e., it is nighttime
-        //   3. we are not already in a discharge cycle
-        //   4. we did not start a nighttime discharge cycle on a partially
-        //      charged battery already (the _nighttimeDischarging flag will
-        //      only be reset at sunrise, see above)
-        if (config.PowerLimiter.BatteryAlwaysUseAtNight &&
-                !isDayPeriod &&
-                !_batteryDischargeEnabled &&
-                !_nighttimeDischarging) {
-            _nighttimeDischarging = true;
-            return true;
+        // check the start condition
+        if (isStartThresholdReached()) {
+            _fromStart = true;
+            return BatteryState::DISCHARGE_ALLOWED;
         }
 
-        // we are between start and stop threshold and keep the state that was
-        // last triggered, either charging or discharging.
-        return _batteryDischargeEnabled;
+        // all of the following conditions mean that we are in the "stop-start zone",
+        // and we must use the buffered information 'From which direction did we enter the stop-start zone'.
+
+        // if we come from start we always allow discharging of the battery
+        if (_fromStart) { return BatteryState::DISCHARGE_ALLOWED; }
+
+        // if we reach this line we come from stop and have to consider the 'Solar-Passthrough' and the 'Use Battery at night' settings.
+        auto solarPassThroughEnabled = isSolarPassThroughEnabled();
+        auto isBatteryAlwaysUseAtNightEnabled = config.PowerLimiter.BatteryAlwaysUseAtNight;
+
+        if (!isBatteryAlwaysUseAtNightEnabled) { _oneStopPerNightDone = false; }
+
+        if (!solarPassThroughEnabled && !isBatteryAlwaysUseAtNightEnabled) { return BatteryState::STOP; }
+
+        if (solarPassThroughEnabled && !isBatteryAlwaysUseAtNightEnabled) { return BatteryState::NO_DISCHARGE; }
+
+        // we reach this line only if 'Use Battery at night' is enabled
+        if (day) {
+            _oneStopPerNightDone = false;
+            return (solarPassThroughEnabled) ? BatteryState::DISCHARGE_ALLOWED : BatteryState::STOP;
+        } else {
+            return (_oneStopPerNightDone) ? BatteryState::STOP : BatteryState::DISCHARGE_NIGHT;
+        }
+
+        // we should never reach this line, but if we do, we use a safe fallback.
+        DTU_LOGE("Unexpected condition in battery state machine, using fallback state: STOP");
+        _fromStart = false;
+        return BatteryState::STOP;
     };
 
     auto getFullSolarPassthrough = [this,&config]() -> bool {
@@ -301,9 +334,18 @@ void PowerLimiterClass::loop()
         return dcVoltage + (acPower * config.PowerLimiter.VoltageLoadCorrectionFactor);
     };
 
-    _batteryDischargeEnabled = getBatteryPower();
-    _fullSolarPassThroughActive = getFullSolarPassthrough();
     _loadCorrectedVoltage = getLoadCorrectedVoltage();
+    _batteryState = getBatteryState();
+
+    // todo: Remove debug logs
+    if (_batteryState == BatteryState::DISCHARGE_ALLOWED) { DTU_LOGI("SW-Nico: Battery State: %s", "Discharge allowed"); }
+    else if (_batteryState == BatteryState::NO_DISCHARGE) { DTU_LOGI("SW-Nico: Battery State: %s", "No discharge"); }
+    else if (_batteryState == BatteryState::DISCHARGE_NIGHT) { DTU_LOGI("SW-Nico: Battery State: %s", "Discharge at night"); }
+    else { DTU_LOGI("SW-Nico: Battery State: %s", "Stopped"); }
+    DTU_LOGI("SW-Nico: Battery come from: %s", (_fromStart)?"start":"stop");
+    DTU_LOGI("SW-Nico: One battery stop per night done: %s", (_oneStopPerNightDone)?"yes":"no");
+
+    _fullSolarPassThroughActive = getFullSolarPassthrough();
 
     DTU_LOGD("up %lu s, it is %s, next inverter restart at %d s (set to %d)",
             millis()/1000,
@@ -326,7 +368,8 @@ void PowerLimiterClass::loop()
                 config.PowerLimiter.VoltageLoadCorrectionFactor);
 
         DTU_LOGD("battery discharge %s, start %.2f V or %u %%, stop %.2f V or %u %%",
-                (_batteryDischargeEnabled?"allowed":"restricted"),
+                (((_batteryState == BatteryState::DISCHARGE_ALLOWED) || (_batteryState == BatteryState::DISCHARGE_NIGHT))?"allowed":
+                (_batteryState == BatteryState::NO_DISCHARGE)?"restricted":"stopped"),
                 config.PowerLimiter.VoltageStartThreshold,
                 config.PowerLimiter.BatterySocStartThreshold,
                 config.PowerLimiter.VoltageStopThreshold,
@@ -345,7 +388,7 @@ void PowerLimiterClass::loop()
                 (isStopThresholdReached()?"":"NOT "),
                 (isSolarPassThroughEnabled()?"en":"dis"),
                 (config.PowerLimiter.BatteryAlwaysUseAtNight?"en":"dis"),
-                (_nighttimeDischarging?"active":"dormant"));
+                ((_batteryState == BatteryState::DISCHARGE_NIGHT)?"active":"dormant"));
 
         DTU_LOGD("total max AC power is %u W, conduction losses are %u %%",
             config.PowerLimiter.TotalUpperPowerLimit,
@@ -517,7 +560,8 @@ uint8_t PowerLimiterClass::getPowerLimiterState() const
         return PL_UI_STATE_CHARGING;
     }
 
-    return _batteryDischargeEnabled ? PL_UI_STATE_USE_SOLAR_AND_BATTERY : PL_UI_STATE_USE_SOLAR_ONLY;
+    return ((_batteryState == BatteryState::DISCHARGE_ALLOWED || _batteryState == BatteryState::DISCHARGE_NIGHT))
+        ? PL_UI_STATE_USE_SOLAR_AND_BATTERY : PL_UI_STATE_USE_SOLAR_ONLY;
 }
 
 uint16_t PowerLimiterClass::calcTargetOutput() const
@@ -704,6 +748,11 @@ uint16_t PowerLimiterClass::calcPowerBusUsage(uint16_t powerRequested) const
         return 0;
     }
 
+    if (_batteryState == BatteryState::STOP) {
+        DTU_LOGD("DC power bus usage blocked by battery below the stop threshold");
+        return 0;
+    }
+
     auto solarOutputDc = getSolarPassthroughPower();
     auto solarOutputAc = dcPowerBusToInverterAc(solarOutputDc);
     if (isFullSolarPassthroughActive() && solarOutputAc > powerRequested) {
@@ -784,7 +833,7 @@ float PowerLimiterClass::getBatteryInvertersOutputAcWatts() const
 
 std::optional<uint16_t> PowerLimiterClass::getBatteryDischargeLimit() const
 {
-    if (!_batteryDischargeEnabled) { return 0; }
+    if ((_batteryState == BatteryState::STOP) || (_batteryState == BatteryState::NO_DISCHARGE)) { return 0; }
 
     auto currentLimit = Battery.getDischargeCurrentLimit();
     if (currentLimit == FLT_MAX) { return std::nullopt; }
@@ -934,4 +983,18 @@ bool PowerLimiterClass::isGovernedBatteryPoweredInverterProducing() const
         if (upInv->isBatteryPowered() && upInv->isProducing()) { return true; }
     }
     return false;
+}
+
+void PowerLimiterClass::serializeRTD(JsonObject const& obj) const
+{
+    // Note: Up to now the PowerLimiterClass does not use a mutex
+    // Use of atomic<bool> would be an solution but I want to avoid the overhead
+    obj["battery_from_start"] = _fromStart;
+}
+
+void PowerLimiterClass::deserializeRTD(JsonObject const& obj)
+{
+    // Note: Up to now the PowerLimiterClass does not use a mutex
+    // Use of atomic<bool> would be an solution but I want to avoid the overhead
+    _fromStart =  obj["battery_from_start"] | false;
 }

--- a/src/PowerLimiterBatteryInverter.cpp
+++ b/src/PowerLimiterBatteryInverter.cpp
@@ -1,4 +1,5 @@
 #include "PowerLimiterBatteryInverter.h"
+#include "LogHelper.h"
 
 PowerLimiterBatteryInverter::PowerLimiterBatteryInverter(PowerLimiterInverterConfig const& config)
     : PowerLimiterInverter(config) { }
@@ -9,7 +10,7 @@ uint16_t PowerLimiterBatteryInverter::getMaxReductionWatts(bool allowStandby) co
 
     if (!isProducing()) { return 0; }
 
-    if (allowStandby) { return getCurrentOutputAcWatts(); }
+    if (allowStandby && _config.AllowStandby) { return getCurrentOutputAcWatts(); }
 
     if (getCurrentOutputAcWatts() <= _config.LowerPowerLimit) { return 0; }
 
@@ -44,11 +45,11 @@ uint16_t PowerLimiterBatteryInverter::applyReduction(uint16_t reduction, bool al
 
     auto low = std::min(getCurrentLimitWatts(), getCurrentOutputAcWatts());
     if (low <= _config.LowerPowerLimit) {
-        if (allowStandby) {
+        if (allowStandby && _config.AllowStandby) {
             standby();
             return std::min(reduction, getCurrentOutputAcWatts());
         }
-        return 0;
+        return 0; // todo @SW-Niko: would it be more safe to set the lower limit again?
     }
 
     if ((getCurrentLimitWatts() - _config.LowerPowerLimit) >= reduction) {
@@ -56,7 +57,7 @@ uint16_t PowerLimiterBatteryInverter::applyReduction(uint16_t reduction, bool al
         return reduction;
     }
 
-    if (allowStandby) {
+    if (allowStandby && _config.AllowStandby) {
         standby();
         return std::min(reduction, getCurrentOutputAcWatts());
     }

--- a/src/PowerLimiterInverter.cpp
+++ b/src/PowerLimiterInverter.cpp
@@ -192,7 +192,13 @@ bool PowerLimiterInverter::update()
             return true;
         }
 
-        float newRelativeLimit = static_cast<float>(*_oTargetPowerLimitWatts * 100) / getInverterMaxPowerWatts();
+        // ATF: get the relative limit from ATF if active
+        float newRelativeLimit = 0.0f;
+        if (isATFActive()) {
+            newRelativeLimit = getATFLimit(*_oTargetPowerLimitWatts); // ATF
+        } else {
+            newRelativeLimit = static_cast<float>(*_oTargetPowerLimitWatts * 100) / getInverterMaxPowerWatts(); // linear
+        }
 
         // if no limit command is pending, the SystemConfigPara does report the
         // current limit, as the answer by the inverter to a limit command is
@@ -348,7 +354,13 @@ float PowerLimiterInverter::getDcVoltage(uint8_t input)
 uint16_t PowerLimiterInverter::getCurrentLimitWatts() const
 {
     auto currentLimitPercent = _spInverter->SystemConfigPara()->getLimitPercent();
-    return static_cast<uint16_t>(currentLimitPercent * getInverterMaxPowerWatts() / 100);
+
+    // get the power from ATF or from the linear calculation
+    if (isATFActive()) {
+        return getATFPower(currentLimitPercent); // ATF
+    } else {
+        return static_cast<uint16_t>(currentLimitPercent * getInverterMaxPowerWatts() / 100); // linear
+    }
 }
 
 void PowerLimiterInverter::debug() const

--- a/src/PowerLimiterInverter.cpp
+++ b/src/PowerLimiterInverter.cpp
@@ -309,7 +309,8 @@ uint16_t PowerLimiterInverter::getConfiguredMaxPowerWatts() const
 
 uint16_t PowerLimiterInverter::getCurrentOutputAcWatts() const
 {
-    return _spInverter->Statistics()->getChannelFieldValue(TYPE_AC, CH0, FLD_PAC);
+    if (_oInverterMeterPower.has_value()) { return _oInverterMeterPower.value();} // use the external inverter meter
+    return _spInverter->Statistics()->getChannelFieldValue(TYPE_AC, CH0, FLD_PAC); // use the inverter stats
 }
 
 uint16_t PowerLimiterInverter::getExpectedOutputAcWatts() const
@@ -446,4 +447,23 @@ char PowerLimiterInverter::mpptName(MpptNum_t mppt)
         default:
             return '?';
     }
+}
+
+bool PowerLimiterInverter::setCurrentOutputAcWatts(float power, uint32_t timestamp) {
+
+    auto oStatsMillis = getLatestStatsMillis();
+    if ((power <= 0.0f) || timestamp == 0|| !oStatsMillis.has_value() || !isEligible()) {
+        _oInverterMeterPower = std::nullopt;
+        return true; // longer waiting makes no sense
+    }
+
+    // todo: use inverter meter delay time instead of fixed 2 seconds?
+    auto nowMillis = millis();
+    if (((nowMillis - timestamp) > (nowMillis - oStatsMillis.value() + 2000))) {
+        _oInverterMeterPower = std::nullopt;
+        return false; // we want to wait longer for a newer value
+    }
+
+    _oInverterMeterPower = power;
+    return true; // ok, now we have a valid value
 }

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -6,11 +6,13 @@
  * - The data is stored in JSON format
  * - The data is written during WebApp 'OTA firmware upgrade' and during Webapp 'Reboot'
  * - For security reasons such as 'unexpected power cycles' or 'physical resets', data is also written once a day at 00:05
- * - The data will not be written if the last write operation was less than one hour ago.
+ * - The data will not be written if the last write operation was less than one hour ago. ('OTA firmware upgrade' and 'Reboot')
  * - Threadsave access to the data is provided by a mutex.
  *
- * Note: Runtime data must be added in the read() and write() methods.
- *       To avoid reenter deadlocks, do not call write() or read() from a locally locked mutex to save local data on demand!
+ * How to use:
+ *  - Runtime data must be added in the read() and write() methods.
+ *  - To avoid reenter deadlocks, do not call write() or read() from a locally locked mutex to save locally data on demand!
+ *  - Use requestWriteOnNextTaskLoop() to avoid deadlocks if you want to save locally data on demand.
  *
  * 2025.09.11 - 1.0 - first version
  */
@@ -51,8 +53,12 @@ void RuntimeClass::init(Scheduler& scheduler)
  */
 void RuntimeClass::loop(void)
 {
-    // check whether it is time to write the runtime data but do not write if last write operation was less than 60 min ago
-    if (getWriteTrigger()) { write(60); }
+
+    // check if we need to write the runtime data, either it is 00:05 or on request
+    if (_writeNow || getWriteTrigger()) {
+        _writeNow = false;
+        write(0); // no freeze time.
+    }
 }
 
 
@@ -77,45 +83,46 @@ bool RuntimeClass::write(uint16_t const freezeMinutes)
     if (!Utils::getEpoch(&nextEpoch, 5)) { return cleanExit(false, "Local time not available, skipping write"); }
     uint16_t nextCount;
 
-    { // prepare the next write count
+    {
         std::lock_guard<std::mutex> lock(_mutex);
 
-        // we do not write more than once in a hour
+        // check minimum interval between writes (enforced only when freezeMinutes > 0)
         if ((_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * freezeMinutes)) {
             return cleanExit(false, "Time interval between 2 write operations too short, skipping write");
         }
+
+        // prepare the next write count
         nextCount = _writeCount + 1;
-    } // mutex is automatically released when lock goes out of this scope
 
-    JsonDocument doc;
-    JsonObject info = doc["info"].to<JsonObject>();
-    info["version"] = RUNTIME_VERSION;
-    info["save_count"] = nextCount;
-    info["save_epoch"] = nextEpoch;
+        JsonDocument doc;
+        JsonObject info = doc["info"].to<JsonObject>();
+        info["version"] = RUNTIME_VERSION;
+        info["save_count"] = nextCount;
+        info["save_epoch"] = nextEpoch;
 
-    // Insert additional runtime data here and protect the shared data with a local mutex
-
+        // Insert additional runtime data here and protect the shared data with a local mutex
 
 
-    if (!Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
-        return cleanExit(false, "JSON alloc fault, skipping write");
-    }
 
-    File fRuntime = LittleFS.open(RUNTIME_FILENAME, "w");
-    if (!fRuntime) { return cleanExit(false, "Failed to open file for writing"); }
+        if (!Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
+            return cleanExit(false, "JSON alloc fault, skipping write");
+        }
 
-    if (serializeJson(doc, fRuntime) == 0) {
+        File fRuntime = LittleFS.open(RUNTIME_FILENAME, "w");
+        if (!fRuntime) { return cleanExit(false, "Failed to open file for writing"); }
+
+        if (serializeJson(doc, fRuntime) == 0) {
+            fRuntime.close();
+            return cleanExit(false, "Failed to serialize to file");
+        }
+
         fRuntime.close();
-        return cleanExit(false, "Failed to serialize to file");
-    }
 
-    fRuntime.close();
-
-    { // commit the new state only after a successful write
-        std::lock_guard<std::mutex> lock(_mutex);
+        // commit the new state only after a successful write
         _writeVersion = RUNTIME_VERSION;
         _writeEpoch = nextEpoch;
         _writeCount = nextCount;
+
     } // mutex is automatically released when lock goes out of this scope
 
     return cleanExit(true, "Written to file");
@@ -210,17 +217,20 @@ String RuntimeClass::getWriteCountAndTimeString(void) const
  * Returns true at the daily trigger time at 00:05
  */
 bool RuntimeClass::getWriteTrigger(void) {
+
+    struct tm nowTime;
+    if (!getLocalTime(&nowTime, 5)) {
+        return false;
+    }
+
     std::lock_guard<std::mutex> lock(_mutex);
-    struct tm actTime;
-    if (getLocalTime(&actTime, 5)) {
-        if ((actTime.tm_hour == 0) && (actTime.tm_min >= 5) && (actTime.tm_min <= 10)) {
-            if (_lastTrigger == false) {
-                _lastTrigger = true;
-                return true;
-            }
-        } else {
-            _lastTrigger = false;
+    if ((nowTime.tm_hour == 0) && (nowTime.tm_min >= 5) && (nowTime.tm_min <= 10)) {
+        if (_lastTrigger == false) {
+            _lastTrigger = true;
+            return true;
         }
+    } else {
+        _lastTrigger = false;
     }
     return false;
 }

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -111,6 +111,7 @@ bool RuntimeClass::write(uint16_t const freezeMinutes)
 
         // Insert additional runtime data here and protect the shared data with a local mutex
         PowerLimiter.serializeRTD(doc["power_limiter"].to<JsonObject>());
+        PowerLimiter.serializeATFtoRTD(doc.as<JsonVariant>());
 
 
 
@@ -172,7 +173,7 @@ bool RuntimeClass::read(ReadMode const mode)
     if (mode == ReadMode::START_UP) {
         PowerLimiter.deserializeRTD(doc["power_limiter"]);
     } else {
-        ;
+        PowerLimiter.deserializeRTDtoATF(doc.as<JsonVariant>());
     }
 
 

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/* Runtime Data Management
+ *
+ * Read and write runtime data persistent on LittleFS
+ * - The data is stored in JSON format.
+ * - The data is written once a day at 00:05, during WebApp 'OTA firmware update' and 'Reset'.
+ * - The data is not written if last write was less then 1 hour ago.
+ * - Threadsave access to the data is provided by a mutex.
+ * Note: Additional runtime data must be added in the read() and write() methods.
+ *       To avoid reenter deadlocks, do not call write() or read() from a locally locked mutex to save local data!
+ *
+ * 2025.09.11 - 1.0 - first version
+ */
+
+#include <Utils.h>
+#include <LittleFS.h>
+#include <LogHelper.h>
+#include "RuntimeData.h"
+
+
+#undef TAG
+static const char* TAG = "configuration";
+static const char* SUBTAG = "runtime";
+
+
+constexpr const char* RUNTIME_FILENAME = "/runtime.json";   // filename of the runtime data file
+constexpr uint16_t RUNTIME_VERSION = 0;                     // version of the runtime data structure, prepared for future use
+
+
+RuntimeClass RuntimeData {RUNTIME_VERSION}; // singleton instance
+
+
+/*
+ * Init the runtime data loop task
+ */
+void RuntimeClass::init(Scheduler& scheduler)
+{
+    scheduler.addTask(_loopTask);
+    _loopTask.setCallback(std::bind(&RuntimeClass::loop, this));
+    _loopTask.setIterations(TASK_FOREVER);
+    _loopTask.setInterval(60 * 1000); // every minute
+    _loopTask.enable();
+}
+
+
+/*
+ * The runtime data loop is called every minute
+ */
+void RuntimeClass::loop(void)
+{
+    // check whether it is time to write the runtime data
+    if (getWriteTrigger()) { write(); }
+}
+
+
+/*
+ * Writes the runtime data to LittleFS file
+ */
+bool RuntimeClass::write(void)
+{
+    auto cleanExit = [this](const bool writeOk, const char* text) -> bool {
+        if (writeOk) {
+            DTU_LOGI("%s", text);
+        } else {
+            DTU_LOGE("%s", text);
+        }
+        _writeOK = writeOk;
+        return writeOk;
+    };
+
+    // we need the local time before we can write the runtime data
+    time_t nowEpoch;
+    if (!Utils::getEpoch(&nowEpoch, 5)) { return cleanExit(true, "Local time not available, skipping write"); }
+
+    JsonDocument doc;
+    { // mutex is automatically released when lock goes out of this scope
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        // we do not write more than once in a hour
+        if ((_writeEpoch != 0) && (difftime(nowEpoch, _writeEpoch) < 60 * 60)) {
+            return cleanExit(true, "Last write less than 1 hour ago, skipping write");
+        }
+
+        _writeEpoch = nowEpoch;
+        _writeCount++;
+        JsonObject info = doc["info"].to<JsonObject>();
+        info["version"] = _writeVersion;
+        info["save_count"] = _writeCount;
+        info["save_epoch"] = _writeEpoch;
+    } // mutex is automatically released when lock goes out of this scope
+
+    // Insert additional runtime data here and protect the shared data with a local mutex
+
+
+    if (!Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
+        return cleanExit(false, "JSON alloc fault, skipping write");
+    }
+
+    File fRuntime = LittleFS.open(RUNTIME_FILENAME, "w");
+    if (!fRuntime) { return cleanExit(false, "Failed to open file for writing"); }
+
+    if (serializeJson(doc, fRuntime) == 0) {
+        fRuntime.close();
+        return cleanExit(false, "Failed to serialize to file");
+    }
+
+    fRuntime.close();
+    return cleanExit(true, "Written to file");
+}
+
+
+/*
+ * Read the runtime data from LittleFS file
+ */
+bool RuntimeClass::read(void)
+{
+    bool readOk = false;
+    JsonDocument doc;
+
+    // Note: We do not exit on read or allocation errors. In that case we need the default values
+    File fRuntime = LittleFS.open(RUNTIME_FILENAME, "r", false);
+    if (fRuntime) {
+        Utils::skipBom(fRuntime);
+        DeserializationError error = deserializeJson(doc, fRuntime);
+        if (!error && Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
+            readOk = true; // success of reading the runtime data
+        }
+    }
+
+    JsonObject info = doc["info"];
+    { // mutex is automatically released when lock goes out of this scope
+        std::lock_guard<std::mutex> lock(_mutex);
+        _writeVersion = info["version"] | RUNTIME_VERSION;
+        _writeCount = info["save_count"] | 0U;
+        _writeEpoch = info["save_epoch"] | 0U;
+    } // mutex is automatically released when lock goes out of this scope
+
+    // deserialize additional runtime data here, prepare default values and protect the shared data with a local mutex
+
+
+    if (fRuntime) { fRuntime.close(); }
+    if (readOk) {
+        DTU_LOGI("Read successfully");
+    } else {
+        DTU_LOGE("Read fault, using default values");
+    }
+    _readOK = readOk;
+    return readOk;
+}
+
+
+/*
+ * Get the write counter
+ */
+uint16_t RuntimeClass::getWriteCount(void) const
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _writeCount;
+}
+
+
+/*
+ * Get the write epoch time
+ */
+time_t RuntimeClass::getWriteEpochTime(void) const
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _writeEpoch;
+}
+
+
+/*
+ * Get the write count and time as string
+ * Format: "<count> / <dd>-<mon> <hh>:<mm>"
+ * If epoch time and local time is not available the time is replaced by "no time"
+ */
+String RuntimeClass::getWriteCountAndTimeString(void) const
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    char buf[32] = "";
+    struct tm time;
+    if ((_writeEpoch != 0) && (getLocalTime(&time, 5))) {
+        localtime_r(&_writeEpoch, &time);
+        strftime(buf, sizeof(buf), " / %d-%h %R", &time);
+    } else {
+        snprintf(buf, sizeof(buf), " / no time");
+    }
+    String ctString = String(_writeCount) + String(buf);
+    return ctString;
+}
+
+
+/*
+ * Returns true at the daily trigger time at 00:05
+ */
+bool RuntimeClass::getWriteTrigger(void) const {
+    static bool lastTrigger = false;
+    struct tm actTime;
+    if (getLocalTime(&actTime, 5)) {
+        if ((actTime.tm_hour == 0) && (actTime.tm_min >= 5) && (actTime.tm_min <= 10)) {
+            if (lastTrigger == false) {
+                lastTrigger = true;
+                return true;
+            }
+        } else {
+            lastTrigger = false;
+        }
+    }
+    return false;
+}

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -3,12 +3,14 @@
 /* Runtime Data Management
  *
  * Read and write runtime data persistent on LittleFS
- * - The data is stored in JSON format.
- * - The data is written once a day at 00:05, during WebApp 'OTA firmware update' and 'Reset'.
- * - The data is not written if last write was less then 1 hour ago.
+ * - The data is stored in JSON format
+ * - The data is written during WebApp 'OTA firmware upgrade' and during Webapp 'Reboot'
+ * - For security reasons such as 'unexpected power cycles' or 'physical resets', data is also written once a day at 00:05
+ * - The data will not be written if the last write operation was less than one hour ago.
  * - Threadsave access to the data is provided by a mutex.
- * Note: Additional runtime data must be added in the read() and write() methods.
- *       To avoid reenter deadlocks, do not call write() or read() from a locally locked mutex to save local data!
+ *
+ * Note: Runtime data must be added in the read() and write() methods.
+ *       To avoid reenter deadlocks, do not call write() or read() from a locally locked mutex to save local data on demand!
  *
  * 2025.09.11 - 1.0 - first version
  */
@@ -20,8 +22,8 @@
 
 
 #undef TAG
-static const char* TAG = "configuration";
-static const char* SUBTAG = "runtime";
+static const char* TAG = "runtimedata";
+static const char* SUBTAG = "Handler";
 
 
 constexpr const char* RUNTIME_FILENAME = "/runtime.json";   // filename of the runtime data file
@@ -49,15 +51,16 @@ void RuntimeClass::init(Scheduler& scheduler)
  */
 void RuntimeClass::loop(void)
 {
-    // check whether it is time to write the runtime data
-    if (getWriteTrigger()) { write(); }
+    // check whether it is time to write the runtime data but do not write if last write operation was less than 60 min ago
+    if (getWriteTrigger()) { write(60); }
 }
 
 
 /*
  * Writes the runtime data to LittleFS file
+ * freezeTime: Minimum necessary time [minutes] between now and last write operation
  */
-bool RuntimeClass::write(void)
+bool RuntimeClass::write(uint16_t const freezeTime = 10)
 {
     auto cleanExit = [this](const bool writeOk, const char* text) -> bool {
         if (writeOk) {
@@ -78,7 +81,7 @@ bool RuntimeClass::write(void)
         std::lock_guard<std::mutex> lock(_mutex);
 
         // we do not write more than once in a hour
-        if ((_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * 60)) {
+        if ((_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * freezeTime)) {
             return cleanExit(true, "Last write less than 1 hour ago, skipping write");
         }
         nextCount = _writeCount + 1;
@@ -189,6 +192,8 @@ String RuntimeClass::getWriteCountAndTimeString(void) const
     std::lock_guard<std::mutex> lock(_mutex);
     char buf[32] = "";
     struct tm time;
+
+    // Check if time service is available before converting epoch to local time
     if ((_writeEpoch != 0) && (getLocalTime(&time, 5))) {
         localtime_r(&_writeEpoch, &time);
         strftime(buf, sizeof(buf), " / %d-%h %R", &time);

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -69,28 +69,29 @@ bool RuntimeClass::write(void)
         return writeOk;
     };
 
-    // we need the local time before we can write the runtime data
-    time_t nowEpoch;
-    if (!Utils::getEpoch(&nowEpoch, 5)) { return cleanExit(true, "Local time not available, skipping write"); }
+    // we need the next local time before we can write the runtime data
+    time_t nextEpoch;
+    if (!Utils::getEpoch(&nextEpoch, 5)) { return cleanExit(true, "Local time not available, skipping write"); }
+    uint16_t nextCount;
 
-    JsonDocument doc;
-    { // mutex is automatically released when lock goes out of this scope
+    { // prepare the next write count
         std::lock_guard<std::mutex> lock(_mutex);
 
         // we do not write more than once in a hour
-        if ((_writeEpoch != 0) && (difftime(nowEpoch, _writeEpoch) < 60 * 60)) {
+        if ((_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * 60)) {
             return cleanExit(true, "Last write less than 1 hour ago, skipping write");
         }
-
-        _writeEpoch = nowEpoch;
-        _writeCount++;
-        JsonObject info = doc["info"].to<JsonObject>();
-        info["version"] = _writeVersion;
-        info["save_count"] = _writeCount;
-        info["save_epoch"] = _writeEpoch;
+        nextCount = _writeCount + 1;
     } // mutex is automatically released when lock goes out of this scope
 
+    JsonDocument doc;
+    JsonObject info = doc["info"].to<JsonObject>();
+    info["version"] = RUNTIME_VERSION;
+    info["save_count"] = nextCount;
+    info["save_epoch"] = nextEpoch;
+
     // Insert additional runtime data here and protect the shared data with a local mutex
+
 
 
     if (!Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
@@ -106,6 +107,14 @@ bool RuntimeClass::write(void)
     }
 
     fRuntime.close();
+
+    { // commit the new state only after a successful write
+        std::lock_guard<std::mutex> lock(_mutex);
+        _writeVersion = RUNTIME_VERSION;
+        _writeEpoch = nextEpoch;
+        _writeCount = nextCount;
+    } // mutex is automatically released when lock goes out of this scope
+
     return cleanExit(true, "Written to file");
 }
 

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -194,17 +194,16 @@ String RuntimeClass::getWriteCountAndTimeString(void) const
 /*
  * Returns true at the daily trigger time at 00:05
  */
-bool RuntimeClass::getWriteTrigger(void) const {
-    static bool lastTrigger = false;
+bool RuntimeClass::getWriteTrigger(void) {
     struct tm actTime;
     if (getLocalTime(&actTime, 5)) {
         if ((actTime.tm_hour == 0) && (actTime.tm_min >= 5) && (actTime.tm_min <= 10)) {
-            if (lastTrigger == false) {
-                lastTrigger = true;
+            if (_lastTrigger == false) {
+                _lastTrigger = true;
                 return true;
             }
         } else {
-            lastTrigger = false;
+            _lastTrigger = false;
         }
     }
     return false;

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -60,7 +60,7 @@ void RuntimeClass::loop(void)
  * Writes the runtime data to LittleFS file
  * freezeTime: Minimum necessary time [minutes] between now and last write operation
  */
-bool RuntimeClass::write(uint16_t const freezeTime = 10)
+bool RuntimeClass::write(uint16_t const freezeTime)
 {
     auto cleanExit = [this](const bool writeOk, const char* text) -> bool {
         if (writeOk) {
@@ -74,7 +74,7 @@ bool RuntimeClass::write(uint16_t const freezeTime = 10)
 
     // we need the next local time before we can write the runtime data
     time_t nextEpoch;
-    if (!Utils::getEpoch(&nextEpoch, 5)) { return cleanExit(true, "Local time not available, skipping write"); }
+    if (!Utils::getEpoch(&nextEpoch, 5)) { return cleanExit(false, "Local time not available, skipping write"); }
     uint16_t nextCount;
 
     { // prepare the next write count
@@ -82,7 +82,7 @@ bool RuntimeClass::write(uint16_t const freezeTime = 10)
 
         // we do not write more than once in a hour
         if ((_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * freezeTime)) {
-            return cleanExit(true, "Last write less than 1 hour ago, skipping write");
+            return cleanExit(false, "Time interval between 2 write operations too short, skipping write");
         }
         nextCount = _writeCount + 1;
     } // mutex is automatically released when lock goes out of this scope
@@ -207,6 +207,7 @@ String RuntimeClass::getWriteCountAndTimeString(void) const
 
 /*
  * Returns true at the daily trigger time at 00:05
+ * Note: This function is not protected by a mutex, but if it is only called by loop() and loop() is only executed on a single thread, we are safe
  */
 bool RuntimeClass::getWriteTrigger(void) {
     struct tm actTime;

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -21,6 +21,7 @@
 #include <LittleFS.h>
 #include <LogHelper.h>
 #include "RuntimeData.h"
+#include "PowerLimiter.h"
 
 
 #undef TAG
@@ -101,6 +102,7 @@ bool RuntimeClass::write(uint16_t const freezeMinutes)
         info["save_epoch"] = nextEpoch;
 
         // Insert additional runtime data here and protect the shared data with a local mutex
+        PowerLimiter.serializeRTD(doc["power_limiter"].to<JsonObject>());
 
 
 
@@ -156,7 +158,8 @@ bool RuntimeClass::read(void)
     } // mutex is automatically released when lock goes out of this scope
 
     // deserialize additional runtime data here, prepare default values and protect the shared data with a local mutex
-
+    PowerLimiter.deserializeRTD(doc["power_limiter"]);
+    
 
     if (fRuntime) { fRuntime.close(); }
     if (readOk) {

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -87,7 +87,7 @@ bool RuntimeClass::write(uint16_t const freezeMinutes)
         std::lock_guard<std::mutex> lock(_mutex);
 
         // check minimum interval between writes (enforced only when freezeMinutes > 0)
-        if ((_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * freezeMinutes)) {
+        if ((freezeMinutes > 0) && (_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * freezeMinutes)) {
             return cleanExit(false, "Time interval between 2 write operations too short, skipping write");
         }
 
@@ -214,7 +214,7 @@ String RuntimeClass::getWriteCountAndTimeString(void) const
 
 
 /*
- * Returns true at the daily trigger time at 00:05
+ * Returns true once a day between 00:05 - 00:10
  */
 bool RuntimeClass::getWriteTrigger(void) {
 

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -58,9 +58,9 @@ void RuntimeClass::loop(void)
 
 /*
  * Writes the runtime data to LittleFS file
- * freezeTime: Minimum necessary time [minutes] between now and last write operation
+ * freezeMinutes: Minimum necessary time [minutes] between now and last write operation
  */
-bool RuntimeClass::write(uint16_t const freezeTime)
+bool RuntimeClass::write(uint16_t const freezeMinutes)
 {
     auto cleanExit = [this](const bool writeOk, const char* text) -> bool {
         if (writeOk) {
@@ -81,7 +81,7 @@ bool RuntimeClass::write(uint16_t const freezeTime)
         std::lock_guard<std::mutex> lock(_mutex);
 
         // we do not write more than once in a hour
-        if ((_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * freezeTime)) {
+        if ((_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * freezeMinutes)) {
             return cleanExit(false, "Time interval between 2 write operations too short, skipping write");
         }
         nextCount = _writeCount + 1;
@@ -193,7 +193,8 @@ String RuntimeClass::getWriteCountAndTimeString(void) const
     char buf[32] = "";
     struct tm time;
 
-    // Check if time service is available before converting epoch to local time
+    // Before we can convert the epoch to local time, we need to ensure we've received the correct time
+    // from the time server. This may take some time after the system boots.
     if ((_writeEpoch != 0) && (getLocalTime(&time, 5))) {
         localtime_r(&_writeEpoch, &time);
         strftime(buf, sizeof(buf), " / %d-%h %R", &time);
@@ -207,9 +208,9 @@ String RuntimeClass::getWriteCountAndTimeString(void) const
 
 /*
  * Returns true at the daily trigger time at 00:05
- * Note: This function is not protected by a mutex, but if it is only called by loop() and loop() is only executed on a single thread, we are safe
  */
 bool RuntimeClass::getWriteTrigger(void) {
+    std::lock_guard<std::mutex> lock(_mutex);
     struct tm actTime;
     if (getLocalTime(&actTime, 5)) {
         if ((actTime.tm_hour == 0) && (actTime.tm_min >= 5) && (actTime.tm_min <= 10)) {

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -12,9 +12,10 @@
  * How to use:
  *  - Runtime data must be added in the read() and write() methods.
  *  - To avoid reenter deadlocks, do not call write() or read() from a locally locked mutex to save locally data on demand!
- *  - Use requestWriteOnNextTaskLoop() to avoid deadlocks if you want to save locally data on demand.
+ *  - Use requestWriteOnNextTaskLoop() and requestReadOnNextTaskLoop() to avoid deadlocks if you want to handle locally data on demand.
  *
  * 2025.09.11 - 1.0 - first version
+ * 2025.12.01 - 1.1 - added read mode ON_DEMAND
  */
 
 #include <Utils.h>
@@ -59,6 +60,13 @@ void RuntimeClass::loop(void)
     if (_writeNow || getWriteTrigger()) {
         _writeNow = false;
         write(0); // no freeze time.
+    }
+
+    // check if we need to read the runtime data on request
+    // for example, if some data is not available during startup
+    if (_readNow) {
+        _readNow = false;
+        read(ReadMode::ON_DEMAND); // read data that can be read on demand
     }
 }
 
@@ -133,8 +141,10 @@ bool RuntimeClass::write(uint16_t const freezeMinutes)
 
 /*
  * Read the runtime data from LittleFS file
+ * mode = START_UP: read data that can be initialized during startup
+ * mode = ON_DEMAND: read data that can not be read during startup
  */
-bool RuntimeClass::read(void)
+bool RuntimeClass::read(ReadMode const mode)
 {
     bool readOk = false;
     JsonDocument doc;
@@ -158,8 +168,13 @@ bool RuntimeClass::read(void)
     } // mutex is automatically released when lock goes out of this scope
 
     // deserialize additional runtime data here, prepare default values and protect the shared data with a local mutex
-    PowerLimiter.deserializeRTD(doc["power_limiter"]);
-    
+    // use mode == 0 for all data that can be initialized during startup
+    if (mode == ReadMode::START_UP) {
+        PowerLimiter.deserializeRTD(doc["power_limiter"]);
+    } else {
+        ;
+    }
+
 
     if (fRuntime) { fRuntime.close(); }
     if (readOk) {

--- a/src/WebApi.cpp
+++ b/src/WebApi.cpp
@@ -41,6 +41,7 @@ void WebApiClass::init(Scheduler& scheduler)
     _webApiWsLive.init(_server, scheduler);
     _webApiBattery.init(_server, scheduler);
     _webApiPowerMeter.init(_server, scheduler);
+    _webApiInverterMeter.init(_server, scheduler);
     _webApiPowerLimiter.init(_server, scheduler);
     _webApiWsSolarChargerLive.init(_server, scheduler);
     _webApiSolarCharger.init(_server, scheduler);

--- a/src/WebApi_firmware.cpp
+++ b/src/WebApi_firmware.cpp
@@ -48,6 +48,9 @@ void WebApiFirmwareClass::onFirmwareUpdateFinish(AsyncWebServerRequest* request)
     response->addHeader(asyncsrv::T_Connection, asyncsrv::T_close);
     response->addHeader(asyncsrv::T_CORS_ACAO, "*");
     request->send(response);
+
+    // write the runtime data to LittleFS, but do not write if last write operation was less than 60 min ago
+    RuntimeData.write(60);
     RestartHelper.triggerRestart();
 }
 
@@ -85,7 +88,6 @@ void WebApiFirmwareClass::onFirmwareUpdateUpload(AsyncWebServerRequest* request,
     }
 
     if (final) { // if the final flag is set then this is the last frame of data
-        RuntimeData.write(); // write the runtime data to LittleFS
         if (!Update.end(true)) { // true to set the size to the current progress
             Update.printError(Serial);
             return request->send(400, asyncsrv::T_text_plain, "Could not end OTA");

--- a/src/WebApi_firmware.cpp
+++ b/src/WebApi_firmware.cpp
@@ -10,6 +10,7 @@
 #include <AsyncJson.h>
 #include <Update.h>
 #include "esp_partition.h"
+#include "RuntimeData.h"
 
 void WebApiFirmwareClass::init(AsyncWebServer& server, Scheduler& scheduler)
 {
@@ -84,6 +85,7 @@ void WebApiFirmwareClass::onFirmwareUpdateUpload(AsyncWebServerRequest* request,
     }
 
     if (final) { // if the final flag is set then this is the last frame of data
+        RuntimeData.write(); // write the runtime data to LittleFS
         if (!Update.end(true)) { // true to set the size to the current progress
             Update.printError(Serial);
             return request->send(400, asyncsrv::T_text_plain, "Could not end OTA");

--- a/src/WebApi_invertermeter.cpp
+++ b/src/WebApi_invertermeter.cpp
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2022-2024 Thomas Basler and others
+ */
+#include "WebApi_invertermeter.h"
+#include "ArduinoJson.h"
+#include "AsyncJson.h"
+#include "Configuration.h"
+#include "MqttHandleHass.h"
+#include "MqttSettings.h"
+#include <invertermeter/Controller.h>
+#include <powermeter/json/http/Provider.h>
+#include <powermeter/sml/http/Provider.h>
+#include "WebApi.h"
+#include "helper.h"
+
+
+void WebApiInverterMeterClass::init(AsyncWebServer& server, Scheduler& scheduler)
+{
+    using std::placeholders::_1;
+
+    _server = &server;
+
+    _server->on("/api/invertermeter/status", HTTP_GET, std::bind(&WebApiInverterMeterClass::onStatus, this, _1));
+    _server->on("/api/invertermeter/config", HTTP_GET, std::bind(&WebApiInverterMeterClass::onAdminGet, this, _1));
+    _server->on("/api/invertermeter/config", HTTP_POST, std::bind(&WebApiInverterMeterClass::onAdminPost, this, _1));
+    _server->on("/api/invertermeter/testhttpjsonrequest", HTTP_POST, std::bind(&WebApiInverterMeterClass::onTestHttpJsonRequest, this, _1));
+    _server->on("/api/invertermeter/testhttpsmlrequest", HTTP_POST, std::bind(&WebApiInverterMeterClass::onTestHttpSmlRequest, this, _1));
+}
+
+
+void WebApiInverterMeterClass::onStatus(AsyncWebServerRequest* request)
+{
+    if (!WebApi.checkCredentialsReadonly(request)) {
+        return;
+    }
+
+    AsyncJsonResponse* response = new AsyncJsonResponse();
+    auto& root = response->getRoot();
+    auto const& config = Configuration.get();
+
+    root["enabled"] = config.InverterMeter.Enabled;
+    root["source"] = config.InverterMeter.Source;
+
+    // Inverter Serial is read as HEX
+    char buffer[sizeof(uint64_t) * 8 + 1];
+    snprintf(buffer, sizeof(buffer), "%0" PRIx32 "%08" PRIx32,
+        static_cast<uint32_t>((config.InverterMeter.Serial >> 32) & 0xFFFFFFFF),
+        static_cast<uint32_t>(config.InverterMeter.Serial & 0xFFFFFFFF));
+    root["serial"] = buffer;
+
+    auto mqtt = root["mqtt"].to<JsonObject>();
+    Configuration.serializePowerMeterMqttConfig(config.InverterMeter.Mqtt, mqtt);
+
+    auto serialSdm = root["serial_sdm"].to<JsonObject>();
+    Configuration.serializePowerMeterSerialSdmConfig(config.InverterMeter.SerialSdm, serialSdm);
+
+    auto httpJson = root["http_json"].to<JsonObject>();
+    Configuration.serializePowerMeterHttpJsonConfig(config.InverterMeter.HttpJson, httpJson);
+
+    auto httpSml = root["http_sml"].to<JsonObject>();
+    Configuration.serializePowerMeterHttpSmlConfig(config.InverterMeter.HttpSml, httpSml);
+
+    auto udpVictron = root["udp_victron"].to<JsonObject>();
+    Configuration.serializePowerMeterUdpVictronConfig(config.InverterMeter.UdpVictron, udpVictron);
+
+    WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
+}
+
+
+void WebApiInverterMeterClass::onAdminGet(AsyncWebServerRequest* request)
+{
+    if (!WebApi.checkCredentials(request)) {
+        return;
+    }
+
+    this->onStatus(request);
+}
+
+
+void WebApiInverterMeterClass::onAdminPost(AsyncWebServerRequest* request)
+{
+    if (!WebApi.checkCredentials(request)) {
+        return;
+    }
+
+    AsyncJsonResponse* response = new AsyncJsonResponse();
+    JsonDocument root;
+    if (!WebApi.parseRequestData(request, response, root)) {
+        return;
+    }
+
+    auto& retMsg = response->getRoot();
+
+    if (!(root["enabled"].is<bool>() && root["source"].is<uint32_t>())) {
+        retMsg["message"] = "Values are missing!";
+        response->setLength();
+        request->send(response);
+        return;
+    }
+
+    auto checkHttpConfig = [&](JsonObject const& cfg) -> bool {
+
+        if (!cfg["url"].is<String>()
+                || (!cfg["url"].as<String>().startsWith("http://")
+                    && !cfg["url"].as<String>().startsWith("https://"))) {
+            retMsg["message"] = "URL must either start with http:// or https://!";
+            response->setLength();
+            request->send(response);
+            return false;
+        }
+
+        if ((cfg["auth_type"].as<uint8_t>() != HttpRequestConfig::Auth::None)
+                && (cfg["username"].as<String>().length() == 0 || cfg["password"].as<String>().length() == 0)) {
+            retMsg["message"] = "Username or password must not be empty!";
+            response->setLength();
+            request->send(response);
+            return false;
+        }
+
+        if (!cfg["timeout"].is<uint16_t>()
+            || cfg["timeout"].as<uint16_t>() <= 0) {
+            retMsg["message"] = "Timeout must be greater than 0 ms!";
+            response->setLength();
+            request->send(response);
+            return false;
+        }
+
+        return true;
+    };
+
+    if (static_cast<::PowerMeters::Provider::Type>(root["source"].as<uint8_t>()) == ::PowerMeters::Provider::Type::HTTP_JSON) {
+        JsonObject httpJson = root["http_json"];
+        JsonArray valueConfigs = httpJson["values"];
+        for (uint8_t i = 0; i < valueConfigs.size(); i++) {
+            JsonObject valueConfig = valueConfigs[i].as<JsonObject>();
+
+            if (i > 0 && !valueConfig["enabled"].as<bool>()) {
+                continue;
+            }
+
+            if (i == 0 || httpJson["individual_requests"].as<bool>()) {
+                if (!checkHttpConfig(valueConfig["http_request"].as<JsonObject>())) {
+                    return;
+                }
+            }
+
+            if (!valueConfig["json_path"].is<String>()
+                    || valueConfig["json_path"].as<String>().length() == 0) {
+                retMsg["message"] = "Json path must not be empty!";
+                response->setLength();
+                request->send(response);
+                return;
+            }
+        }
+    }
+
+    if (static_cast<::PowerMeters::Provider::Type>(root["source"].as<uint8_t>()) == ::PowerMeters::Provider::Type::HTTP_SML) {
+        JsonObject httpSml = root["http_sml"];
+        if (!checkHttpConfig(httpSml["http_request"].as<JsonObject>())) {
+            return;
+        }
+    }
+
+    if (static_cast<::PowerMeters::Provider::Type>(root["source"].as<uint8_t>()) == ::PowerMeters::Provider::Type::MODBUS_UDP_VICTRON) {
+        JsonObject udpVictron = root["udp_victron"];
+        if (!udpVictron["ip_address"].is<String>()
+                || udpVictron["ip_address"].as<String>().length() == 0) {
+            retMsg["message"] = "IP address must not be empty!";
+            response->setLength();
+            request->send(response);
+            return;
+        }
+
+        if (!udpVictron["polling_interval_ms"].is<uint32_t>()
+                || udpVictron["polling_interval_ms"].as<uint32_t>() <= 0) {
+            retMsg["message"] = "Polling interval must be greater than 0 ms!";
+            response->setLength();
+            request->send(response);
+            return;
+        }
+    }
+
+    {
+        auto guard = Configuration.getWriteGuard();
+        auto& config = guard.getConfig();
+        config.InverterMeter.Enabled = root["enabled"].as<bool>();
+        config.InverterMeter.Source = root["source"].as<uint8_t>();
+
+        // Interpret the string as a hex value and convert it to uint64_t
+        const uint64_t serial = strtoll(root["serial"].as<String>().c_str(), NULL, 16);
+        config.InverterMeter.Serial = serial;
+
+        Configuration.deserializePowerMeterMqttConfig(root["mqtt"].as<JsonObject>(),
+                config.InverterMeter.Mqtt);
+
+        Configuration.deserializePowerMeterSerialSdmConfig(root["serial_sdm"].as<JsonObject>(),
+                config.InverterMeter.SerialSdm);
+
+        Configuration.deserializePowerMeterHttpJsonConfig(root["http_json"].as<JsonObject>(),
+                config.InverterMeter.HttpJson);
+
+        Configuration.deserializePowerMeterHttpSmlConfig(root["http_sml"].as<JsonObject>(),
+                config.InverterMeter.HttpSml);
+
+        Configuration.deserializePowerMeterUdpVictronConfig(root["udp_victron"].as<JsonObject>(),
+                config.InverterMeter.UdpVictron);
+    }
+
+    WebApi.writeConfig(retMsg);
+
+    WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
+
+    InverterMeter.updateSettings();
+
+}
+
+
+void WebApiInverterMeterClass::onTestHttpJsonRequest(AsyncWebServerRequest* request)
+{
+    if (!WebApi.checkCredentials(request)) {
+        return;
+    }
+
+    AsyncJsonResponse* asyncJsonResponse = new AsyncJsonResponse();
+    JsonDocument root;
+    if (!WebApi.parseRequestData(request, asyncJsonResponse, root)) {
+        return;
+    }
+
+    auto& retMsg = asyncJsonResponse->getRoot();
+
+    char response[256];
+
+    auto powerMeterConfig = std::make_unique<PowerMeterHttpJsonConfig>();
+    Configuration.deserializePowerMeterHttpJsonConfig(root["http_json"].as<JsonObject>(),
+            *powerMeterConfig);
+    auto upMeter = std::make_unique<::PowerMeters::Json::Http::Provider>(*powerMeterConfig);
+    upMeter->init();
+    auto res = upMeter->poll();
+    using values_t = ::PowerMeters::DataPointContainer;
+    if (std::holds_alternative<values_t>(res)) {
+        retMsg["type"] = "success";
+        auto const& vals = std::get<values_t>(res);
+        auto iter = vals.cbegin();
+        auto pos = snprintf(response, sizeof(response), "Result: %sW", iter->second.getValueText().c_str());
+        ++iter;
+        while (iter != vals.cend()) {
+            pos += snprintf(response + pos, sizeof(response) - pos, ", %sW", iter->second.getValueText().c_str());
+            ++iter;
+        }
+        snprintf(response + pos, sizeof(response) - pos, ", Total: %5.2f", upMeter->getPowerTotal());
+    } else {
+        snprintf(response, sizeof(response), "%s", std::get<String>(res).c_str());
+    }
+
+    retMsg["message"] = response;
+    asyncJsonResponse->setLength();
+    request->send(asyncJsonResponse);
+}
+
+
+void WebApiInverterMeterClass::onTestHttpSmlRequest(AsyncWebServerRequest* request)
+{
+    if (!WebApi.checkCredentials(request)) {
+        return;
+    }
+
+    AsyncJsonResponse* asyncJsonResponse = new AsyncJsonResponse();
+    JsonDocument root;
+    if (!WebApi.parseRequestData(request, asyncJsonResponse, root)) {
+        return;
+    }
+
+    auto& retMsg = asyncJsonResponse->getRoot();
+
+    char response[256];
+
+    auto powerMeterConfig = std::make_unique<PowerMeterHttpSmlConfig>();
+    Configuration.deserializePowerMeterHttpSmlConfig(root["http_sml"].as<JsonObject>(),
+            *powerMeterConfig);
+    auto upMeter = std::make_unique<::PowerMeters::Sml::Http::Provider>(*powerMeterConfig);
+    upMeter->init();
+    auto res = upMeter->poll();
+    if (res.isEmpty()) {
+        retMsg["type"] = "success";
+        snprintf(response, sizeof(response), "Result: %5.2fW", upMeter->getPowerTotal());
+    } else {
+        snprintf(response, sizeof(response), "%s", res.c_str());
+    }
+
+    retMsg["message"] = response;
+    asyncJsonResponse->setLength();
+    request->send(asyncJsonResponse);
+}

--- a/src/WebApi_maintenance.cpp
+++ b/src/WebApi_maintenance.cpp
@@ -8,6 +8,7 @@
 #include "WebApi.h"
 #include "WebApi_errors.h"
 #include <AsyncJson.h>
+#include "RuntimeData.h"
 
 void WebApiMaintenanceClass::init(AsyncWebServer& server, Scheduler& scheduler)
 {
@@ -43,6 +44,7 @@ void WebApiMaintenanceClass::onRebootPost(AsyncWebServerRequest* request)
         retMsg["code"] = WebApiError::MaintenanceRebootTriggered;
 
         WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
+        RuntimeData.write(); // write the runtime data to LittleFS
         RestartHelper.triggerRestart();
     } else {
         retMsg["message"] = "Reboot cancled!";

--- a/src/WebApi_maintenance.cpp
+++ b/src/WebApi_maintenance.cpp
@@ -44,7 +44,9 @@ void WebApiMaintenanceClass::onRebootPost(AsyncWebServerRequest* request)
         retMsg["code"] = WebApiError::MaintenanceRebootTriggered;
 
         WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
-        RuntimeData.write(); // write the runtime data to LittleFS
+
+        // write the runtime data to LittleFS, but do not write if last write operation was less than 60 min ago
+        RuntimeData.write(60);
         RestartHelper.triggerRestart();
     } else {
         retMsg["message"] = "Reboot cancled!";

--- a/src/WebApi_sysstatus.cpp
+++ b/src/WebApi_sysstatus.cpp
@@ -14,6 +14,7 @@
 #include <Hoymiles.h>
 #include <LittleFS.h>
 #include <ResetReason.h>
+#include "RuntimeData.h"
 
 void WebApiSysstatusClass::init(AsyncWebServer& server, Scheduler& scheduler)
 {
@@ -79,6 +80,7 @@ void WebApiSysstatusClass::onSystemStatus(AsyncWebServerRequest* request)
     root["resetreason_1"] = reason;
 
     root["cfgsavecount"] = Configuration.get().Cfg.SaveCount;
+    root["runtime_savecount"] = RuntimeData.getWriteCountAndTimeString();
 
     char version[16];
     snprintf(version, sizeof(version), "%d.%d.%d", CONFIG_VERSION >> 24 & 0xff, CONFIG_VERSION >> 16 & 0xff, CONFIG_VERSION >> 8 & 0xff);

--- a/src/WebApi_ws_live.cpp
+++ b/src/WebApi_ws_live.cpp
@@ -14,6 +14,7 @@
 #include "defaults.h"
 #include <solarcharger/Controller.h>
 #include <AsyncJson.h>
+#include "PowerLimiter.h"
 
 #undef TAG
 static const char* TAG = "webapi";
@@ -272,7 +273,12 @@ void WebApiWsLiveClass::generateInverterCommonJsonResponse(JsonObject& root, std
     root["producing"] = inv->isProducing();
     root["limit_relative"] = inv->SystemConfigPara()->getLimitPercent();
     if (inv->DevInfo()->getMaxPower() > 0) {
-        root["limit_absolute"] = inv->SystemConfigPara()->getLimitPercent() * inv->DevInfo()->getMaxPower() / 100.0;
+        auto oATFPower = PowerLimiter.getATFInverterPower(inv->serial(), inv->SystemConfigPara()->getLimitPercent());
+        if (oATFPower.has_value()) {
+            root["limit_absolute"] = oATFPower.value();
+        } else {
+            root["limit_absolute"] = inv->SystemConfigPara()->getLimitPercent() * inv->DevInfo()->getMaxPower() / 100.0;
+        }
     } else {
         root["limit_absolute"] = -1;
     }

--- a/src/invertermeter/Controller.cpp
+++ b/src/invertermeter/Controller.cpp
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/* Inverter-Meter
+ *
+ * The Inverter-Meter adding support for an AC power meter to measure inverter output power for DPL functionality.
+ * During the DPL loop the value from the Inverter-Meter is used and not the value from the inverter internal power meter.
+ * Especially HM-xxx inverters powered by 24VDC measure wrong power values at high loads.
+ * - reuse existing PowerMeter providers to get the inverter power values
+ *
+ * Currently restrictions:
+ * - only one Inverter-Meter supported
+ * - only one phase power measurement supported
+ *
+ * 01.08.2024 - 0.1 - first version
+ */
+
+#include <invertermeter/Controller.h>
+#include <Configuration.h>
+#include <powermeter/json/http/Provider.h>
+#include <powermeter/json/mqtt/Provider.h>
+#include <powermeter/sdm/serial/Provider.h>
+#include <powermeter/sml/http/Provider.h>
+#include <powermeter/sml/serial/Provider.h>
+#include <powermeter/smahm/udp/Provider.h>
+#include <powermeter/modbus/udp/victron/Provider.h>
+
+InverterMeters::Controller InverterMeter;
+
+namespace InverterMeters {
+
+void Controller::init(Scheduler& scheduler)
+{
+    scheduler.addTask(_loopTask);
+    _loopTask.setCallback(std::bind(&Controller::loop, this));
+    _loopTask.setIterations(TASK_FOREVER);
+    _loopTask.enable();
+
+    updateSettings();
+}
+
+void Controller::updateSettings()
+{
+    std::lock_guard<std::mutex> l(_mutex);
+
+    if (_upProvider) { _upProvider.reset(); }
+
+    auto const& imcfg = Configuration.get().InverterMeter;
+
+    if (!imcfg.Enabled) { return; }
+
+    // Reuse PowerMeter providers with InverterMeter configuration
+    switch(static_cast<PowerMeters::Provider::Type>(imcfg.Source)) {
+        case PowerMeters::Provider::Type::MQTT:
+            _upProvider = std::make_unique<::PowerMeters::Json::Mqtt::Provider>(imcfg.Mqtt);
+            break;
+        case PowerMeters::Provider::Type::SDM1PH:
+            _upProvider = std::make_unique<::PowerMeters::Sdm::Serial::Provider>(
+                    ::PowerMeters::Sdm::Serial::Provider::Phases::One, imcfg.SerialSdm);
+            break;
+        case PowerMeters::Provider::Type::SDM3PH:
+            _upProvider = std::make_unique<::PowerMeters::Sdm::Serial::Provider>(
+                    ::PowerMeters::Sdm::Serial::Provider::Phases::Three, imcfg.SerialSdm);
+            break;
+        case PowerMeters::Provider::Type::HTTP_JSON:
+            _upProvider = std::make_unique<::PowerMeters::Json::Http::Provider>(imcfg.HttpJson);
+            break;
+        case PowerMeters::Provider::Type::SERIAL_SML:
+            _upProvider = std::make_unique<::PowerMeters::Sml::Serial::Provider>();
+            break;
+        case PowerMeters::Provider::Type::SMAHM2:
+            _upProvider = std::make_unique<::PowerMeters::SmaHM::Udp::Provider>();
+            break;
+        case PowerMeters::Provider::Type::HTTP_SML:
+            _upProvider = std::make_unique<::PowerMeters::Sml::Http::Provider>(imcfg.HttpSml);
+            break;
+        case PowerMeters::Provider::Type::MODBUS_UDP_VICTRON:
+            _upProvider = std::make_unique<::PowerMeters::Modbus::Udp::Victron::Provider>(imcfg.UdpVictron);
+            break;
+    }
+
+    if (_upProvider && !_upProvider->init()) {
+        _upProvider = nullptr;
+    }
+}
+
+float Controller::getPowerTotal() const
+{
+    std::lock_guard<std::mutex> l(_mutex);
+    if (!_upProvider) { return 0.0; }
+    return _upProvider->getPowerTotal();
+}
+
+std::optional<float> Controller::getPower(uint64_t inverterID) const
+{
+    // for now we only support one inverter meter
+    auto serial = Configuration.get().InverterMeter.Serial;
+
+    std::lock_guard<std::mutex> l(_mutex);
+
+    if (inverterID != serial) { return std::nullopt; }
+
+    if (!_upProvider) { return std::nullopt; }
+
+    if (!_upProvider->isDataValid()) { return std::nullopt; }
+
+    return _upProvider->getPowerTotal();
+}
+
+uint32_t Controller::getTime(uint64_t inverterSN) const
+{
+    // for now we only support one inverter meter
+    auto serial = Configuration.get().InverterMeter.Serial;
+
+    std::lock_guard<std::mutex> l(_mutex);
+
+    if (inverterSN != serial) { return 0; }
+    if (!_upProvider) { return 0; }
+
+    return _upProvider->getLastUpdate();
+}
+
+uint32_t Controller::getLastUpdate() const
+{
+    std::lock_guard<std::mutex> l(_mutex);
+    if (!_upProvider) { return 0; }
+    return _upProvider->getLastUpdate();
+}
+
+bool Controller::isDataValid() const
+{
+    std::lock_guard<std::mutex> l(_mutex);
+    if (!_upProvider) { return false; }
+    return _upProvider->isDataValid();
+}
+
+uint32_t Controller::getRequestTime() const
+{
+    std::lock_guard<std::mutex> l(_mutex);
+    if (_upProvider) {
+        if (Configuration.get().InverterMeter.Source == static_cast<uint32_t>(PowerMeters::Provider::Type::HTTP_JSON)) {
+            return Configuration.get().InverterMeter.HttpJson.PollingInterval + 200;
+        }
+        if (Configuration.get().InverterMeter.Source == static_cast<uint32_t>(PowerMeters::Provider::Type::HTTP_SML)) {
+            return Configuration.get().InverterMeter.HttpSml.PollingInterval + 200;
+        }
+    }
+    return 2000;
+}
+
+void Controller::loop()
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (!_upProvider) { return; }
+    _upProvider->loop();
+
+    // Skip MQTT republishing for InverterMeter to avoid conflicts
+}
+
+} // namespace InverterMeters

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@
 #include "Utils.h"
 #include "WebApi.h"
 #include <powermeter/Controller.h>
+#include <invertermeter/Controller.h>
 #include "PowerLimiter.h"
 #include "defaults.h"
 #include <solarcharger/Controller.h>
@@ -149,6 +150,7 @@ void setup()
     // OpenDTU-OnBattery-specific initializations go between here...
     SolarCharger.init(scheduler);
     PowerMeter.init(scheduler);
+    InverterMeter.init(scheduler);
     PowerLimiter.init(scheduler);
     GridCharger.init(scheduler);
     Battery.init(scheduler);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -146,14 +146,17 @@ void setup()
     Datastore.init(scheduler);
     RestartHelper.init(scheduler);
 
-    // OpenDTU-OnBattery-specific initializations go below
-    RuntimeData.init(scheduler);
-    RuntimeData.read(); // make runtime data available as early as possible
+    // OpenDTU-OnBattery-specific initializations go between here...
     SolarCharger.init(scheduler);
     PowerMeter.init(scheduler);
     PowerLimiter.init(scheduler);
     GridCharger.init(scheduler);
     Battery.init(scheduler);
+    // ... and here (before RuntimeData)
+
+    // Must be done after all other components have been initialized
+    RuntimeData.init(scheduler);
+    RuntimeData.read();
 
     ESP_LOGI(TAG, "Startup complete");
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,6 +36,7 @@
 #include <LittleFS.h>
 #include <TaskScheduler.h>
 #include <esp_heap_caps.h>
+#include "RuntimeData.h"
 
 #undef TAG
 static const char* TAG = "main";
@@ -146,6 +147,8 @@ void setup()
     RestartHelper.init(scheduler);
 
     // OpenDTU-OnBattery-specific initializations go below
+    RuntimeData.init(scheduler);
+    RuntimeData.read(); // make runtime data available as early as possible
     SolarCharger.init(scheduler);
     PowerMeter.init(scheduler);
     PowerLimiter.init(scheduler);

--- a/webapp/src/components/FirmwareInfo.vue
+++ b/webapp/src/components/FirmwareInfo.vue
@@ -84,6 +84,10 @@
                         <td>{{ $n(systemStatus.cfgsavecount, 'decimal') }}</td>
                     </tr>
                     <tr>
+                        <th>{{ $t('firmwareinfo.RuntimeSaveCount') }}</th>
+                        <td>{{ systemStatus.runtime_savecount }}</td>
+                    </tr>
+                    <tr>
                         <th>{{ $t('firmwareinfo.Uptime') }}</th>
                         <td>
                             {{ $t('firmwareinfo.UptimeValue', timeInHours(systemStatus.uptime)) }}

--- a/webapp/src/components/NavBar.vue
+++ b/webapp/src/components/NavBar.vue
@@ -87,6 +87,11 @@
                                 }}</router-link>
                             </li>
                             <li>
+                                <router-link @click="onClick" class="dropdown-item" to="/settings/invertermeter">{{
+                                    $t('menu.InverterMeterSettings')
+                                }}</router-link>
+                            </li>
+                            <li>
                                 <router-link @click="onClick" class="dropdown-item" to="/settings/powerlimiter"
                                     >Dynamic Power Limiter</router-link
                                 >

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -729,7 +729,7 @@
         "UpperPowerLimit": "Maximales Leistungslimit",
         "UpperPowerLimitHint": "Der Wechselrichter wird stets so eingestellt, dass höchstens diese Ausgangsleistung erreicht wird. Dieser Wert muss so gewählt werden, dass die Strombelastbarkeit der AC-Anschlussleitungen eingehalten wird.",
         "AllowStandby": "Standby erlauben",
-        "AllowStandbyHint": "Erlaubt dem Wechselrichter in Standby zu gehen, wenn das berechnete Leistungslimit unter dem minimalen Leistungslimit liegt.",
+        "AllowStandbyHint": "Erlaubt dem Wechselrichter in Standby zu gehen, wenn das berechnete Leistungslimit unter dem minimalen Leistungslimit liegt. Ansonsten wird der Wechselrichter auf das minimale Leistungslimit gesetzt.",
         "SocThresholds": "Batterie State of Charge (SoC) Schwellwerte",
         "IgnoreSoc": "Nur Spannungs-Schwellwerte nutzen",
         "IgnoreSocHint": "Falls aktiviert werden nur die Spannungs-Schwellwerte berücksichtigt. Deaktiviere diesen Schalter, um Batterie State of Charge (SoC) Schwellwerte zu konfigurieren (nicht empfohlen, da der SoC-Wert häufig ungenau ist).",

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -12,6 +12,7 @@
         "DeviceManager": "Hardware",
         "SolarChargerSettings": "Solarladeregler",
         "PowerMeterSettings": "Stromzähler",
+        "InverterMeterSettings": "Wechselrichter-Stromzähler",
         "BatterySettings": "Batterie",
         "AcChargerSettings": "AC-Ladegerät",
         "ConfigManagement": "Konfigurationsverwaltung",
@@ -673,6 +674,13 @@
         "testHttpSmlRequest": "HTTP(S)-Anfrage senden und Antwort verarbeiten",
         "HTTP_SML": "HTTP(S) + SML - Konfiguration",
         "UDP_VICTRON": "Victron VM-3P75CT (Modbus UDP) - Konfiguration"
+    },
+    "invertermeteradmin": {
+        "InverterMeterSettings": "Wechselrichter-Stromzähler Einstellungen",
+        "InverterMeterConfiguration": "Wechselrichter-Stromzähler Konfiguration",
+        "InverterMeterEnable": "Aktiviere Wechselrichter-Stromzähler",
+        "InverterMeterSource": "Wechselrichter-Stromzählertyp",
+        "Serial": "Wechselrichter-Seriennummer"
     },
     "httprequestsettings": {
         "url": "URL",

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -282,6 +282,7 @@
         "ResetReason0": "Reset Grund CPU 0",
         "ResetReason1": "Reset Grund CPU 1",
         "ConfigSaveCount": "Anzahl der Konfigurationsspeicherungen",
+        "RuntimeSaveCount": "Laufzeitdatenspeicherungen Anzahl / Zeit",
         "Uptime": "Betriebszeit",
         "UptimeValue": "0 Tage {time} | 1 Tag {time} | {count} Tage {time}"
     },

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -737,6 +737,8 @@
         "UpperPowerLimit": "Maximales Leistungslimit",
         "UpperPowerLimitHint": "Der Wechselrichter wird stets so eingestellt, dass höchstens diese Ausgangsleistung erreicht wird. Dieser Wert muss so gewählt werden, dass die Strombelastbarkeit der AC-Anschlussleitungen eingehalten wird.",
         "AllowStandby": "Standby erlauben",
+        "UseATF": "ATF aktivieren",
+        "UseATFHint": "ATF (Adaptive Transfer Function) ersetzt die lineare Berechnung des prozentualen Limits aus der Leistung. Damit ist es z.B. möglich einen HM-Inverter an 24VDC ohne Einschränkungen zu betreiben. ATF benötigt nach der Aktivierung etwas Zeit für die automatische Anpassung an den Inverter. Diese Option kann für maximal 2 Inverter aktiviert werden.",
         "AllowStandbyHint": "Erlaubt dem Wechselrichter in Standby zu gehen, wenn das berechnete Leistungslimit unter dem minimalen Leistungslimit liegt. Ansonsten wird der Wechselrichter auf das minimale Leistungslimit gesetzt.",
         "SocThresholds": "Batterie State of Charge (SoC) Schwellwerte",
         "IgnoreSoc": "Nur Spannungs-Schwellwerte nutzen",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -12,6 +12,7 @@
         "DeviceManager": "Device-Manager",
         "SolarChargerSettings": "Solar Charger",
         "PowerMeterSettings": "Power Meter",
+        "InverterMeterSettings": "Inverter Meter",
         "BatterySettings": "Battery",
         "AcChargerSettings": "AC Charger",
         "ConfigManagement": "Config Management",
@@ -673,6 +674,13 @@
         "testHttpSmlRequest": "Send HTTP(S) request and process response",
         "HTTP_SML": "Configuration",
         "UDP_VICTRON": "Configuration"
+    },
+    "invertermeteradmin": {
+        "InverterMeterSettings": "Inverter Meter Settings",
+        "InverterMeterConfiguration": "Inverter Meter Configuration",
+        "InverterMeterEnable": "Enable Inverter Meter",
+        "InverterMeterSource": "Inverter Meter Type",
+        "Serial": "Inverter Serial Number"
     },
     "httprequestsettings": {
         "url": "URL",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -737,6 +737,8 @@
         "UpperPowerLimit": "Maximum Power Limit",
         "UpperPowerLimitHint": "The inverter is always set such that no more than this output power is achieved. This value must be selected to comply with the current carrying capacity of the AC connection cables.",
         "AllowStandby": "Allow Standby",
+        "UseATF": "Enable ATF",
+        "UseATFHint": "ATF (Adaptive Transfer Function) replaces the linear calculation of the percentage limit based on power. This makes it possible, for example, to operate an HM inverter on 24VDC without restrictions. After activation, ATF requires some time to automatically adapt to the inverter. This option can be activated for a maximum of two inverters.",
         "AllowStandbyHint": "Allow the inverter to go into standby if the calculated power limit is below the minimum power limit. Otherwise, the inverter will be set to the minimum power limit.",
         "SocThresholds": "Battery State of Charge (SoC) Thresholds",
         "IgnoreSoc": "Use Voltage Thresholds Only",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -729,7 +729,7 @@
         "UpperPowerLimit": "Maximum Power Limit",
         "UpperPowerLimitHint": "The inverter is always set such that no more than this output power is achieved. This value must be selected to comply with the current carrying capacity of the AC connection cables.",
         "AllowStandby": "Allow Standby",
-        "AllowStandbyHint": "Allow the inverter to go into standby if the calculated power limit is below the minimum power limit.",
+        "AllowStandbyHint": "Allow the inverter to go into standby if the calculated power limit is below the minimum power limit. Otherwise, the inverter will be set to the minimum power limit.",
         "SocThresholds": "Battery State of Charge (SoC) Thresholds",
         "IgnoreSoc": "Use Voltage Thresholds Only",
         "IgnoreSocHint": "When enabled, only voltage thresholds are considered. Disable this switch to configure and use battery State of Charge (SoC) thresholds (not recommended as the SoC value is often inaccurate).",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -282,6 +282,7 @@
         "ResetReason0": "Reset Reason CPU 0",
         "ResetReason1": "Reset Reason CPU 1",
         "ConfigSaveCount": "Config save count",
+        "RuntimeSaveCount": "Runtime data save count / time",
         "Uptime": "Uptime",
         "UptimeValue": "0 days {time} | 1 day {time} | {count} days {time}"
     },

--- a/webapp/src/router/index.ts
+++ b/webapp/src/router/index.ts
@@ -12,6 +12,7 @@ import SolarChargerAdminView from '@/views/SolarChargerAdminView.vue';
 import PowerMeterAdminView from '@/views/PowerMeterAdminView.vue';
 import PowerLimiterAdminView from '@/views/PowerLimiterAdminView.vue';
 import InverterAdminView from '@/views/InverterAdminView.vue';
+import InverterMeterAdminView from '@/views/InverterMeterAdminView.vue';
 import LoginView from '@/views/LoginView.vue';
 import MaintenanceRebootView from '@/views/MaintenanceRebootView.vue';
 import LoggingAdminView from '@/views/LoggingAdminView.vue';
@@ -126,6 +127,11 @@ const router = createRouter({
             path: '/settings/inverter',
             name: 'Inverter Settings',
             component: InverterAdminView,
+        },
+        {
+            path: '/settings/invertermeter',
+            name: 'Inverter Meter Settings',
+            component: InverterMeterAdminView,
         },
         {
             path: '/settings/dtu',

--- a/webapp/src/types/InverterMeterConfig.ts
+++ b/webapp/src/types/InverterMeterConfig.ts
@@ -1,0 +1,53 @@
+import type { HttpRequestConfig } from '@/types/HttpRequestConfig';
+
+export interface InverterMeterMqttValue {
+    topic: string;
+    json_path: string;
+    unit: number;
+    sign_inverted: boolean;
+}
+
+export interface InverterMeterMqttConfig {
+    values: Array<InverterMeterMqttValue>;
+}
+
+export interface InverterMeterSerialSdmConfig {
+    polling_interval: number;
+    address: number;
+}
+
+export interface PowerMeterHttpJsonValue {
+    http_request: HttpRequestConfig;
+    enabled: boolean;
+    json_path: string;
+    unit: number;
+    sign_inverted: boolean;
+}
+
+export interface InverterMeterHttpJsonConfig {
+    polling_interval: number;
+    individual_requests: boolean;
+    values: Array<PowerMeterHttpJsonValue>;
+}
+
+export interface InverterMeterHttpSmlConfig {
+    polling_interval: number;
+    http_request: HttpRequestConfig;
+}
+
+export interface InverterMeterUdpVictronConfig {
+    polling_interval_ms: number;
+    ip_address: string;
+}
+
+export interface InverterMeterConfig {
+    enabled: boolean;
+    source: number;
+    serial: string;
+    interval: number;
+    mqtt: InverterMeterMqttConfig;
+    serial_sdm: InverterMeterSerialSdmConfig;
+    http_json: InverterMeterHttpJsonConfig;
+    http_sml: InverterMeterHttpSmlConfig;
+    udp_victron: InverterMeterUdpVictronConfig;
+}

--- a/webapp/src/types/PowerLimiterConfig.ts
+++ b/webapp/src/types/PowerLimiterConfig.ts
@@ -29,6 +29,7 @@ export interface PowerLimiterInverterConfig {
     power_source: number;
     use_overscaling_to_compensate_shading: boolean;
     allow_standby: boolean;
+    use_atf: boolean;
     lower_power_limit: number;
     upper_power_limit: number;
 }

--- a/webapp/src/types/SystemStatus.ts
+++ b/webapp/src/types/SystemStatus.ts
@@ -31,6 +31,7 @@ export interface SystemStatus {
     resetreason_0: string;
     resetreason_1: string;
     cfgsavecount: number;
+    runtime_savecount: string;
     uptime: number;
     update_text: string;
     update_url: string;

--- a/webapp/src/views/InverterMeterAdminView.vue
+++ b/webapp/src/views/InverterMeterAdminView.vue
@@ -43,12 +43,10 @@
                         maxlength="32"
                         wide
                     />
-
                 </template>
             </CardElement>
 
             <template v-if="inverterMeterConfigList.enabled">
-
                 <!-- yarn linter wants us to not combine v-if with v-for, so we need to wrap the CardElements //-->
                 <template v-if="inverterMeterConfigList.source === 0">
                     <CardElement

--- a/webapp/src/views/InverterMeterAdminView.vue
+++ b/webapp/src/views/InverterMeterAdminView.vue
@@ -1,0 +1,430 @@
+<template>
+    <BasePage :title="$t('invertermeteradmin.InverterMeterSettings')" :isLoading="dataLoading">
+        <BootstrapAlert
+            v-model="showAlert"
+            dismissible
+            :variant="alertType"
+            :auto-dismiss="alertType != 'success' ? 0 : 5000"
+        >
+            {{ alertMessage }}
+        </BootstrapAlert>
+
+        <form @submit="saveInverterMeterConfig">
+            <CardElement :text="$t('invertermeteradmin.InverterMeterConfiguration')" textVariant="text-bg-primary">
+                <InputElement
+                    :label="$t('invertermeteradmin.InverterMeterEnable')"
+                    v-model="inverterMeterConfigList.enabled"
+                    type="checkbox"
+                    wide
+                />
+
+                <template v-if="inverterMeterConfigList.enabled">
+                    <div class="row mb-3">
+                        <label for="inputInverterMeterSource" class="col-sm-4 col-form-label">{{
+                            $t('invertermeteradmin.InverterMeterSource')
+                        }}</label>
+                        <div class="col-sm-8">
+                            <select
+                                id="inputInverterMeterSource"
+                                class="form-select"
+                                v-model="inverterMeterConfigList.source"
+                            >
+                                <option v-for="source in inverterMeterSourceList" :key="source.key" :value="source.key">
+                                    {{ source.value }}
+                                </option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <InputElement
+                        :label="$t('invertermeteradmin.Serial')"
+                        v-model="inverterMeterConfigList.serial"
+                        type="text"
+                        maxlength="32"
+                        wide
+                    />
+
+                </template>
+            </CardElement>
+
+            <template v-if="inverterMeterConfigList.enabled">
+
+                <!-- yarn linter wants us to not combine v-if with v-for, so we need to wrap the CardElements //-->
+                <template v-if="inverterMeterConfigList.source === 0">
+                    <CardElement
+                        v-for="(mqtt, index) in inverterMeterConfigList.mqtt.values"
+                        v-bind:key="index"
+                        :text="$t('powermeteradmin.MqttValue', { valueNumber: index + 1 })"
+                        textVariant="text-bg-primary"
+                        add-space
+                    >
+                        <InputElement
+                            :label="$t('powermeteradmin.MqttTopic')"
+                            v-model="mqtt.topic"
+                            type="text"
+                            maxlength="256"
+                            wide
+                        />
+
+                        <InputElement
+                            :label="$t('powermeteradmin.mqttJsonPath')"
+                            v-model="mqtt.json_path"
+                            type="text"
+                            maxlength="256"
+                            :tooltip="$t('powermeteradmin.valueJsonPathDescription')"
+                            wide
+                        />
+
+                        <div class="row mb-3">
+                            <label for="mqtt_power_unit" class="col-sm-4 col-form-label">
+                                {{ $t('powermeteradmin.valueUnit') }}
+                            </label>
+                            <div class="col-sm-8">
+                                <select id="mqtt_power_unit" class="form-select" v-model="mqtt.unit">
+                                    <option v-for="u in unitTypeList" :key="u.key" :value="u.key">
+                                        {{ u.value }}
+                                    </option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <InputElement
+                            :label="$t('powermeteradmin.valueSignInverted')"
+                            v-model="mqtt.sign_inverted"
+                            :tooltip="$t('powermeteradmin.valueSignInvertedHint')"
+                            type="checkbox"
+                            wide
+                        />
+                    </CardElement>
+                </template>
+
+                <CardElement
+                    v-if="inverterMeterConfigList.source === 1 || inverterMeterConfigList.source === 2"
+                    :text="$t('powermeteradmin.SDM')"
+                    textVariant="text-bg-primary"
+                    add-space
+                >
+                    <InputElement
+                        :label="$t('powermeteradmin.pollingInterval')"
+                        v-model="inverterMeterConfigList.serial_sdm.polling_interval"
+                        type="number"
+                        min="1"
+                        max="15"
+                        :postfix="$t('powermeteradmin.seconds')"
+                        wide
+                    />
+
+                    <InputElement
+                        :label="$t('powermeteradmin.sdmaddress')"
+                        v-model="inverterMeterConfigList.serial_sdm.address"
+                        type="number"
+                        wide
+                    />
+                </CardElement>
+
+                <template v-if="inverterMeterConfigList.source === 3">
+                    <CardElement :text="$t('invertermeteradmin.HTTP')" textVariant="text-bg-primary" add-space>
+                        <InputElement
+                            :label="$t('powermeteradmin.httpIndividualRequests')"
+                            v-model="inverterMeterConfigList.http_json.individual_requests"
+                            type="checkbox"
+                            wide
+                        />
+
+                        <InputElement
+                            :label="$t('powermeteradmin.pollingInterval')"
+                            v-model="inverterMeterConfigList.http_json.polling_interval"
+                            type="number"
+                            min="1"
+                            max="15"
+                            :postfix="$t('powermeteradmin.seconds')"
+                            wide
+                        />
+                    </CardElement>
+
+                    <CardElement
+                        v-for="(httpJson, index) in inverterMeterConfigList.http_json.values"
+                        :key="index"
+                        :text="$t('powermeteradmin.httpValue', { valueNumber: index + 1 })"
+                        textVariant="text-bg-primary"
+                        add-space
+                    >
+                        <InputElement
+                            v-if="index > 0"
+                            :label="$t('powermeteradmin.httpEnabled')"
+                            v-model="httpJson.enabled"
+                            type="checkbox"
+                            wide
+                        />
+
+                        <template v-if="httpJson.enabled || index == 0">
+                            <HttpRequestSettings
+                                v-model="httpJson.http_request"
+                                v-if="index == 0 || inverterMeterConfigList.http_json.individual_requests"
+                            />
+
+                            <InputElement
+                                :label="$t('powermeteradmin.valueJsonPath')"
+                                v-model="httpJson.json_path"
+                                type="text"
+                                maxlength="256"
+                                :tooltip="$t('powermeteradmin.valueJsonPathDescription')"
+                                wide
+                            />
+
+                            <div class="row mb-3">
+                                <label for="power_unit" class="col-sm-4 col-form-label">
+                                    {{ $t('powermeteradmin.valueUnit') }}
+                                </label>
+                                <div class="col-sm-8">
+                                    <select id="power_unit" class="form-select" v-model="httpJson.unit">
+                                        <option v-for="u in unitTypeList" :key="u.key" :value="u.key">
+                                            {{ u.value }}
+                                        </option>
+                                    </select>
+                                </div>
+                            </div>
+
+                            <InputElement
+                                :label="$t('powermeteradmin.valueSignInverted')"
+                                v-model="httpJson.sign_inverted"
+                                :tooltip="$t('powermeteradmin.valueSignInvertedHint')"
+                                type="checkbox"
+                                wide
+                            />
+                        </template>
+                    </CardElement>
+
+                    <CardElement
+                        :text="$t('powermeteradmin.testHttpJsonHeader')"
+                        textVariant="text-bg-primary"
+                        add-space
+                    >
+                        <div class="text-center mb-3">
+                            <button type="button" class="btn btn-primary" @click="testHttpJsonRequest()">
+                                {{ $t('powermeteradmin.testHttpJsonRequest') }}
+                            </button>
+                        </div>
+
+                        <BootstrapAlert
+                            v-model="testHttpJsonRequestAlert.show"
+                            dismissible
+                            :variant="testHttpJsonRequestAlert.type"
+                        >
+                            {{ testHttpJsonRequestAlert.message }}
+                        </BootstrapAlert>
+                    </CardElement>
+                </template>
+
+                <template v-if="inverterMeterConfigList.source === 6">
+                    <CardElement :text="$t('powermeteradmin.HTTP_SML')" textVariant="text-bg-primary" add-space>
+                        <InputElement
+                            :label="$t('powermeteradmin.pollingInterval')"
+                            v-model="inverterMeterConfigList.http_sml.polling_interval"
+                            type="number"
+                            min="1"
+                            max="15"
+                            :postfix="$t('powermeteradmin.seconds')"
+                            wide
+                        />
+
+                        <HttpRequestSettings v-model="inverterMeterConfigList.http_sml.http_request" />
+                    </CardElement>
+
+                    <CardElement
+                        :text="$t('powermeteradmin.testHttpSmlHeader')"
+                        textVariant="text-bg-primary"
+                        add-space
+                    >
+                        <div class="text-center mb-3">
+                            <button type="button" class="btn btn-primary" @click="testHttpSmlRequest()">
+                                {{ $t('powermeteradmin.testHttpSmlRequest') }}
+                            </button>
+                        </div>
+
+                        <BootstrapAlert
+                            v-model="testHttpSmlRequestAlert.show"
+                            dismissible
+                            :variant="testHttpSmlRequestAlert.type"
+                        >
+                            {{ testHttpSmlRequestAlert.message }}
+                        </BootstrapAlert>
+                    </CardElement>
+                </template>
+
+                <template v-if="inverterMeterConfigList.source === 7">
+                    <CardElement :text="$t('powermeteradmin.UDP_VICTRON')" textVariant="text-bg-primary" add-space>
+                        <InputElement
+                            :label="$t('powermeteradmin.pollingInterval')"
+                            v-model="udpVictronPollIntervalSeconds"
+                            type="number"
+                            min="0.5"
+                            max="15.0"
+                            step="0.1"
+                            :postfix="$t('powermeteradmin.seconds')"
+                            wide
+                        />
+
+                        <InputElement
+                            :label="$t('powermeteradmin.ipAddress')"
+                            v-model="inverterMeterConfigList.udp_victron.ip_address"
+                            type="text"
+                            maxlength="15"
+                            wide
+                        />
+                    </CardElement>
+                </template>
+            </template>
+
+            <FormFooter @reload="getInverterMeterConfig" />
+        </form>
+    </BasePage>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import BasePage from '@/components/BasePage.vue';
+import BootstrapAlert from '@/components/BootstrapAlert.vue';
+import CardElement from '@/components/CardElement.vue';
+import FormFooter from '@/components/FormFooter.vue';
+import InputElement from '@/components/InputElement.vue';
+import HttpRequestSettings from '@/components/HttpRequestSettings.vue';
+import { handleResponse, authHeader } from '@/utils/authentication';
+import type { InverterMeterConfig } from '@/types/InverterMeterConfig';
+
+export default defineComponent({
+    components: {
+        BasePage,
+        BootstrapAlert,
+        CardElement,
+        FormFooter,
+        HttpRequestSettings,
+        InputElement,
+    },
+    data() {
+        return {
+            dataLoading: true,
+            inverterMeterConfigList: {} as InverterMeterConfig,
+            inverterMeterSourceList: [
+                { key: 0, value: this.$t('powermeteradmin.typeMQTT') },
+                { key: 1, value: this.$t('powermeteradmin.typeSDM1ph') },
+                { key: 2, value: this.$t('powermeteradmin.typeSDM3ph') },
+                { key: 3, value: this.$t('powermeteradmin.typeHTTP_JSON') },
+                { key: 4, value: this.$t('powermeteradmin.typeSML') },
+                { key: 5, value: this.$t('powermeteradmin.typeSMAHM2') },
+                { key: 6, value: this.$t('powermeteradmin.typeHTTP_SML') },
+                { key: 7, value: this.$t('powermeteradmin.typeUDP_VICTRON') },
+            ],
+            unitTypeList: [
+                { key: 1, value: 'mW' },
+                { key: 0, value: 'W' },
+                { key: 2, value: 'kW' },
+            ],
+            alertMessage: '',
+            alertType: 'info',
+            showAlert: false,
+            testHttpJsonRequestAlert: { message: '', type: '', show: false } as {
+                message: string;
+                type: string;
+                show: boolean;
+            },
+            testHttpSmlRequestAlert: { message: '', type: '', show: false } as {
+                message: string;
+                type: string;
+                show: boolean;
+            },
+        };
+    },
+    created() {
+        this.getInverterMeterConfig();
+    },
+    computed: {
+        udpVictronPollIntervalSeconds: {
+            get(): number {
+                return this.inverterMeterConfigList.udp_victron.polling_interval_ms / 1000;
+            },
+            set(value: number) {
+                this.inverterMeterConfigList.udp_victron.polling_interval_ms = value * 1000;
+            },
+        },
+    },
+    methods: {
+        getInverterMeterConfig() {
+            this.dataLoading = true;
+            fetch('/api/invertermeter/config', { headers: authHeader() })
+                .then((response) => handleResponse(response, this.$emitter, this.$router))
+                .then((data) => {
+                    this.inverterMeterConfigList = data;
+                    this.dataLoading = false;
+                });
+        },
+        saveInverterMeterConfig(e: Event) {
+            e.preventDefault();
+
+            const formData = new FormData();
+            formData.append('data', JSON.stringify(this.inverterMeterConfigList));
+
+            fetch('/api/invertermeter/config', {
+                method: 'POST',
+                headers: authHeader(),
+                body: formData,
+            })
+                .then((response) => handleResponse(response, this.$emitter, this.$router))
+                .then((response) => {
+                    this.alertMessage = response.message;
+                    this.alertType = response.type;
+                    this.showAlert = true;
+                    window.scrollTo(0, 0);
+                });
+        },
+        testHttpJsonRequest() {
+            this.testHttpJsonRequestAlert = {
+                message: 'Triggering HTTP request...',
+                type: 'info',
+                show: true,
+            };
+
+            const formData = new FormData();
+            formData.append('data', JSON.stringify(this.inverterMeterConfigList));
+
+            fetch('/api/invertermeter/testhttpjsonrequest', {
+                method: 'POST',
+                headers: authHeader(),
+                body: formData,
+            })
+                .then((response) => handleResponse(response, this.$emitter, this.$router))
+                .then((response) => {
+                    this.testHttpJsonRequestAlert = {
+                        message: response.message,
+                        type: response.type,
+                        show: true,
+                    };
+                });
+        },
+        testHttpSmlRequest() {
+            this.testHttpSmlRequestAlert = {
+                message: 'Triggering HTTP request...',
+                type: 'info',
+                show: true,
+            };
+
+            const formData = new FormData();
+            formData.append('data', JSON.stringify(this.inverterMeterConfigList));
+
+            fetch('/api/invertermeter/testhttpsmlrequest', {
+                method: 'POST',
+                headers: authHeader(),
+                body: formData,
+            })
+                .then((response) => handleResponse(response, this.$emitter, this.$router))
+                .then((response) => {
+                    this.testHttpSmlRequestAlert = {
+                        message: response.message,
+                        type: response.type,
+                        show: true,
+                    };
+                });
+        },
+    },
+});
+</script>

--- a/webapp/src/views/PowerLimiterAdminView.vue
+++ b/webapp/src/views/PowerLimiterAdminView.vue
@@ -161,7 +161,7 @@
                         <InputElement
                             :label="$t('powerlimiteradmin.AllowStandby')"
                             :tooltip="$t('powerlimiteradmin.AllowStandbyHint')"
-                            v-if="inv.power_source == 2"
+                            v-if="inv.power_source == 2 || inv.power_source == 0"
                             v-model="inv.allow_standby"
                             type="checkbox"
                             wide

--- a/webapp/src/views/PowerLimiterAdminView.vue
+++ b/webapp/src/views/PowerLimiterAdminView.vue
@@ -168,6 +168,16 @@
                         />
 
                         <InputElement
+                            v-if="inv.power_source == 0"
+                            :label="$t('powerlimiteradmin.UseATF')"
+                            :tooltip="$t('powerlimiteradmin.UseATFHint')"
+                            v-model="inv.use_atf"
+                            type="checkbox"
+                            :disabled="isATFFull && !inv.use_atf"
+                            wide
+                        />
+
+                        <InputElement
                             v-if="inv.power_source != 0 && inverterSupportsOverscaling(inv.serial)"
                             :label="$t('powerlimiteradmin.UseOverscaling')"
                             :tooltip="$t('powerlimiteradmin.UseOverscalingHint')"
@@ -528,6 +538,18 @@ export default defineComponent({
         hasBatteryInterface(): boolean {
             const meta = this.powerLimiterMetaData;
             return meta.battery_enabled && this.governingBatteryPoweredInverters;
+        },
+        isATFFull(): boolean {
+            let full = false;
+            for (const inv of this.powerLimiterConfigList.inverters) {
+                if ( inv.use_atf)
+                {
+                    // currently ATF is limited to 1 inverter only
+                    full = true;
+                    break;
+                }
+            }
+            return full;
         },
     },
     methods: {

--- a/webapp/src/views/PowerLimiterAdminView.vue
+++ b/webapp/src/views/PowerLimiterAdminView.vue
@@ -542,8 +542,7 @@ export default defineComponent({
         isATFFull(): boolean {
             let full = false;
             for (const inv of this.powerLimiterConfigList.inverters) {
-                if ( inv.use_atf)
-                {
+                if (inv.use_atf) {
                     // currently ATF is limited to 1 inverter only
                     full = true;
                     break;


### PR DESCRIPTION
This PR is specifically for HM-xxx inverters powered by a 24VDC battery.
See also #1601 

- Replaces the faulty inverter AC measurement with an external power meter (Inverter-Meter).
- Replaces the faulty linear conversion from limit to power and power to limit (ATF).
- The Inverter-Meter can be configured and assigned to an inverter in the WebUI.
- The DPL offers the AFT option for battery-powered inverters.
- In the live view, the power from the Inverter-Meter is automatically used to calculate the "Inverter Total Power".
- The ATF values ​​are automatically displayed in the inverter live view.

Snapshot with an inverter (ATF and inverter meter active)
(1) Measurement from the inverter meter
(2) ATF calculated values ​​(limit and power)
(3) Values ​​measured by the inverter

<img width="400" height="370" alt="grafik" src="https://github.com/user-attachments/assets/3125e970-1e2d-466b-8427-1266a0fa266a" />

Limitations:
ATF is only available for battery-powered inverters.
Currently, only one inverter can be selected for ATF/inverter meters.

Note:
This PR is based on PRs: #2355, #2262 and #2340  