### PR TITLE
Fix: Websocket: Battery livedata can not be refreshed when read-only is disabled

### DIFF
--- a/src/WebApi_ws_battery.cpp
+++ b/src/WebApi_ws_battery.cpp
@@ -99,12 +99,6 @@ void WebApiWsBatteryLiveClass::sendDataTaskCb()
             String buffer;
             serializeJson(root, buffer);
 
-            if (Configuration.get().Security.AllowReadonly) {
-                _ws.setAuthentication("", "");
-            } else {
-                _ws.setAuthentication(AUTH_USERNAME, Configuration.get().Security.Password);
-            }
-
             _ws.textAll(buffer);
         }
     } catch (std::bad_alloc& bad_alloc) {


### PR DESCRIPTION
Connection to `/batterylivedata` failed when read-only access was disabled.

