### PR TITLE
Configurable stale-data timeout per provider; fixes Zendure false positives

### DIFF
--- a/include/battery/Stats.h
+++ b/include/battery/Stats.h
@@ -69,6 +69,9 @@ public:
 protected:
     virtual void mqttPublish() const;
 
+    // the maximum age of data before battery is rendered as unreachable in Web UI
+    virtual uint32_t getMaxAgeSeconds() const { return 20; }
+
     void setSoC(float soc, uint8_t precision, uint32_t timestamp) {
         _soc = soc;
         _socPrecision = precision;

--- a/include/battery/zendure/Stats.h
+++ b/include/battery/zendure/Stats.h
@@ -204,6 +204,8 @@ public:
     }
 
 protected:
+    uint32_t getMaxAgeSeconds() const override { return 90; }
+
     std::shared_ptr<PackStats> getPackData(size_t index) const;
     std::shared_ptr<PackStats> addPackData(size_t index, String serial);
 

--- a/include/solarcharger/Stats.h
+++ b/include/solarcharger/Stats.h
@@ -52,7 +52,7 @@ public:
 protected:
     virtual void mqttPublish() const;
 
-    // the maximum age of data before solar charger is rendered as unreachable in Web UI
+    // maximum age before data is considered stale (affects MQTT publish, live view, and Web UI timeout display)
     virtual uint32_t getMaxAgeMilliSeconds() const { return 10 * 1000; }
 
     void populateJsonWithBasicStats(JsonObject instance, uint32_t age_ms, bool hideSerial = false) const;

--- a/include/solarcharger/Stats.h
+++ b/include/solarcharger/Stats.h
@@ -55,7 +55,7 @@ protected:
     // maximum age before data is considered stale (affects MQTT publish, live view, and Web UI timeout display)
     virtual uint32_t getMaxAgeMilliSeconds() const { return 10 * 1000; }
 
-    void populateAgeFields(JsonObject instance, uint32_t age_ms, bool hideSerial = false) const;
+    void populateJsonWithBasicStats(JsonObject instance, uint32_t age_ms, bool hideSerial = false) const;
 private:
     uint32_t _lastMqttPublish = 0;
 };

--- a/include/solarcharger/Stats.h
+++ b/include/solarcharger/Stats.h
@@ -55,7 +55,7 @@ protected:
     // maximum age before data is considered stale (affects MQTT publish, live view, and Web UI timeout display)
     virtual uint32_t getMaxAgeMilliSeconds() const { return 10 * 1000; }
 
-    void populateJsonWithBasicStats(JsonObject instance, uint32_t age_ms, bool hideSerial = false) const;
+    void populateAgeFields(JsonObject instance, uint32_t age_ms, bool hideSerial = false) const;
 private:
     uint32_t _lastMqttPublish = 0;
 };

--- a/include/solarcharger/Stats.h
+++ b/include/solarcharger/Stats.h
@@ -52,6 +52,10 @@ public:
 protected:
     virtual void mqttPublish() const;
 
+    // the maximum age of data before solar charger is rendered as unreachable in Web UI
+    virtual uint32_t getMaxAgeMilliSeconds() const { return 10 * 1000; }
+
+    void populateJsonWithBasicStats(JsonObject instance, uint32_t age_ms, bool hideSerial = false) const;
 private:
     uint32_t _lastMqttPublish = 0;
 };

--- a/src/battery/Stats.cpp
+++ b/src/battery/Stats.cpp
@@ -43,6 +43,7 @@ void Stats::getLiveViewData(JsonVariant& root) const
         root["hwversion"] = _hwversion;
     }
     root["data_age"] = getAgeSeconds();
+    root["max_age"] = getMaxAgeSeconds();
 
     if (isSoCValid()) {
         addLiveViewValue(root, "SoC", _soc, "%", _socPrecision);

--- a/src/solarcharger/Stats.cpp
+++ b/src/solarcharger/Stats.cpp
@@ -47,4 +47,10 @@ void Stats::mqttPublish() const
 {
 }
 
+void Stats::populateJsonWithBasicStats(JsonObject instance, uint32_t age_ms, bool hideSerial /*= false */) const {
+    instance["data_age_ms"] = age_ms;
+    instance["max_age_ms"] = getMaxAgeMilliSeconds();
+    instance["hide_serial"] = hideSerial;
+}
+
 } // namespace SolarChargers

--- a/src/solarcharger/Stats.cpp
+++ b/src/solarcharger/Stats.cpp
@@ -47,7 +47,7 @@ void Stats::mqttPublish() const
 {
 }
 
-void Stats::populateJsonWithBasicStats(JsonObject instance, uint32_t age_ms, bool hideSerial /*= false */) const {
+void Stats::populateAgeFields(JsonObject instance, uint32_t age_ms, bool hideSerial /*= false */) const {
     instance["data_age_ms"] = age_ms;
     instance["max_age_ms"] = getMaxAgeMilliSeconds();
     instance["hide_serial"] = hideSerial;

--- a/src/solarcharger/Stats.cpp
+++ b/src/solarcharger/Stats.cpp
@@ -47,7 +47,7 @@ void Stats::mqttPublish() const
 {
 }
 
-void Stats::populateAgeFields(JsonObject instance, uint32_t age_ms, bool hideSerial /*= false */) const {
+void Stats::populateJsonWithBasicStats(JsonObject instance, uint32_t age_ms, bool hideSerial /*= false */) const {
     instance["data_age_ms"] = age_ms;
     instance["max_age_ms"] = getMaxAgeMilliSeconds();
     instance["hide_serial"] = hideSerial;

--- a/src/solarcharger/mqtt/Stats.cpp
+++ b/src/solarcharger/mqtt/Stats.cpp
@@ -59,9 +59,8 @@ void Stats::getLiveViewData(JsonVariant& root, const boolean fullUpdate, const u
     auto hasUpdate = _lastUpdate > 0 && age < millis() - lastPublish;
     if (!fullUpdate && !hasUpdate) { return; }
 
-    const JsonObject instance = root["solarcharger"]["instances"]["MQTT"].to<JsonObject>();
-    instance["data_age_ms"] = age;
-    instance["hide_serial"] = true;
+    auto instance = root["solarcharger"]["instances"]["MQTT"].to<JsonObject>();
+    populateJsonWithBasicStats(instance, age, true);
     instance["product_id"] = "MQTT"; // will be translated by the web app
 
     const JsonObject output = instance["values"]["output"].to<JsonObject>();

--- a/src/solarcharger/mqtt/Stats.cpp
+++ b/src/solarcharger/mqtt/Stats.cpp
@@ -60,7 +60,7 @@ void Stats::getLiveViewData(JsonVariant& root, const boolean fullUpdate, const u
     if (!fullUpdate && !hasUpdate) { return; }
 
     auto instance = root["solarcharger"]["instances"]["MQTT"].to<JsonObject>();
-    populateAgeFields(instance, age, true);
+    populateJsonWithBasicStats(instance, age, true);
     instance["product_id"] = "MQTT"; // will be translated by the web app
 
     const JsonObject output = instance["values"]["output"].to<JsonObject>();

--- a/src/solarcharger/mqtt/Stats.cpp
+++ b/src/solarcharger/mqtt/Stats.cpp
@@ -60,7 +60,7 @@ void Stats::getLiveViewData(JsonVariant& root, const boolean fullUpdate, const u
     if (!fullUpdate && !hasUpdate) { return; }
 
     auto instance = root["solarcharger"]["instances"]["MQTT"].to<JsonObject>();
-    populateJsonWithBasicStats(instance, age, true);
+    populateAgeFields(instance, age, true);
     instance["product_id"] = "MQTT"; // will be translated by the web app
 
     const JsonObject output = instance["values"]["output"].to<JsonObject>();

--- a/src/solarcharger/victron/Stats.cpp
+++ b/src/solarcharger/victron/Stats.cpp
@@ -190,7 +190,7 @@ bool Stats::isStale(data_map_t::value_type const& data) const
     // age unknown
     if (!_lastUpdate[data.first]) { return true; }
 
-    return millis() - _lastUpdate[data.first] > 10 * 1000;
+    return millis() - _lastUpdate[data.first] > getMaxAgeMilliSeconds();
 }
 
 void Stats::getLiveViewData(JsonVariant& root, const boolean fullUpdate, const uint32_t lastPublish) const
@@ -208,9 +208,8 @@ void Stats::getLiveViewData(JsonVariant& root, const boolean fullUpdate, const u
         auto hasUpdate = age != 0 && age < millis() - lastPublish;
         if (!fullUpdate && !hasUpdate) { continue; }
 
-        JsonObject instance = instances[entry.second.serialNr_SER].to<JsonObject>();
-        instance["data_age_ms"] = age;
-        instance["hide_serial"] = false;
+        auto instance = instances[entry.second.serialNr_SER].to<JsonObject>();
+        populateJsonWithBasicStats(instance, age);
         populateJsonWithInstanceStats(instance, entry.second);
     }
 }

--- a/src/solarcharger/victron/Stats.cpp
+++ b/src/solarcharger/victron/Stats.cpp
@@ -209,7 +209,7 @@ void Stats::getLiveViewData(JsonVariant& root, const boolean fullUpdate, const u
         if (!fullUpdate && !hasUpdate) { continue; }
 
         auto instance = instances[entry.second.serialNr_SER].to<JsonObject>();
-        populateJsonWithBasicStats(instance, age);
+        populateAgeFields(instance, age);
         populateJsonWithInstanceStats(instance, entry.second);
     }
 }

--- a/src/solarcharger/victron/Stats.cpp
+++ b/src/solarcharger/victron/Stats.cpp
@@ -209,7 +209,7 @@ void Stats::getLiveViewData(JsonVariant& root, const boolean fullUpdate, const u
         if (!fullUpdate && !hasUpdate) { continue; }
 
         auto instance = instances[entry.second.serialNr_SER].to<JsonObject>();
-        populateAgeFields(instance, age);
+        populateJsonWithBasicStats(instance, age);
         populateJsonWithInstanceStats(instance, entry.second);
     }
 }

--- a/webapp/src/components/BatteryView.vue
+++ b/webapp/src/components/BatteryView.vue
@@ -12,8 +12,8 @@
                     <div
                         class="card-header d-flex justify-content-between align-items-center"
                         :class="{
-                            'text-bg-danger': batteryData.data_age >= 20,
-                            'text-bg-success': batteryData.data_age < 20,
+                            'text-bg-danger': batteryData.data_age >= batteryData.max_age,
+                            'text-bg-success': batteryData.data_age < batteryData.max_age,
                         }"
                     >
                         <div class="p-1 flex-grow-1">

--- a/webapp/src/components/SolarChargerView.vue
+++ b/webapp/src/components/SolarChargerView.vue
@@ -12,8 +12,8 @@
                     <div
                         class="card-header d-flex justify-content-between align-items-center"
                         :class="{
-                            'text-bg-danger': item.data_age_ms >= 10000,
-                            'text-bg-success': item.data_age_ms < 10000,
+                            'text-bg-danger': item.data_age_ms >= item.max_age_ms,
+                            'text-bg-success': item.data_age_ms < item.max_age_ms,
                         }"
                     >
                         <div class="p-1 flex-grow-1">

--- a/webapp/src/types/BatteryDataStatus.ts
+++ b/webapp/src/types/BatteryDataStatus.ts
@@ -9,6 +9,7 @@ export interface Battery {
     fwversion: string;
     hwversion: string;
     data_age: number;
+    max_age: number;
     values: BatteryData[];
     showIssues: boolean;
     issues: number[];

--- a/webapp/src/types/SolarChargerLiveDataStatus.ts
+++ b/webapp/src/types/SolarChargerLiveDataStatus.ts
@@ -14,6 +14,7 @@ type MpptData = (ValueObject | string)[];
 
 export interface SolarChargerInstance {
     data_age_ms: number;
+    max_age_ms: number;
     product_id: string;
     firmware_version?: string;
     hide_serial: boolean;


### PR DESCRIPTION
The maximum data age used for ageing `BatteryView` and `SolarChargerView` is currently hard coded in the WebUI. This PR makes this reachable via WebAPI and therefore adjustable by C++ code. With this change, the data ageing can be directly controlled by the Battery/SolarCharger implementation (e.g. Zendure, that overwrites the default value)

Default values are set to formerly hard coded values in C++

Will also fix #2571 