### PR TITLE
add build env option 'generic_esp32s3_usb_quad_psram'

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ extra_configs =
 [env]
 ; Make sure to NOT add any spaces in the custom_ci_action property
 ; (also the position in the file is important)
-custom_ci_action = generic_esp32_4mb_no_ota,generic_esp32_8mb,generic_esp32s3,generic_esp32s3_usb,generic_esp32s3_usb_octal_psram
+custom_ci_action = generic_esp32_4mb_no_ota,generic_esp32_8mb,generic_esp32s3,generic_esp32s3_usb,generic_esp32s3_usb_octal_psram,generic_esp32s3_usb_quad_psram
 
 framework = arduino
 platform = espressif32@6.10.0
@@ -149,6 +149,18 @@ build_flags = ${env.build_flags}
 board = esp32-s3-devkitc-1
 upload_protocol = esp-builtin
 board_build.arduino.memory_type = qio_opi
+build_flags = ${env.build_flags}
+    -DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DPIN_MAPPING_REQUIRED=1
+    -DBOARD_HAS_PSRAM
+
+
+[env:generic_esp32s3_usb_quad_psram]
+; Fusion Board v2.1 (N8R2), v2.3 (N16R2)
+board = esp32-s3-devkitc-1
+upload_protocol = esp-builtin
+board_build.arduino.memory_type = qio_qspi
 build_flags = ${env.build_flags}
     -DARDUINO_USB_MODE=1
     -DARDUINO_USB_CDC_ON_BOOT=1


### PR DESCRIPTION
Works with all Quad SPI PSRAM ESP32-S3, Fusion Board v2.1 (N8R2) and v2.3 (N16R2)