### PR TITLE
NRF24: use protocol-correct response channel offset after TX

### DIFF
--- a/lib/Hoymiles/src/HoymilesRadio_NRF.cpp
+++ b/lib/Hoymiles/src/HoymilesRadio_NRF.cpp
@@ -192,7 +192,9 @@ void HoymilesRadio_NRF::sendEsbPacket(CommandAbstract& cmd)
 
     _radio->setRetries(0, 0);
     openReadingPipe();
-    _radio->setChannel(getRxNxtChannel());
+    // Switch to response channel: inverter responds on (txChIdx + 3) % 5
+    _rxChIdx = (_txChIdx + 3) % sizeof(_rxChLst);
+    _radio->setChannel(_rxChLst[_rxChIdx]);
     _radio->startListening();
     _busyFlag = true;
     _rxTimeout.set(cmd.getTimeout());


### PR DESCRIPTION
After transmitting on channel index N, switch the receiver to channel (N+3) % 5 instead of the next sequential channel. This follows the Hoymiles protocol convention, where inverters respond on an offset channel.

This behavior is confirmed by the AhoyDTU implementation and has been hardware‑verified with HM‑series inverters (1CH and 2CH).

Success rate is now approximately 98%, compared to about 75% before the change.
Tested with three active inverters: HM300, HM600, HM600.

At the same time, three additional inverters and an AhoyDTU are present in the area.