### PR TITLE
Fix: Powermeter API: Do not leak sensitive data to unauthorized API clients

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -482,13 +482,13 @@ public:
 
     int8_t getIndexForLogModule(const String& moduleName) const;
 
-    static void serializeHttpRequestConfig(HttpRequestConfig const& source, JsonObject& target, bool fullAccess);
+    static void serializeHttpRequestConfig(HttpRequestConfig const& source, JsonObject& target, bool includeCredentials);
     static void serializeSolarChargerConfig(SolarChargerConfig const& source, JsonObject& target);
     static void serializeSolarChargerMqttConfig(SolarChargerMqttConfig const& source, JsonObject& target);
     static void serializePowerMeterMqttConfig(PowerMeterMqttConfig const& source, JsonObject& target);
     static void serializePowerMeterSerialSdmConfig(PowerMeterSerialSdmConfig const& source, JsonObject& target);
-    static void serializePowerMeterHttpJsonConfig(PowerMeterHttpJsonConfig const& source, JsonObject& target, bool fullAccess);
-    static void serializePowerMeterHttpSmlConfig(PowerMeterHttpSmlConfig const& source, JsonObject& target, bool fullAccess);
+    static void serializePowerMeterHttpJsonConfig(PowerMeterHttpJsonConfig const& source, JsonObject& target, bool includeCredentials);
+    static void serializePowerMeterHttpSmlConfig(PowerMeterHttpSmlConfig const& source, JsonObject& target, bool includeCredentials);
     static void serializePowerMeterUdpVictronConfig(PowerMeterUdpVictronConfig const& source, JsonObject& target);
     static void serializeBatteryConfig(BatteryConfig const& source, JsonObject& target);
     static void serializeBatteryZendureConfig(BatteryZendureConfig const& source, JsonObject& target);

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -482,13 +482,13 @@ public:
 
     int8_t getIndexForLogModule(const String& moduleName) const;
 
-    static void serializeHttpRequestConfig(HttpRequestConfig const& source, JsonObject& target);
+    static void serializeHttpRequestConfig(HttpRequestConfig const& source, JsonObject& target, bool fullAccess);
     static void serializeSolarChargerConfig(SolarChargerConfig const& source, JsonObject& target);
     static void serializeSolarChargerMqttConfig(SolarChargerMqttConfig const& source, JsonObject& target);
     static void serializePowerMeterMqttConfig(PowerMeterMqttConfig const& source, JsonObject& target);
     static void serializePowerMeterSerialSdmConfig(PowerMeterSerialSdmConfig const& source, JsonObject& target);
-    static void serializePowerMeterHttpJsonConfig(PowerMeterHttpJsonConfig const& source, JsonObject& target);
-    static void serializePowerMeterHttpSmlConfig(PowerMeterHttpSmlConfig const& source, JsonObject& target);
+    static void serializePowerMeterHttpJsonConfig(PowerMeterHttpJsonConfig const& source, JsonObject& target, bool fullAccess);
+    static void serializePowerMeterHttpSmlConfig(PowerMeterHttpSmlConfig const& source, JsonObject& target, bool fullAccess);
     static void serializePowerMeterUdpVictronConfig(PowerMeterUdpVictronConfig const& source, JsonObject& target);
     static void serializeBatteryConfig(BatteryConfig const& source, JsonObject& target);
     static void serializeBatteryZendureConfig(BatteryZendureConfig const& source, JsonObject& target);

--- a/include/WebApi_powermeter.h
+++ b/include/WebApi_powermeter.h
@@ -17,7 +17,7 @@ private:
     void onTestHttpJsonRequest(AsyncWebServerRequest* request);
     void onTestHttpSmlRequest(AsyncWebServerRequest* request);
 
-    void generateStatus(AsyncWebServerRequest* request, bool fullAccess);
+    void generateStatus(AsyncWebServerRequest* request, bool includeCredentials);
 
     AsyncWebServer* _server;
 };

--- a/include/WebApi_powermeter.h
+++ b/include/WebApi_powermeter.h
@@ -17,5 +17,7 @@ private:
     void onTestHttpJsonRequest(AsyncWebServerRequest* request);
     void onTestHttpSmlRequest(AsyncWebServerRequest* request);
 
+    void generateStatus(AsyncWebServerRequest* request, bool fullAccess);
+
     AsyncWebServer* _server;
 };

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -42,16 +42,20 @@ double ConfigurationClass::roundedFloat(float val)
     return static_cast<int>(val * 100 + (val > 0 ? 0.5 : -0.5)) / 100.0;
 }
 
-void ConfigurationClass::serializeHttpRequestConfig(HttpRequestConfig const& source, JsonObject& target)
+void ConfigurationClass::serializeHttpRequestConfig(HttpRequestConfig const& source, JsonObject& target, bool fullAccess)
 {
     JsonObject target_http_config = target["http_request"].to<JsonObject>();
     target_http_config["url"] = source.Url;
+    target_http_config["timeout"] = source.Timeout;
+
+    // only include auth details if we have full access
+    if (!fullAccess) { return; }
+
     target_http_config["auth_type"] = source.AuthType;
     target_http_config["username"] = source.Username;
     target_http_config["password"] = source.Password;
     target_http_config["header_key"] = source.HeaderKey;
     target_http_config["header_value"] = source.HeaderValue;
-    target_http_config["timeout"] = source.Timeout;
 }
 
 void ConfigurationClass::serializeSolarChargerConfig(SolarChargerConfig const& source, JsonObject& target)
@@ -96,7 +100,7 @@ void ConfigurationClass::serializePowerMeterSerialSdmConfig(PowerMeterSerialSdmC
     target["polling_interval"] = source.PollingInterval;
 }
 
-void ConfigurationClass::serializePowerMeterHttpJsonConfig(PowerMeterHttpJsonConfig const& source, JsonObject& target)
+void ConfigurationClass::serializePowerMeterHttpJsonConfig(PowerMeterHttpJsonConfig const& source, JsonObject& target, bool fullAccess)
 {
     target["polling_interval"] = source.PollingInterval;
     target["individual_requests"] = source.IndividualRequests;
@@ -106,7 +110,7 @@ void ConfigurationClass::serializePowerMeterHttpJsonConfig(PowerMeterHttpJsonCon
         JsonObject t = values.add<JsonObject>();
         PowerMeterHttpJsonValue const& s = source.Values[i];
 
-        serializeHttpRequestConfig(s.HttpRequest, t);
+        serializeHttpRequestConfig(s.HttpRequest, t, fullAccess);
 
         t["enabled"] = s.Enabled;
         t["json_path"] = s.JsonPath;
@@ -115,10 +119,10 @@ void ConfigurationClass::serializePowerMeterHttpJsonConfig(PowerMeterHttpJsonCon
     }
 }
 
-void ConfigurationClass::serializePowerMeterHttpSmlConfig(PowerMeterHttpSmlConfig const& source, JsonObject& target)
+void ConfigurationClass::serializePowerMeterHttpSmlConfig(PowerMeterHttpSmlConfig const& source, JsonObject& target, bool fullAccess)
 {
     target["polling_interval"] = source.PollingInterval;
-    serializeHttpRequestConfig(source.HttpRequest, target);
+    serializeHttpRequestConfig(source.HttpRequest, target, fullAccess);
 }
 
 void ConfigurationClass::serializePowerMeterUdpVictronConfig(PowerMeterUdpVictronConfig const& source, JsonObject& target)
@@ -421,10 +425,10 @@ bool ConfigurationClass::write()
     serializePowerMeterSerialSdmConfig(config.PowerMeter.SerialSdm, powermeter_serial_sdm);
 
     JsonObject powermeter_http_json = powermeter["http_json"].to<JsonObject>();
-    serializePowerMeterHttpJsonConfig(config.PowerMeter.HttpJson, powermeter_http_json);
+    serializePowerMeterHttpJsonConfig(config.PowerMeter.HttpJson, powermeter_http_json, true);
 
     JsonObject powermeter_http_sml = powermeter["http_sml"].to<JsonObject>();
-    serializePowerMeterHttpSmlConfig(config.PowerMeter.HttpSml, powermeter_http_sml);
+    serializePowerMeterHttpSmlConfig(config.PowerMeter.HttpSml, powermeter_http_sml, true);
 
     JsonObject powermeter_udp_victron = powermeter["udp_victron"].to<JsonObject>();
     serializePowerMeterUdpVictronConfig(config.PowerMeter.UdpVictron, powermeter_udp_victron);

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -42,14 +42,13 @@ double ConfigurationClass::roundedFloat(float val)
     return static_cast<int>(val * 100 + (val > 0 ? 0.5 : -0.5)) / 100.0;
 }
 
-void ConfigurationClass::serializeHttpRequestConfig(HttpRequestConfig const& source, JsonObject& target, bool fullAccess)
+void ConfigurationClass::serializeHttpRequestConfig(HttpRequestConfig const& source, JsonObject& target, bool includeCredentials)
 {
     JsonObject target_http_config = target["http_request"].to<JsonObject>();
     target_http_config["url"] = source.Url;
     target_http_config["timeout"] = source.Timeout;
 
-    // only include auth details if we have full access
-    if (!fullAccess) { return; }
+    if (!includeCredentials) { return; }
 
     target_http_config["auth_type"] = source.AuthType;
     target_http_config["username"] = source.Username;
@@ -100,7 +99,7 @@ void ConfigurationClass::serializePowerMeterSerialSdmConfig(PowerMeterSerialSdmC
     target["polling_interval"] = source.PollingInterval;
 }
 
-void ConfigurationClass::serializePowerMeterHttpJsonConfig(PowerMeterHttpJsonConfig const& source, JsonObject& target, bool fullAccess)
+void ConfigurationClass::serializePowerMeterHttpJsonConfig(PowerMeterHttpJsonConfig const& source, JsonObject& target, bool includeCredentials)
 {
     target["polling_interval"] = source.PollingInterval;
     target["individual_requests"] = source.IndividualRequests;
@@ -110,7 +109,7 @@ void ConfigurationClass::serializePowerMeterHttpJsonConfig(PowerMeterHttpJsonCon
         JsonObject t = values.add<JsonObject>();
         PowerMeterHttpJsonValue const& s = source.Values[i];
 
-        serializeHttpRequestConfig(s.HttpRequest, t, fullAccess);
+        serializeHttpRequestConfig(s.HttpRequest, t, includeCredentials);
 
         t["enabled"] = s.Enabled;
         t["json_path"] = s.JsonPath;
@@ -119,10 +118,10 @@ void ConfigurationClass::serializePowerMeterHttpJsonConfig(PowerMeterHttpJsonCon
     }
 }
 
-void ConfigurationClass::serializePowerMeterHttpSmlConfig(PowerMeterHttpSmlConfig const& source, JsonObject& target, bool fullAccess)
+void ConfigurationClass::serializePowerMeterHttpSmlConfig(PowerMeterHttpSmlConfig const& source, JsonObject& target, bool includeCredentials)
 {
     target["polling_interval"] = source.PollingInterval;
-    serializeHttpRequestConfig(source.HttpRequest, target, fullAccess);
+    serializeHttpRequestConfig(source.HttpRequest, target, includeCredentials);
 }
 
 void ConfigurationClass::serializePowerMeterUdpVictronConfig(PowerMeterUdpVictronConfig const& source, JsonObject& target)

--- a/src/WebApi_powermeter.cpp
+++ b/src/WebApi_powermeter.cpp
@@ -28,12 +28,8 @@ void WebApiPowerMeterClass::init(AsyncWebServer& server, Scheduler& scheduler)
     _server->on("/api/powermeter/testhttpsmlrequest", HTTP_POST, static_cast<ArRequestHandlerFunction>(std::bind(&WebApiPowerMeterClass::onTestHttpSmlRequest, this, _1)));
 }
 
-void WebApiPowerMeterClass::onStatus(AsyncWebServerRequest* request)
+void WebApiPowerMeterClass::generateStatus(AsyncWebServerRequest* request, bool fullAccess)
 {
-    if (!WebApi.checkCredentialsReadonly(request)) {
-        return;
-    }
-
     AsyncJsonResponse* response = new AsyncJsonResponse();
     auto& root = response->getRoot();
     auto const& config = Configuration.get();
@@ -48,15 +44,24 @@ void WebApiPowerMeterClass::onStatus(AsyncWebServerRequest* request)
     Configuration.serializePowerMeterSerialSdmConfig(config.PowerMeter.SerialSdm, serialSdm);
 
     auto httpJson = root["http_json"].to<JsonObject>();
-    Configuration.serializePowerMeterHttpJsonConfig(config.PowerMeter.HttpJson, httpJson);
+    Configuration.serializePowerMeterHttpJsonConfig(config.PowerMeter.HttpJson, httpJson, fullAccess);
 
     auto httpSml = root["http_sml"].to<JsonObject>();
-    Configuration.serializePowerMeterHttpSmlConfig(config.PowerMeter.HttpSml, httpSml);
+    Configuration.serializePowerMeterHttpSmlConfig(config.PowerMeter.HttpSml, httpSml, fullAccess);
 
     auto udpVictron = root["udp_victron"].to<JsonObject>();
     Configuration.serializePowerMeterUdpVictronConfig(config.PowerMeter.UdpVictron, udpVictron);
 
     WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
+}
+
+void WebApiPowerMeterClass::onStatus(AsyncWebServerRequest* request)
+{
+    if (!WebApi.checkCredentialsReadonly(request)) {
+        return;
+    }
+
+    this->generateStatus(request, false);
 }
 
 void WebApiPowerMeterClass::onAdminGet(AsyncWebServerRequest* request)
@@ -65,7 +70,7 @@ void WebApiPowerMeterClass::onAdminGet(AsyncWebServerRequest* request)
         return;
     }
 
-    this->onStatus(request);
+    this->generateStatus(request, true);
 }
 
 void WebApiPowerMeterClass::onAdminPost(AsyncWebServerRequest* request)

--- a/src/WebApi_powermeter.cpp
+++ b/src/WebApi_powermeter.cpp
@@ -28,7 +28,7 @@ void WebApiPowerMeterClass::init(AsyncWebServer& server, Scheduler& scheduler)
     _server->on("/api/powermeter/testhttpsmlrequest", HTTP_POST, static_cast<ArRequestHandlerFunction>(std::bind(&WebApiPowerMeterClass::onTestHttpSmlRequest, this, _1)));
 }
 
-void WebApiPowerMeterClass::generateStatus(AsyncWebServerRequest* request, bool fullAccess)
+void WebApiPowerMeterClass::generateStatus(AsyncWebServerRequest* request, bool includeCredentials)
 {
     AsyncJsonResponse* response = new AsyncJsonResponse();
     auto& root = response->getRoot();
@@ -44,10 +44,10 @@ void WebApiPowerMeterClass::generateStatus(AsyncWebServerRequest* request, bool 
     Configuration.serializePowerMeterSerialSdmConfig(config.PowerMeter.SerialSdm, serialSdm);
 
     auto httpJson = root["http_json"].to<JsonObject>();
-    Configuration.serializePowerMeterHttpJsonConfig(config.PowerMeter.HttpJson, httpJson, fullAccess);
+    Configuration.serializePowerMeterHttpJsonConfig(config.PowerMeter.HttpJson, httpJson, includeCredentials);
 
     auto httpSml = root["http_sml"].to<JsonObject>();
-    Configuration.serializePowerMeterHttpSmlConfig(config.PowerMeter.HttpSml, httpSml, fullAccess);
+    Configuration.serializePowerMeterHttpSmlConfig(config.PowerMeter.HttpSml, httpSml, includeCredentials);
 
     auto udpVictron = root["udp_victron"].to<JsonObject>();
     Configuration.serializePowerMeterUdpVictronConfig(config.PowerMeter.UdpVictron, udpVictron);


### PR DESCRIPTION
Credentials are exposed via API to unauthorized users, as the `/api/powermeter/status` endpoint in API uses the same serialization functions as `/api/powermeter/config` does. This PR fixes this by adding a new `fullAccess` argument to the function and skips serializing sensitive data if `fullAccess == false`.