### PR TITLE
Bugfix: Zendure: Accept non-static message ids

### DIFF
--- a/src/battery/zendure/LocalMqttProvider.cpp
+++ b/src/battery/zendure/LocalMqttProvider.cpp
@@ -229,12 +229,7 @@ void LocalMqttProvider::onMqttMessageReport(espMqttClientTypes::MessagePropertie
     auto obj = json.as<JsonObjectConst>();
 
     // validate input data
-    // messageId has to be set to "123"
     // deviceId has to be set to the configured deviceId
-    if (!json["messageId"].as<String>().equals("123")) {
-        DTU_LOGE("Invalid or missing 'messageId' in '%s'", logValue.c_str());
-        return;
-    }
     if (!json["deviceId"].as<String>().equals(Configuration.get().Battery.Zendure.DeviceId)) {
         DTU_LOGE("Invalid or missing 'deviceId' in '%s'", logValue.c_str());
         return;


### PR DESCRIPTION
Seems that recent firmware versions (at least Hyper2000) increment the message id. This PR removes the check for static message id, so frames are accepted.

This should fixe the issue mentioned in #2556