### PR TITLE
Feature: preserve the DPL-Battery-State

### DIFF
--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -12,13 +12,14 @@
 #include <optional>
 #include <TaskSchedulerDeclarations.h>
 #include <frozen/string.h>
+#include "RuntimeData.h"
 
 #define PL_UI_STATE_INACTIVE 0
 #define PL_UI_STATE_CHARGING 1
 #define PL_UI_STATE_USE_SOLAR_ONLY 2
 #define PL_UI_STATE_USE_SOLAR_AND_BATTERY 3
 
-class PowerLimiterClass {
+class PowerLimiterClass : public InterfaceProviderRT {
 public:
     PowerLimiterClass() = default;
 
@@ -57,6 +58,11 @@ public:
     // used to interlock Huawei R48xx grid charger against battery-powered inverters
     bool isGovernedBatteryPoweredInverterProducing() const;
 
+    // interface to the Runtime Provider
+    String getIdRT() const override { return "power_limiter"; }
+    void serializeRT(JsonObject obj) const override;
+    void deserializeRT(JsonObject obj) override;
+
 private:
     void loop();
 
@@ -77,7 +83,10 @@ private:
     enum class BatteryState : uint8_t { STOP = 0, NO_DISCHARGE = 1, DISCHARGE_ALLOWED = 2, DISCHARGE_NIGHT = 3 };
     BatteryState _batteryState = BatteryState::STOP;
     bool _fromStart = false;
+    bool _fromStartRT = false;
     bool _oneStopPerNightDone = false;
+    bool _oneStopPerNightDoneRT = false;
+    time_t _lastBatteryStateSaveEpoch = 0;
 
     std::pair<bool, uint32_t> _nextInverterRestart = { false, 0 };
     bool _fullSolarPassThroughActive = false;

--- a/include/PowerLimiter.h
+++ b/include/PowerLimiter.h
@@ -19,7 +19,7 @@
 #define PL_UI_STATE_USE_SOLAR_ONLY 2
 #define PL_UI_STATE_USE_SOLAR_AND_BATTERY 3
 
-class PowerLimiterClass : public InterfaceProviderRT {
+class PowerLimiterClass {
 public:
     PowerLimiterClass() = default;
 
@@ -58,11 +58,6 @@ public:
     // used to interlock Huawei R48xx grid charger against battery-powered inverters
     bool isGovernedBatteryPoweredInverterProducing() const;
 
-    // interface to the Runtime Provider
-    String getIdRT() const override { return "power_limiter"; }
-    void serializeRT(JsonObject obj) const override;
-    void deserializeRT(JsonObject obj) override;
-
 private:
     void loop();
 
@@ -83,10 +78,7 @@ private:
     enum class BatteryState : uint8_t { STOP = 0, NO_DISCHARGE = 1, DISCHARGE_ALLOWED = 2, DISCHARGE_NIGHT = 3 };
     BatteryState _batteryState = BatteryState::STOP;
     bool _fromStart = false;
-    bool _fromStartRT = false;
     bool _oneStopPerNightDone = false;
-    bool _oneStopPerNightDoneRT = false;
-    time_t _lastBatteryStateSaveEpoch = 0;
 
     std::pair<bool, uint32_t> _nextInverterRestart = { false, 0 };
     bool _fullSolarPassThroughActive = false;
@@ -115,6 +107,7 @@ private:
     bool isBelowStopThreshold() const;
     void calcNextInverterRestart();
     bool isSolarPassThroughEnabled() const;
+    void persistBatteryState();
 };
 
 extern PowerLimiterClass PowerLimiter;

--- a/include/RuntimeData.h
+++ b/include/RuntimeData.h
@@ -1,107 +1,60 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-
-/*
- * Locking policy:
- * - Public getters having the prefix 'get' take a lock internally. getWriteCount(), getWriteEpochTime(), etc.
- * - Public mutating methods take a lock internally.
- * - Private methods are called with the appropriate lock held by the public methods.
- * - Fetching external data is done before acquiring the mutex.
- * - Flags marked as atomic may be read lock-free.
- * - methods read() and writeAll() must be called from the task loop to avoid deadlocks,
- *   use requestWriteOnNextLoop() and requestReadOnNextLoop() to trigger them on demand.
- * - Do not call registerProvider(), unregisterProvider(), or requestReadOnNextLoop() from serializeRT() or deserializeRT()
- *   to avoid deadlocks, as they also take locks internally.
- */
-
 #pragma once
 
 #include <TaskSchedulerDeclarations.h>
 #include <mutex>
-#include <atomic>
-#include <map>
-#include <vector>
-#include <string>
-#include <ArduinoJson.h>
+#include <cstdint>
+#include <ctime>
+#include <WString.h>
 
+// Runtime data of all components that need to persist state across reboots.
+// Unlike Configuration, this is not user-facing settings but internally
+// derived state (e.g. "was the battery discharging when we lost power").
+struct RUNTIME_DATA_T {
+    struct {
+        uint32_t Version;
+        time_t   WriteEpoch;
+        uint16_t WriteCount;
+    } Meta;
 
-// The RuntimeClass Interface, each subsystem have to implement this interface
-// to be able to store and read data in the runtime data file.
-class InterfaceProviderRT {
-public:
-    virtual String getIdRT() const = 0;
-    virtual void serializeRT(JsonObject obj) const = 0;
-    virtual void deserializeRT(JsonObject obj) = 0;
-    virtual ~InterfaceProviderRT() = default;
+    struct {
+        bool FromStart;
+        bool OneStopPerNightDone;
+    } PowerLimiter;
 
-    void setReadOnStartupRT(bool readOnStartup) { _readOnStartup = readOnStartup; }
-    bool getReadOnStartupRT() const { return _readOnStartup; }
-private:
-    bool _readOnStartup = true;   // if true, the data of this provider is readable on startup
+    struct {
+        // reserved for future battery runtime state
+    } Battery;
 };
 
-
-// The RuntimeClass manages the runtime data of the system, which is stored in a file in the flash memory.
-class RuntimeProvider {
+class RuntimeDataClass {
 public:
-    RuntimeProvider() = default;
-    ~RuntimeProvider() = default;
-    RuntimeProvider(const RuntimeProvider&) = delete;
-    RuntimeProvider& operator=(const RuntimeProvider&) = delete;
-    RuntimeProvider(RuntimeProvider&&) = delete;
-    RuntimeProvider& operator=(RuntimeProvider&&) = delete;
-
-    // init the runtime data loop task
     void init(Scheduler& scheduler);
+    bool read();
+    bool write();
+    RUNTIME_DATA_T const& get();
+    String getWriteCountAndTimeString() const;
 
-    // write all providers to file, do not write if last write operation was less than freezeMinutes ago
-    // just call it from the task loop, do not call it from a locally locked mutex to avoid deadlocks
-    bool writeAll(uint16_t const freezeMinutes = 10);
+    class WriteGuard {
+    public:
+        WriteGuard();
+        RUNTIME_DATA_T& getRuntimeData();
+        ~WriteGuard();
 
-    // read from file, if readOnStartup is true, read data from providers that are marked to be read on startup,
-    // otherwise read on demand data from providers from the _readIDList
-    // just call it from the task loop, do not call it from a locally locked mutex to avoid deadlocks
-    bool read(bool const readOnStartup = true);
+    private:
+        std::unique_lock<std::mutex> _lock;
+        RUNTIME_DATA_T _before;
+    };
 
-    // use this method to request storing data on demand
-    void requestWriteOnNextLoop(void) { _writeNow.store(true); }
-
-    // use this method to request reading data on demand, addID is the ID of the provider to be read
-    void requestReadOnNextLoop(const String& addID);
-
-    // register a provider to be managed by the RuntimeProvider, if readOnStartup is true, the data of this provider will be read on startup
-    // The caller retains ownership and must ensure the provider outlives RuntimeProvider.
-    void registerProvider(InterfaceProviderRT* provider, bool readOnStartup = true);
-
-    // unregister a provider, the provider will no longer be managed by the RuntimeProvider, and its data will not be read or written anymore
-    void unregisterProvider(const String& id);
-    void unregisterProvider(InterfaceProviderRT* provider);
-
-    // getters for the runtime data, these methods are protected by mutex to ensure thread safety
-    uint16_t getWriteCount(void) const;
-    time_t getWriteEpochTime(void) const;
-    bool getReadState(void) const { return _readOK.load(); }
-    bool getWriteState(void) const { return _writeOK.load(); }
-    String getWriteCountAndTimeString(void) const;
+    WriteGuard getWriteGuard();
 
 private:
-    void loop(void);
-    bool getWriteTrigger(void);
+    void loop();
+    bool getDailyWriteTrigger();
 
     Task _loopTask;
-    std::atomic<bool> _readOK = false;      // true if the last read operation was successful
-    std::atomic<bool> _writeOK = false;     // true if the last write operation was successful
-    std::atomic<bool> _readNow = false;     // if true, the data is read in the next task loop()
-    std::atomic<bool> _writeNow = false;    // if true, the data is stored in the next task loop()
-
-    mutable std::mutex _mutexData;          // to protect the shared data below
-    bool _lastTrigger = false;              // auxiliary value to prevent multiple triggering on the same day
-    uint16_t _fileVersion = 0;              // shared data: version of the runtime data file, prepared for future migration support
-    uint16_t _writeCount = 0;               // shared data: number of write operations
-    time_t _writeEpoch = 0;                 // shared data: epoch time when the data was written
-
-    mutable std::mutex _mutexInterface;     // to protect the interface data below
-    std::map<String, InterfaceProviderRT*> _providers;
-    std::vector<String> _readIDList;        // list of provider IDs to be read on demand
+    bool _dirty = false;
+    bool _lastTrigger = false;
 };
 
-extern RuntimeProvider Runtime;
+extern RuntimeDataClass Runtime;

--- a/include/RuntimeData.h
+++ b/include/RuntimeData.h
@@ -1,27 +1,82 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+ * Locking policy:
+ * - Public getters having the prefix 'get' take a lock internally. getWriteCount(), getWriteEpochTime(), etc.
+ * - Public mutating methods take a lock internally.
+ * - Private methods are called with the appropriate lock held by the public methods.
+ * - Fetching external data is done before acquiring the mutex.
+ * - Flags marked as atomic may be read lock-free.
+ * - methods read() and writeAll() must be called from the task loop to avoid deadlocks,
+ *   use requestWriteOnNextLoop() and requestReadOnNextLoop() to trigger them on demand.
+ * - Do not call registerProvider(), unregisterProvider(), or requestReadOnNextLoop() from serializeRT() or deserializeRT()
+ *   to avoid deadlocks, as they also take locks internally.
+ */
+
 #pragma once
 
 #include <TaskSchedulerDeclarations.h>
 #include <mutex>
 #include <atomic>
+#include <map>
+#include <vector>
+#include <string>
+#include <ArduinoJson.h>
 
 
-class RuntimeClass {
+// The RuntimeClass Interface, each subsystem have to implement this interface
+// to be able to store and read data in the runtime data file.
+class InterfaceProviderRT {
 public:
-    RuntimeClass() = default;
-    ~RuntimeClass() = default;
-    RuntimeClass(const RuntimeClass&) = delete;
-    RuntimeClass& operator=(const RuntimeClass&) = delete;
-    RuntimeClass(RuntimeClass&&) = delete;
-    RuntimeClass& operator=(RuntimeClass&&) = delete;
+    virtual String getIdRT() const = 0;
+    virtual void serializeRT(JsonObject obj) const = 0;
+    virtual void deserializeRT(JsonObject obj) = 0;
+    virtual ~InterfaceProviderRT() = default;
 
+    void setReadOnStartupRT(bool readOnStartup) { _readOnStartup = readOnStartup; }
+    bool getReadOnStartupRT() const { return _readOnStartup; }
+private:
+    bool _readOnStartup = true;   // if true, the data of this provider is readable on startup
+};
+
+
+// The RuntimeClass manages the runtime data of the system, which is stored in a file in the flash memory.
+class RuntimeProvider {
+public:
+    RuntimeProvider() = default;
+    ~RuntimeProvider() = default;
+    RuntimeProvider(const RuntimeProvider&) = delete;
+    RuntimeProvider& operator=(const RuntimeProvider&) = delete;
+    RuntimeProvider(RuntimeProvider&&) = delete;
+    RuntimeProvider& operator=(RuntimeProvider&&) = delete;
+
+    // init the runtime data loop task
     void init(Scheduler& scheduler);
-    enum class ReadMode : uint8_t { START_UP, ON_DEMAND };
-    bool read(ReadMode const mode = ReadMode::START_UP);                // read runtime data
-    bool write(uint16_t const freezeMinutes = 10);                      // do not write if last write operation was less than freezeMinutes ago
-    void requestWriteOnNextTaskLoop(void) { _writeNow.store(true); };   // use this member function to store data on demand
-    void requestReadOnNextTaskLoop(void) { _readNow.store(true); };     // use this member function to read data on demand
 
+    // write all providers to file, do not write if last write operation was less than freezeMinutes ago
+    // just call it from the task loop, do not call it from a locally locked mutex to avoid deadlocks
+    bool writeAll(uint16_t const freezeMinutes = 10);
+
+    // read from file, if readOnStartup is true, read data from providers that are marked to be read on startup,
+    // otherwise read on demand data from providers from the _readIDList
+    // just call it from the task loop, do not call it from a locally locked mutex to avoid deadlocks
+    bool read(bool const readOnStartup = true);
+
+    // use this method to request storing data on demand
+    void requestWriteOnNextLoop(void) { _writeNow.store(true); }
+
+    // use this method to request reading data on demand, addID is the ID of the provider to be read
+    void requestReadOnNextLoop(const String& addID);
+
+    // register a provider to be managed by the RuntimeProvider, if readOnStartup is true, the data of this provider will be read on startup
+    // The caller retains ownership and must ensure the provider outlives RuntimeProvider.
+    void registerProvider(InterfaceProviderRT* provider, bool readOnStartup = true);
+
+    // unregister a provider, the provider will no longer be managed by the RuntimeProvider, and its data will not be read or written anymore
+    void unregisterProvider(const String& id);
+    void unregisterProvider(InterfaceProviderRT* provider);
+
+    // getters for the runtime data, these methods are protected by mutex to ensure thread safety
     uint16_t getWriteCount(void) const;
     time_t getWriteEpochTime(void) const;
     bool getReadState(void) const { return _readOK.load(); }
@@ -37,11 +92,16 @@ private:
     std::atomic<bool> _writeOK = false;     // true if the last write operation was successful
     std::atomic<bool> _readNow = false;     // if true, the data is read in the next task loop()
     std::atomic<bool> _writeNow = false;    // if true, the data is stored in the next task loop()
-    mutable std::mutex _mutex;              // to protect the shared data below
+
+    mutable std::mutex _mutexData;          // to protect the shared data below
     bool _lastTrigger = false;              // auxiliary value to prevent multiple triggering on the same day
     uint16_t _fileVersion = 0;              // shared data: version of the runtime data file, prepared for future migration support
     uint16_t _writeCount = 0;               // shared data: number of write operations
     time_t _writeEpoch = 0;                 // shared data: epoch time when the data was written
+
+    mutable std::mutex _mutexInterface;     // to protect the interface data below
+    std::map<String, InterfaceProviderRT*> _providers;
+    std::vector<String> _readIDList;        // list of provider IDs to be read on demand
 };
 
-extern RuntimeClass RuntimeData;
+extern RuntimeProvider Runtime;

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -25,10 +25,6 @@
 static const char* TAG = "dynamicPowerLimiter";
 static const char* SUBTAG = "Controller";
 
-// runtime data keys
-static constexpr const char* FROM_START = "battery_from_start";
-static constexpr const char* ONE_STOP_PER_NIGHT_DONE = "battery_one_stop_per_night_done";
-
 static auto sBatteryPoweredFilter = [](PowerLimiterInverter const& inv) {
     return inv.isBatteryPowered();
 };
@@ -56,7 +52,19 @@ void PowerLimiterClass::init(Scheduler& scheduler)
     _loopTask.setIterations(TASK_FOREVER);
     _loopTask.enable();
 
-    Runtime.registerProvider(this); // register for read on startup
+    // Runtime is read synchronously before any component's init() runs (see main.cpp),
+    // so the persisted battery state is available immediately, no timing tricks needed.
+    // Discard it only if we can positively tell it is stale (saved more than 1h ago) --
+    // a long power-off means the battery may have changed state while we were away.
+    // NTP is usually not synced yet at this point, so "can't tell" defaults to trusting
+    // the data; any wrong carry-over gets corrected on the next real threshold crossing.
+    time_t nowEpoch;
+    bool stale = Utils::getEpoch(&nowEpoch, 1) &&
+            (difftime(nowEpoch, Runtime.get().Meta.WriteEpoch) > 60 * 60);
+    if (!stale) {
+        _fromStart = Runtime.get().PowerLimiter.FromStart;
+        _oneStopPerNightDone = Runtime.get().PowerLimiter.OneStopPerNightDone;
+    }
 }
 
 frozen::string const& PowerLimiterClass::getStatusText(PowerLimiterClass::Status status) const
@@ -268,24 +276,6 @@ void PowerLimiterClass::loop()
         // check if we have a battery powered inverter
         if (!usesBatteryPoweredInverter()) { return BatteryState::STOP; }
 
-        // the startup requires special handling, because the voltage or the SoC may not be available at the beginning of the DPL loop.
-        // if we are in the first 15 seconds after startup, we use the buffered information from the runtime data if available and not too old.
-        // A perfect solution would require refactoring of isStopThresholdReached() and related methods to handle the state if
-        // data is not available during the startup scenario properly.
-        if (_fromStartRT && (millis() < 15 * 1000)) {
-            time_t nowEpoch;
-            Utils::getEpoch(&nowEpoch, 1);
-
-            // if the runtime epoch is more than one hour in the past, we assume that the runtime data is too old.
-            if ((nowEpoch - _lastBatteryStateSaveEpoch) <= (60 * 60)) {
-                _fromStart = _fromStartRT;
-                _oneStopPerNightDone = _oneStopPerNightDoneRT;
-            }
-        } else {
-            _fromStartRT = false;
-            _oneStopPerNightDoneRT = false;
-        }
-
         // check the stop condition
         auto day = SunPosition.isDayPeriod();
         if (isStopThresholdReached()) {
@@ -359,6 +349,7 @@ void PowerLimiterClass::loop()
 
     _loadCorrectedVoltage = getLoadCorrectedVoltage();
     _batteryState = getBatteryState();
+    persistBatteryState();
     _fullSolarPassThroughActive = getFullSolarPassthrough();
 
     DTU_LOGD("up %lu s, it is %s, next inverter restart at %d s (set to %d)",
@@ -1008,26 +999,10 @@ bool PowerLimiterClass::isGovernedBatteryPoweredInverterProducing() const
     return false;
 }
 
-void PowerLimiterClass::serializeRT(JsonObject obj) const
+void PowerLimiterClass::persistBatteryState()
 {
-    // Note: Up to now the PowerLimiterClass does not use a mutex
-    // As long as we read and write during startup or from the main task, we are fine.
-    obj[FROM_START] = _fromStart;
-    obj[ONE_STOP_PER_NIGHT_DONE] = _oneStopPerNightDone;
-}
-
-void PowerLimiterClass::deserializeRT(JsonObject obj)
-{
-    // Note: Up to now the PowerLimiterClass does not use a mutex
-    // As long as we read and write during startup or from the main task, we are fine.
-    // We can not use the write epoch time to determine whether the serialized data is outdated,
-    // because the system time may not be available at the time of deserialization
-    _lastBatteryStateSaveEpoch = Runtime.getWriteEpochTime();
-
-    if (obj[FROM_START].is<bool>()) {
-        _fromStartRT = obj[FROM_START];
-    }
-    if (obj[ONE_STOP_PER_NIGHT_DONE].is<bool>()) {
-        _oneStopPerNightDoneRT = obj[ONE_STOP_PER_NIGHT_DONE];
-    }
+    auto guard = Runtime.getWriteGuard();
+    auto& runtimeData = guard.getRuntimeData();
+    runtimeData.PowerLimiter.FromStart = _fromStart;
+    runtimeData.PowerLimiter.OneStopPerNightDone = _oneStopPerNightDone;
 }

--- a/src/PowerLimiter.cpp
+++ b/src/PowerLimiter.cpp
@@ -18,10 +18,16 @@
 #include <frozen/map.h>
 #include "SunPosition.h"
 #include <LogHelper.h>
+#include "Utils.h"
+#include "RuntimeData.h"
 
 #undef TAG
 static const char* TAG = "dynamicPowerLimiter";
 static const char* SUBTAG = "Controller";
+
+// runtime data keys
+static constexpr const char* FROM_START = "battery_from_start";
+static constexpr const char* ONE_STOP_PER_NIGHT_DONE = "battery_one_stop_per_night_done";
 
 static auto sBatteryPoweredFilter = [](PowerLimiterInverter const& inv) {
     return inv.isBatteryPowered();
@@ -49,6 +55,8 @@ void PowerLimiterClass::init(Scheduler& scheduler)
     _loopTask.setCallback(std::bind(&PowerLimiterClass::loop, this));
     _loopTask.setIterations(TASK_FOREVER);
     _loopTask.enable();
+
+    Runtime.registerProvider(this); // register for read on startup
 }
 
 frozen::string const& PowerLimiterClass::getStatusText(PowerLimiterClass::Status status) const
@@ -259,6 +267,24 @@ void PowerLimiterClass::loop()
 
         // check if we have a battery powered inverter
         if (!usesBatteryPoweredInverter()) { return BatteryState::STOP; }
+
+        // the startup requires special handling, because the voltage or the SoC may not be available at the beginning of the DPL loop.
+        // if we are in the first 15 seconds after startup, we use the buffered information from the runtime data if available and not too old.
+        // A perfect solution would require refactoring of isStopThresholdReached() and related methods to handle the state if
+        // data is not available during the startup scenario properly.
+        if (_fromStartRT && (millis() < 15 * 1000)) {
+            time_t nowEpoch;
+            Utils::getEpoch(&nowEpoch, 1);
+
+            // if the runtime epoch is more than one hour in the past, we assume that the runtime data is too old.
+            if ((nowEpoch - _lastBatteryStateSaveEpoch) <= (60 * 60)) {
+                _fromStart = _fromStartRT;
+                _oneStopPerNightDone = _oneStopPerNightDoneRT;
+            }
+        } else {
+            _fromStartRT = false;
+            _oneStopPerNightDoneRT = false;
+        }
 
         // check the stop condition
         auto day = SunPosition.isDayPeriod();
@@ -980,4 +1006,28 @@ bool PowerLimiterClass::isGovernedBatteryPoweredInverterProducing() const
         if (upInv->isBatteryPowered() && upInv->isProducing()) { return true; }
     }
     return false;
+}
+
+void PowerLimiterClass::serializeRT(JsonObject obj) const
+{
+    // Note: Up to now the PowerLimiterClass does not use a mutex
+    // As long as we read and write during startup or from the main task, we are fine.
+    obj[FROM_START] = _fromStart;
+    obj[ONE_STOP_PER_NIGHT_DONE] = _oneStopPerNightDone;
+}
+
+void PowerLimiterClass::deserializeRT(JsonObject obj)
+{
+    // Note: Up to now the PowerLimiterClass does not use a mutex
+    // As long as we read and write during startup or from the main task, we are fine.
+    // We can not use the write epoch time to determine whether the serialized data is outdated,
+    // because the system time may not be available at the time of deserialization
+    _lastBatteryStateSaveEpoch = Runtime.getWriteEpochTime();
+
+    if (obj[FROM_START].is<bool>()) {
+        _fromStartRT = obj[FROM_START];
+    }
+    if (obj[ONE_STOP_PER_NIGHT_DONE].is<bool>()) {
+        _oneStopPerNightDoneRT = obj[ONE_STOP_PER_NIGHT_DONE];
+    }
 }

--- a/src/RestartHelper.cpp
+++ b/src/RestartHelper.cpp
@@ -5,6 +5,7 @@
 #include "RestartHelper.h"
 #include "Display_Graphic.h"
 #include "Led_Single.h"
+#include "RuntimeData.h"
 #include <Esp.h>
 
 RestartHelperClass RestartHelper;
@@ -30,6 +31,9 @@ void RestartHelperClass::loop()
     if (_rebootTask.isFirstIteration()) {
         LedSingle.turnAllOff();
         Display.setStatus(false);
+
+        // write the runtime data to LittleFS, but do not write if last write operation was less than 10 min ago
+        Runtime.writeAll(10);
     } else {
         ESP.restart();
     }

--- a/src/RestartHelper.cpp
+++ b/src/RestartHelper.cpp
@@ -32,8 +32,8 @@ void RestartHelperClass::loop()
         LedSingle.turnAllOff();
         Display.setStatus(false);
 
-        // write the runtime data to LittleFS, but do not write if last write operation was less than 10 min ago
-        Runtime.writeAll(10);
+        // write the runtime data to LittleFS if anything changed
+        Runtime.write();
     } else {
         ESP.restart();
     }

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -6,73 +6,129 @@
  * - The data is stored in JSON format
  * - The data is written during WebApp 'OTA firmware upgrade' and during Webapp 'Reboot'
  * - For security reasons such as 'unexpected power cycles' or 'physical resets', data is also written once a day at 00:05
- * - The data will not be written if the last write operation was less than one hour ago. ('OTA firmware upgrade' and 'Reboot')
- * - Threadsave access to the data is provided by a mutex.
+ * - The data will not be written if the last write operation was less than 10 minutes ago.
+ * - Threadsafe access to data and interface is provided by two mutexes.
+ * - Reading is done on startup and if requested on demand.
  *
  * How to use:
- *  - Runtime data must be added in the read() and write() methods.
- *  - To avoid reenter deadlocks, do not call write() or read() from a locally locked mutex to save locally data on demand!
- *  - Use requestWriteOnNextTaskLoop() and requestReadOnNextTaskLoop() to avoid deadlocks if you want to handle locally data on demand.
+ *  - Derive your own class from the interface class InterfaceProviderRT.
+ *  - Implement the serializeRT() and deserializeRT() methods to define how your subsystem's runtime data is stored and read.
+ *  - Register the provider to the RuntimeProvider singleton instance in the setup() method of your subsystem
+ *  - Use requestWriteOnNextLoop() and requestReadOnNextLoop() if you want to handle runtime data on demand.
+ *
+ * Note:
+ * - The LittleFS filesystem must be initialized before using Runtime, otherwise the write and read operations will fail.
  *
  * 2025.09.11 - 1.0 - first version
  * 2025.12.01 - 1.1 - added read mode ON_DEMAND and START_UP
+ * 2026.05.06 - 1.2 - added InterfaceProviderRT interface and provider registration and unregistration methods
+ *                    improved read() method to read data of all or of specific providers
+ *                    improved writeAll() method to keep data of providers that are currently not active or not registered
  */
 
 #include <Utils.h>
 #include <LittleFS.h>
 #include <esp_log.h>
 #include <ArduinoJson.h>
+#include <algorithm>
 #include "RuntimeData.h"
-
 
 #undef TAG
 static const char* TAG = "runtime";
 
+static constexpr const char* RUNTIME_FILENAME = "/runtime.json";    // filename of the runtime data file
+static constexpr uint16_t RUNTIME_VERSION = 1;                      // version prepared for future migration support
 
-constexpr const char* RUNTIME_FILENAME = "/runtime.json";   // filename of the runtime data file
-constexpr uint16_t RUNTIME_VERSION = 1;                     // version prepared for future migration support
+// runtime data keys
+static constexpr const char* INFO = "info";
+static constexpr const char* VERSION = "version";
+static constexpr const char* SAVE_COUNT = "save_count";
+static constexpr const char* SAVE_EPOCH = "save_epoch";
 
 
-RuntimeClass RuntimeData; // singleton instance
+RuntimeProvider Runtime; // singleton instance
 
 
 /*
  * Init the runtime data loop task
  */
-void RuntimeClass::init(Scheduler& scheduler)
+void RuntimeProvider::init(Scheduler& scheduler)
 {
     scheduler.addTask(_loopTask);
-    _loopTask.setCallback(std::bind(&RuntimeClass::loop, this));
+    _loopTask.setCallback(std::bind(&RuntimeProvider::loop, this));
     _loopTask.setIterations(TASK_FOREVER);
-    _loopTask.setInterval(60 * 1000); // every minute
+    _loopTask.setInterval(15 * 1000); // every 15 seconds
     _loopTask.enable();
 }
 
 
 /*
- * The runtime data loop is called every minute
+ * The runtime data loop is called every 15 seconds and checks if a write or read operation is requested
  */
-void RuntimeClass::loop(void)
+void RuntimeProvider::loop(void)
 {
-
     // check if we need to write the runtime data, either it is 00:05 or on request
-    if (_writeNow.exchange(false) || getWriteTrigger()) {
-        write(0); // no freeze time.
+    bool dailyWriteTriggered = getWriteTrigger();
+    if (_writeNow.exchange(false) || dailyWriteTriggered) {
+        writeAll(0); // no freeze time.
     }
 
-    // check if we need to read the runtime data on request
-    // for example, if some data is not available during startup
+    // check if we need to read runtime data on request
     if (_readNow.exchange(false)) {
-        read(ReadMode::ON_DEMAND); // read data that can be read on demand
+        read(false); // read on demand, not on startup
     }
 }
 
 
 /*
- * Writes the runtime data to LittleFS file
+ * Register a provider to be managed by the RuntimeProvider,
+ * if readOnStartup is true, the data of this provider will be read on startup
+ */
+void RuntimeProvider::registerProvider(InterfaceProviderRT* provider, bool readOnStartup) {
+
+    { // mutex is automatically released when lock goes out of this scope
+        std::lock_guard<std::mutex> lock(_mutexInterface);
+
+        provider->setReadOnStartupRT(readOnStartup);
+        _providers[provider->getIdRT()] = provider;
+    } // mutex is automatically released when lock goes out of this scope
+
+    ESP_LOGI(TAG, "Provider '%s' registered", provider->getIdRT().c_str());
+}
+
+
+/*
+ * Unregister a provider, the provider will no longer be managed by the RuntimeProvider,
+ * and its data will not be read or written anymore
+ */
+void RuntimeProvider::unregisterProvider(const String& id) {
+
+    { // mutex is automatically released when lock goes out of this scope
+        std::lock_guard<std::mutex> lock(_mutexInterface);
+
+        _providers.erase(id);
+    } // mutex is automatically released when lock goes out of this scope
+
+    ESP_LOGI(TAG, "Provider '%s' unregistered", id.c_str());
+}
+
+void RuntimeProvider::unregisterProvider(InterfaceProviderRT* provider) {
+
+    { // mutex is automatically released when lock goes out of this scope
+        std::lock_guard<std::mutex> lock(_mutexInterface);
+
+        _providers.erase(provider->getIdRT());
+    } // mutex is automatically released when lock goes out of this scope
+
+    ESP_LOGI(TAG, "Provider '%s' unregistered", provider->getIdRT().c_str());
+}
+
+
+/*
+ * Write the runtime data from all registered providers into LittleFS file
  * freezeMinutes: Minimum necessary time [minutes] between now and last write operation
  */
-bool RuntimeClass::write(uint16_t const freezeMinutes)
+bool RuntimeProvider::writeAll(uint16_t const freezeMinutes)
 {
     auto cleanExit = [this](const bool writeOk, const char* text) -> bool {
         if (writeOk) {
@@ -87,115 +143,167 @@ bool RuntimeClass::write(uint16_t const freezeMinutes)
     // we need a valid epoch time before we can write the runtime data
     time_t nextEpoch;
     if (!Utils::getEpoch(&nextEpoch, 1)) { return cleanExit(false, "Local time not available, skipping write"); }
-    uint16_t nextCount;
 
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
+    { // mutex is automatically released when lock goes out of this scope
+        std::lock_guard<std::mutex> lock(_mutexInterface);
+
+        // fast exit if no providers are registered, no need to write an empty file
+        if (_providers.empty()) {
+            return cleanExit(true, "No providers registered, skipping write");
+        }
+    } // mutex is automatically released when lock goes out of this scope
+
+    { // mutex is automatically released when lock goes out of this scope
+        std::lock_guard<std::mutex> lock(_mutexData);
+
+        if (!LittleFS.exists(RUNTIME_FILENAME)) { _writeEpoch = 0; }
 
         // check minimum interval between writes (enforced only when freezeMinutes > 0)
         if ((freezeMinutes > 0) && (_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * freezeMinutes)) {
             return cleanExit(false, "Time interval too short, skipping write");
         }
-
-        // prepare the next write count
-        nextCount = _writeCount + 1;
-
     } // mutex is automatically released when lock goes out of this scope
 
-    // prepare the JSON document and store the runtime data in it is done outside the
+    // prepare the JSON document and store the runtime data is done outside the
     // mutex protection to minimize the time the mutex is locked.
     JsonDocument doc;
-    JsonObject info = doc["info"].to<JsonObject>();
-    info["version"] = RUNTIME_VERSION;
-    info["save_count"] = nextCount;
-    info["save_epoch"] = nextEpoch;
 
-    // serialize additional runtime data here
-    // make sure the additional data remains under its own mutex protection.
-    // todo: serialize additional runtime data
+    // read the existing runtime data to keep the data of providers that are currently not active or
+    // not registered anymore, otherwise we would lose this data on write
+    File fRuntime = LittleFS.open(RUNTIME_FILENAME, "r", false);
+    if (fRuntime) {
+        Utils::skipBom(fRuntime);
+        DeserializationError error = deserializeJson(doc, fRuntime);
+        fRuntime.close();
+        if (error || !Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
+            ESP_LOGW(TAG, "Read data error, rewriting runtime file from current provider state");
+            doc.clear();
+        }
+    }
+
+    JsonObject info = doc[INFO].as<JsonObject>();
+    uint16_t nextCount = info[SAVE_COUNT] | 0U;
+    nextCount++; // increase the count for the next write operation
+
+    info = doc[INFO].to<JsonObject>();
+    info[VERSION] = RUNTIME_VERSION;
+    info[SAVE_COUNT] = nextCount;
+    info[SAVE_EPOCH] = nextEpoch;
+
+    { // mutex is automatically released when lock goes out of this scope
+        std::lock_guard<std::mutex> lock(_mutexInterface);
+
+        // serialize the runtime data of all registered providers
+        for (auto& [id, provider] : _providers) {
+            provider->serializeRT(doc[id].to<JsonObject>());
+        }
+    } // mutex is automatically released when lock goes out of this scope
 
     if (!Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
         return cleanExit(false, "JSON alloc fault, skipping write");
     }
 
-    File fRuntime = LittleFS.open(RUNTIME_FILENAME, "w");
+    fRuntime = LittleFS.open(RUNTIME_FILENAME, "w");
     if (!fRuntime) { return cleanExit(false, "Failed to open file for writing"); }
 
     if (serializeJson(doc, fRuntime) == 0) {
         fRuntime.close();
         return cleanExit(false, "Failed to serialize to file");
     }
-
     fRuntime.close();
 
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
+    { // mutex is automatically released when lock goes out of this scope
+        std::lock_guard<std::mutex> lock(_mutexData);
 
         // commit the new state only after a successful write
         _fileVersion = RUNTIME_VERSION;
         _writeEpoch = nextEpoch;
         _writeCount = nextCount;
-
     } // mutex is automatically released when lock goes out of this scope
 
-    return cleanExit(true, "Written to file");
+    return cleanExit(true, "Write to file");
 }
 
 
 /*
  * Read the runtime data from LittleFS file
- * mode = START_UP: read data that can be initialized during startup
- * mode = ON_DEMAND: read data that can not be read during startup
+ * readOnStartup = true: read data from providers that are marked to be read on startup
+ * readOnStartup = false: read data from providers that are requested to be read on demand
  */
-bool RuntimeClass::read(ReadMode const mode)
+bool RuntimeProvider::read(bool const readOnStartup)
 {
-    bool readOk = false;
+    auto cleanExit = [this](const bool readOk, const char* text) -> bool {
+        if (readOk) {
+            ESP_LOGI(TAG,"%s", text);
+        } else {
+            ESP_LOGE(TAG,"%s", text);
+        }
+        _readOK.store(readOk);
+        return readOk;
+    };
+
     JsonDocument doc;
 
-    // Note: We do not exit on read or allocation errors. In that case we need the default values
+    // Note: We do not exit on read or allocation errors.
+    // Every provider can decide by itself whether to use default configuration values in that case
+    bool readOk = LittleFS.exists(RUNTIME_FILENAME);
     File fRuntime = LittleFS.open(RUNTIME_FILENAME, "r", false);
     if (fRuntime) {
         Utils::skipBom(fRuntime);
         DeserializationError error = deserializeJson(doc, fRuntime);
-        if (!error && Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
-            readOk = true; // success of reading the runtime data
+        fRuntime.close();
+        if (error || !Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
+            readOk = false;
         }
     }
 
-    JsonObject info = doc["info"];
+    JsonObject info = doc[INFO].as<JsonObject>();
+
     { // mutex is automatically released when lock goes out of this scope
-        std::lock_guard<std::mutex> lock(_mutex);
-        _fileVersion = info["version"] | 0U; // 0 means no file available and runtime data is not valid
-        _writeCount = info["save_count"] | 0U;
-        _writeEpoch = info["save_epoch"] | 0U;
+        std::lock_guard<std::mutex> lock(_mutexData);
+
+        // 0 means no file available and runtime data is not valid
+        _fileVersion = info[VERSION] | 0U;
+        _writeCount = info[SAVE_COUNT] | 0U;
+        _writeEpoch = info[SAVE_EPOCH].as<time_t>();
+        if (_writeEpoch == 0) { readOk = false; } // no valid data available
     } // mutex is automatically released when lock goes out of this scope
 
-    // deserialize additional runtime data here, prepare default values and protect the shared data with a mutex
-    // use ReadMode::START_UP for all data that can be initialized during startup
-    if (mode == ReadMode::START_UP) {
-        ; // todo: deserialize additional runtime data that can be initialized during startup
-    } else {
-        ; // todo: deserialize additional runtime data that can not be initialized during startup
+    { // mutex is automatically released when lock goes out of this scope
+        std::lock_guard<std::mutex> lock(_mutexInterface);
+
+        for (auto& [id, provider] : _providers) {
+            if (readOnStartup) {
+                if (!provider->getReadOnStartupRT()) { continue; } // skip providers that are not read on startup
+            } else {
+                auto providerIt = std::find(_readIDList.begin(), _readIDList.end(), id);
+                if (providerIt == _readIDList.end()) { continue; } // skip providers that are not requested to be read on demand
+            }
+
+            // JsonObject can be empty, but as mentioned before, we do not exit on read or allocation errors,
+            // so the provider can decide by itself whether to use default configuration values in that case
+            provider->deserializeRT(doc[id].as<JsonObject>());
+        }
+
+        // Clear the on-demand read list after processing
+        if (!readOnStartup) { _readIDList.clear(); }
+
+    } // mutex is automatically released when lock goes out of this scope
+
+    if (!readOk) {
+        return cleanExit(false, "File not found or error, using default values");
     }
 
-
-    if (fRuntime) { fRuntime.close(); }
-    if (readOk) {
-        ESP_LOGI(TAG, "Read successfully");
-    } else {
-        ESP_LOGE(TAG, "Read fault, using default values");
-    }
-    _readOK.store(readOk);
-    return readOk;
+    return cleanExit(true, "Read from file");
 }
 
 
 /*
  * Get the write counter
  */
-uint16_t RuntimeClass::getWriteCount(void) const
+uint16_t RuntimeProvider::getWriteCount(void) const
 {
-    std::lock_guard<std::mutex> lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutexData);
     return _writeCount;
 }
 
@@ -203,9 +311,9 @@ uint16_t RuntimeClass::getWriteCount(void) const
 /*
  * Get the write epoch time
  */
-time_t RuntimeClass::getWriteEpochTime(void) const
+time_t RuntimeProvider::getWriteEpochTime(void) const
 {
-    std::lock_guard<std::mutex> lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutexData);
     return _writeEpoch;
 }
 
@@ -215,12 +323,13 @@ time_t RuntimeClass::getWriteEpochTime(void) const
  * Format: "<count> / <dd>-<mon> <hh>:<mm>"
  * If epoch time and local time is not available the time is replaced by "no time"
  */
-String RuntimeClass::getWriteCountAndTimeString(void) const
+String RuntimeProvider::getWriteCountAndTimeString(void) const
 {
     time_t epoch;
     uint16_t count;
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
+
+    { // mutex is automatically released when lock goes out of this scope
+        std::lock_guard<std::mutex> lock(_mutexData);
         epoch = _writeEpoch;
         count = _writeCount;
     } // mutex is automatically released when lock goes out of this scope
@@ -242,16 +351,17 @@ String RuntimeClass::getWriteCountAndTimeString(void) const
 
 
 /*
+ * Get the daily write trigger
  * Returns true once a day between 00:05 - 00:10
  */
-bool RuntimeClass::getWriteTrigger(void) {
+bool RuntimeProvider::getWriteTrigger(void) {
 
     struct tm nowTime;
     if (!getLocalTime(&nowTime, 1)) {
         return false;
     }
 
-    std::lock_guard<std::mutex> lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutexData);
     if ((nowTime.tm_hour == 0) && (nowTime.tm_min >= 5) && (nowTime.tm_min <= 10)) {
         if (_lastTrigger == false) {
             _lastTrigger = true;
@@ -261,4 +371,18 @@ bool RuntimeClass::getWriteTrigger(void) {
         _lastTrigger = false;
     }
     return false;
+}
+
+
+/*
+ * Add an provider ID to the read list
+ */
+void RuntimeProvider::requestReadOnNextLoop(String const& addID) {
+
+    std::lock_guard<std::mutex> lock(_mutexInterface);
+
+    // if the ID is not already on the list, add it
+    auto id = std::find(_readIDList.begin(), _readIDList.end(), addID);
+    if (id == _readIDList.end()) { _readIDList.push_back(addID); }
+    _readNow.store(true);
 }

--- a/src/RuntimeData.cpp
+++ b/src/RuntimeData.cpp
@@ -2,336 +2,198 @@
 
 /* Runtime Data Management
  *
- * Read and write runtime data persistent on LittleFS
- * - The data is stored in JSON format
- * - The data is written during WebApp 'OTA firmware upgrade' and during Webapp 'Reboot'
- * - For security reasons such as 'unexpected power cycles' or 'physical resets', data is also written once a day at 00:05
- * - The data will not be written if the last write operation was less than 10 minutes ago.
- * - Threadsafe access to data and interface is provided by two mutexes.
- * - Reading is done on startup and if requested on demand.
+ * Read and write runtime data persistent on LittleFS.
+ * - RuntimeData is the shared home for internally-derived state that components
+ *   want to survive a reboot (as opposed to Configuration, which is user settings).
+ * - The whole RUNTIME_DATA_T struct is known at compile time (like CONFIG_T), so
+ *   there is no provider registration/dispatch: components just read/write their
+ *   own section of the struct directly via get()/WriteGuard.
+ * - read() is called once, synchronously, before any component's init() runs, so
+ *   components have their persisted state available immediately.
+ * - write() is only ever a no-op away from being called: it is gated on a dirty
+ *   flag that WriteGuard sets by comparing the struct before/after mutation, so
+ *   unchanged data is never rewritten (avoids flash wear and avoids bumping
+ *   Meta.WriteEpoch when nothing actually changed).
+ * - write() is triggered from WebApp 'OTA firmware upgrade' and 'Reboot' (via
+ *   RestartHelper), and once a day at 00:05 as a safety net against unexpected
+ *   power loss between those graceful triggers.
  *
- * How to use:
- *  - Derive your own class from the interface class InterfaceProviderRT.
- *  - Implement the serializeRT() and deserializeRT() methods to define how your subsystem's runtime data is stored and read.
- *  - Register the provider to the RuntimeProvider singleton instance in the setup() method of your subsystem
- *  - Use requestWriteOnNextLoop() and requestReadOnNextLoop() if you want to handle runtime data on demand.
- *
- * Note:
- * - The LittleFS filesystem must be initialized before using Runtime, otherwise the write and read operations will fail.
- *
- * 2025.09.11 - 1.0 - first version
+ * 2025.09.11 - 1.0 - first version (generic provider/JSON model)
  * 2025.12.01 - 1.1 - added read mode ON_DEMAND and START_UP
- * 2026.05.06 - 1.2 - added InterfaceProviderRT interface and provider registration and unregistration methods
- *                    improved read() method to read data of all or of specific providers
- *                    improved writeAll() method to keep data of providers that are currently not active or not registered
+ * 2026.05.06 - 1.2 - added InterfaceProviderRT interface and provider registration
+ * 2026.07.06 - 2.0 - replaced provider/JSON-map model with a compile-time struct
+ *                    (mirrors Configuration), dirty-gated writes, no eager startup read
  */
 
 #include <Utils.h>
 #include <LittleFS.h>
 #include <esp_log.h>
 #include <ArduinoJson.h>
-#include <algorithm>
 #include "RuntimeData.h"
 
 #undef TAG
 static const char* TAG = "runtime";
 
-static constexpr const char* RUNTIME_FILENAME = "/runtime.json";    // filename of the runtime data file
-static constexpr uint16_t RUNTIME_VERSION = 1;                      // version prepared for future migration support
+static constexpr const char* RUNTIME_FILENAME = "/runtime.json";
+static constexpr uint32_t RUNTIME_VERSION = 2;
+static constexpr uint16_t WRITE_FREEZE_MINUTES = 10; // do not write more often than this
 
-// runtime data keys
-static constexpr const char* INFO = "info";
+// JSON section/key names
+static constexpr const char* META = "meta";
 static constexpr const char* VERSION = "version";
-static constexpr const char* SAVE_COUNT = "save_count";
-static constexpr const char* SAVE_EPOCH = "save_epoch";
+static constexpr const char* WRITE_COUNT = "write_count";
+static constexpr const char* WRITE_EPOCH = "write_epoch";
+static constexpr const char* POWER_LIMITER = "power_limiter";
+static constexpr const char* FROM_START = "from_start";
+static constexpr const char* ONE_STOP_PER_NIGHT_DONE = "one_stop_per_night_done";
 
+RuntimeDataClass Runtime; // singleton instance
 
-RuntimeProvider Runtime; // singleton instance
+static RUNTIME_DATA_T runtimeData;
+static std::mutex sMutex;
 
-
-/*
- * Init the runtime data loop task
- */
-void RuntimeProvider::init(Scheduler& scheduler)
+void RuntimeDataClass::init(Scheduler& scheduler)
 {
     scheduler.addTask(_loopTask);
-    _loopTask.setCallback(std::bind(&RuntimeProvider::loop, this));
+    _loopTask.setCallback(std::bind(&RuntimeDataClass::loop, this));
     _loopTask.setIterations(TASK_FOREVER);
     _loopTask.setInterval(15 * 1000); // every 15 seconds
     _loopTask.enable();
+
+    memset(&runtimeData, 0x0, sizeof(runtimeData));
 }
 
-
-/*
- * The runtime data loop is called every 15 seconds and checks if a write or read operation is requested
- */
-void RuntimeProvider::loop(void)
+// daily safety-net write, in case a reboot/OTA never happens gracefully
+void RuntimeDataClass::loop(void)
 {
-    // check if we need to write the runtime data, either it is 00:05 or on request
-    bool dailyWriteTriggered = getWriteTrigger();
-    if (_writeNow.exchange(false) || dailyWriteTriggered) {
-        writeAll(0); // no freeze time.
+    if (getDailyWriteTrigger()) { write(); }
+}
+
+bool RuntimeDataClass::getDailyWriteTrigger(void)
+{
+    struct tm nowTime;
+    if (!getLocalTime(&nowTime, 1)) { return false; }
+
+    if ((nowTime.tm_hour == 0) && (nowTime.tm_min >= 5) && (nowTime.tm_min <= 10)) {
+        if (!_lastTrigger) {
+            _lastTrigger = true;
+            return true;
+        }
+    } else {
+        _lastTrigger = false;
+    }
+    return false;
+}
+
+bool RuntimeDataClass::read()
+{
+    std::lock_guard<std::mutex> lock(sMutex);
+
+    if (!LittleFS.exists(RUNTIME_FILENAME)) {
+        ESP_LOGI(TAG, "No runtime data file, using default values");
+        return false;
     }
 
-    // check if we need to read runtime data on request
-    if (_readNow.exchange(false)) {
-        read(false); // read on demand, not on startup
-    }
-}
-
-
-/*
- * Register a provider to be managed by the RuntimeProvider,
- * if readOnStartup is true, the data of this provider will be read on startup
- */
-void RuntimeProvider::registerProvider(InterfaceProviderRT* provider, bool readOnStartup) {
-
-    { // mutex is automatically released when lock goes out of this scope
-        std::lock_guard<std::mutex> lock(_mutexInterface);
-
-        provider->setReadOnStartupRT(readOnStartup);
-        _providers[provider->getIdRT()] = provider;
-    } // mutex is automatically released when lock goes out of this scope
-
-    ESP_LOGI(TAG, "Provider '%s' registered", provider->getIdRT().c_str());
-}
-
-
-/*
- * Unregister a provider, the provider will no longer be managed by the RuntimeProvider,
- * and its data will not be read or written anymore
- */
-void RuntimeProvider::unregisterProvider(const String& id) {
-
-    { // mutex is automatically released when lock goes out of this scope
-        std::lock_guard<std::mutex> lock(_mutexInterface);
-
-        _providers.erase(id);
-    } // mutex is automatically released when lock goes out of this scope
-
-    ESP_LOGI(TAG, "Provider '%s' unregistered", id.c_str());
-}
-
-void RuntimeProvider::unregisterProvider(InterfaceProviderRT* provider) {
-
-    { // mutex is automatically released when lock goes out of this scope
-        std::lock_guard<std::mutex> lock(_mutexInterface);
-
-        _providers.erase(provider->getIdRT());
-    } // mutex is automatically released when lock goes out of this scope
-
-    ESP_LOGI(TAG, "Provider '%s' unregistered", provider->getIdRT().c_str());
-}
-
-
-/*
- * Write the runtime data from all registered providers into LittleFS file
- * freezeMinutes: Minimum necessary time [minutes] between now and last write operation
- */
-bool RuntimeProvider::writeAll(uint16_t const freezeMinutes)
-{
-    auto cleanExit = [this](const bool writeOk, const char* text) -> bool {
-        if (writeOk) {
-            ESP_LOGI(TAG,"%s", text);
-        } else {
-            ESP_LOGE(TAG,"%s", text);
-        }
-        _writeOK.store(writeOk);
-        return writeOk;
-    };
-
-    // we need a valid epoch time before we can write the runtime data
-    time_t nextEpoch;
-    if (!Utils::getEpoch(&nextEpoch, 1)) { return cleanExit(false, "Local time not available, skipping write"); }
-
-    { // mutex is automatically released when lock goes out of this scope
-        std::lock_guard<std::mutex> lock(_mutexInterface);
-
-        // fast exit if no providers are registered, no need to write an empty file
-        if (_providers.empty()) {
-            return cleanExit(true, "No providers registered, skipping write");
-        }
-    } // mutex is automatically released when lock goes out of this scope
-
-    { // mutex is automatically released when lock goes out of this scope
-        std::lock_guard<std::mutex> lock(_mutexData);
-
-        if (!LittleFS.exists(RUNTIME_FILENAME)) { _writeEpoch = 0; }
-
-        // check minimum interval between writes (enforced only when freezeMinutes > 0)
-        if ((freezeMinutes > 0) && (_writeEpoch != 0) && (difftime(nextEpoch, _writeEpoch) < 60 * freezeMinutes)) {
-            return cleanExit(false, "Time interval too short, skipping write");
-        }
-    } // mutex is automatically released when lock goes out of this scope
-
-    // prepare the JSON document and store the runtime data is done outside the
-    // mutex protection to minimize the time the mutex is locked.
-    JsonDocument doc;
-
-    // read the existing runtime data to keep the data of providers that are currently not active or
-    // not registered anymore, otherwise we would lose this data on write
     File fRuntime = LittleFS.open(RUNTIME_FILENAME, "r", false);
-    if (fRuntime) {
-        Utils::skipBom(fRuntime);
-        DeserializationError error = deserializeJson(doc, fRuntime);
-        fRuntime.close();
-        if (error || !Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
-            ESP_LOGW(TAG, "Read data error, rewriting runtime file from current provider state");
-            doc.clear();
-        }
+    if (!fRuntime) {
+        ESP_LOGE(TAG, "Failed to open runtime data file");
+        return false;
     }
 
-    JsonObject info = doc[INFO].as<JsonObject>();
-    uint16_t nextCount = info[SAVE_COUNT] | 0U;
-    nextCount++; // increase the count for the next write operation
+    JsonDocument doc;
+    Utils::skipBom(fRuntime);
+    DeserializationError error = deserializeJson(doc, fRuntime);
+    fRuntime.close();
+    if (error || !Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
+        ESP_LOGE(TAG, "Failed to parse runtime data file");
+        return false;
+    }
 
-    info = doc[INFO].to<JsonObject>();
-    info[VERSION] = RUNTIME_VERSION;
-    info[SAVE_COUNT] = nextCount;
-    info[SAVE_EPOCH] = nextEpoch;
+    JsonObject meta = doc[META];
+    runtimeData.Meta.Version = meta[VERSION] | 0U;
+    runtimeData.Meta.WriteCount = meta[WRITE_COUNT] | 0U;
+    runtimeData.Meta.WriteEpoch = meta[WRITE_EPOCH].as<time_t>();
 
-    { // mutex is automatically released when lock goes out of this scope
-        std::lock_guard<std::mutex> lock(_mutexInterface);
+    JsonObject powerLimiter = doc[POWER_LIMITER];
+    runtimeData.PowerLimiter.FromStart = powerLimiter[FROM_START] | false;
+    runtimeData.PowerLimiter.OneStopPerNightDone = powerLimiter[ONE_STOP_PER_NIGHT_DONE] | false;
 
-        // serialize the runtime data of all registered providers
-        for (auto& [id, provider] : _providers) {
-            provider->serializeRT(doc[id].to<JsonObject>());
-        }
-    } // mutex is automatically released when lock goes out of this scope
+    ESP_LOGI(TAG, "Read from file");
+    return true;
+}
+
+bool RuntimeDataClass::write()
+{
+    std::lock_guard<std::mutex> lock(sMutex);
+
+    if (!_dirty) {
+        ESP_LOGD(TAG, "No changes, skipping write");
+        return true;
+    }
+
+    time_t nextEpoch;
+    if (!Utils::getEpoch(&nextEpoch, 1)) {
+        ESP_LOGW(TAG, "Local time not available, skipping write");
+        return false;
+    }
+
+    if ((runtimeData.Meta.WriteEpoch != 0) &&
+            (difftime(nextEpoch, runtimeData.Meta.WriteEpoch) < 60 * WRITE_FREEZE_MINUTES)) {
+        ESP_LOGD(TAG, "Time interval too short, skipping write");
+        return false;
+    }
+
+    runtimeData.Meta.Version = RUNTIME_VERSION;
+    runtimeData.Meta.WriteEpoch = nextEpoch;
+    runtimeData.Meta.WriteCount++;
+
+    JsonDocument doc;
+    JsonObject meta = doc[META].to<JsonObject>();
+    meta[VERSION] = runtimeData.Meta.Version;
+    meta[WRITE_COUNT] = runtimeData.Meta.WriteCount;
+    meta[WRITE_EPOCH] = runtimeData.Meta.WriteEpoch;
+
+    JsonObject powerLimiter = doc[POWER_LIMITER].to<JsonObject>();
+    powerLimiter[FROM_START] = runtimeData.PowerLimiter.FromStart;
+    powerLimiter[ONE_STOP_PER_NIGHT_DONE] = runtimeData.PowerLimiter.OneStopPerNightDone;
 
     if (!Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
-        return cleanExit(false, "JSON alloc fault, skipping write");
+        ESP_LOGE(TAG, "JSON alloc fault, skipping write");
+        return false;
     }
 
-    fRuntime = LittleFS.open(RUNTIME_FILENAME, "w");
-    if (!fRuntime) { return cleanExit(false, "Failed to open file for writing"); }
+    File fRuntime = LittleFS.open(RUNTIME_FILENAME, "w");
+    if (!fRuntime) {
+        ESP_LOGE(TAG, "Failed to open file for writing");
+        return false;
+    }
 
     if (serializeJson(doc, fRuntime) == 0) {
         fRuntime.close();
-        return cleanExit(false, "Failed to serialize to file");
+        ESP_LOGE(TAG, "Failed to serialize to file");
+        return false;
     }
     fRuntime.close();
 
-    { // mutex is automatically released when lock goes out of this scope
-        std::lock_guard<std::mutex> lock(_mutexData);
-
-        // commit the new state only after a successful write
-        _fileVersion = RUNTIME_VERSION;
-        _writeEpoch = nextEpoch;
-        _writeCount = nextCount;
-    } // mutex is automatically released when lock goes out of this scope
-
-    return cleanExit(true, "Write to file");
+    _dirty = false;
+    ESP_LOGI(TAG, "Write to file");
+    return true;
 }
 
-
-/*
- * Read the runtime data from LittleFS file
- * readOnStartup = true: read data from providers that are marked to be read on startup
- * readOnStartup = false: read data from providers that are requested to be read on demand
- */
-bool RuntimeProvider::read(bool const readOnStartup)
+RUNTIME_DATA_T const& RuntimeDataClass::get()
 {
-    auto cleanExit = [this](const bool readOk, const char* text) -> bool {
-        if (readOk) {
-            ESP_LOGI(TAG,"%s", text);
-        } else {
-            ESP_LOGE(TAG,"%s", text);
-        }
-        _readOK.store(readOk);
-        return readOk;
-    };
-
-    JsonDocument doc;
-
-    // Note: We do not exit on read or allocation errors.
-    // Every provider can decide by itself whether to use default configuration values in that case
-    bool readOk = LittleFS.exists(RUNTIME_FILENAME);
-    File fRuntime = LittleFS.open(RUNTIME_FILENAME, "r", false);
-    if (fRuntime) {
-        Utils::skipBom(fRuntime);
-        DeserializationError error = deserializeJson(doc, fRuntime);
-        fRuntime.close();
-        if (error || !Utils::checkJsonAlloc(doc, __FUNCTION__, __LINE__)) {
-            readOk = false;
-        }
-    }
-
-    JsonObject info = doc[INFO].as<JsonObject>();
-
-    { // mutex is automatically released when lock goes out of this scope
-        std::lock_guard<std::mutex> lock(_mutexData);
-
-        // 0 means no file available and runtime data is not valid
-        _fileVersion = info[VERSION] | 0U;
-        _writeCount = info[SAVE_COUNT] | 0U;
-        _writeEpoch = info[SAVE_EPOCH].as<time_t>();
-        if (_writeEpoch == 0) { readOk = false; } // no valid data available
-    } // mutex is automatically released when lock goes out of this scope
-
-    { // mutex is automatically released when lock goes out of this scope
-        std::lock_guard<std::mutex> lock(_mutexInterface);
-
-        for (auto& [id, provider] : _providers) {
-            if (readOnStartup) {
-                if (!provider->getReadOnStartupRT()) { continue; } // skip providers that are not read on startup
-            } else {
-                auto providerIt = std::find(_readIDList.begin(), _readIDList.end(), id);
-                if (providerIt == _readIDList.end()) { continue; } // skip providers that are not requested to be read on demand
-            }
-
-            // JsonObject can be empty, but as mentioned before, we do not exit on read or allocation errors,
-            // so the provider can decide by itself whether to use default configuration values in that case
-            provider->deserializeRT(doc[id].as<JsonObject>());
-        }
-
-        // Clear the on-demand read list after processing
-        if (!readOnStartup) { _readIDList.clear(); }
-
-    } // mutex is automatically released when lock goes out of this scope
-
-    if (!readOk) {
-        return cleanExit(false, "File not found or error, using default values");
-    }
-
-    return cleanExit(true, "Read from file");
+    return runtimeData;
 }
 
-
-/*
- * Get the write counter
- */
-uint16_t RuntimeProvider::getWriteCount(void) const
-{
-    std::lock_guard<std::mutex> lock(_mutexData);
-    return _writeCount;
-}
-
-
-/*
- * Get the write epoch time
- */
-time_t RuntimeProvider::getWriteEpochTime(void) const
-{
-    std::lock_guard<std::mutex> lock(_mutexData);
-    return _writeEpoch;
-}
-
-
-/*
- * Get the write count and time as string
- * Format: "<count> / <dd>-<mon> <hh>:<mm>"
- * If epoch time and local time is not available the time is replaced by "no time"
- */
-String RuntimeProvider::getWriteCountAndTimeString(void) const
+String RuntimeDataClass::getWriteCountAndTimeString() const
 {
     time_t epoch;
     uint16_t count;
 
     { // mutex is automatically released when lock goes out of this scope
-        std::lock_guard<std::mutex> lock(_mutexData);
-        epoch = _writeEpoch;
-        count = _writeCount;
+        std::lock_guard<std::mutex> lock(sMutex);
+        epoch = runtimeData.Meta.WriteEpoch;
+        count = runtimeData.Meta.WriteCount;
     } // mutex is automatically released when lock goes out of this scope
 
     char buf[32] = "";
@@ -345,44 +207,28 @@ String RuntimeProvider::getWriteCountAndTimeString(void) const
     } else {
         snprintf(buf, sizeof(buf), " / no time");
     }
-    String ctString = String(count) + String(buf);
-    return ctString;
+    return String(count) + String(buf);
 }
 
-
-/*
- * Get the daily write trigger
- * Returns true once a day between 00:05 - 00:10
- */
-bool RuntimeProvider::getWriteTrigger(void) {
-
-    struct tm nowTime;
-    if (!getLocalTime(&nowTime, 1)) {
-        return false;
-    }
-
-    std::lock_guard<std::mutex> lock(_mutexData);
-    if ((nowTime.tm_hour == 0) && (nowTime.tm_min >= 5) && (nowTime.tm_min <= 10)) {
-        if (_lastTrigger == false) {
-            _lastTrigger = true;
-            return true;
-        }
-    } else {
-        _lastTrigger = false;
-    }
-    return false;
+RuntimeDataClass::WriteGuard RuntimeDataClass::getWriteGuard()
+{
+    return WriteGuard();
 }
 
+RuntimeDataClass::WriteGuard::WriteGuard()
+    : _lock(sMutex)
+    , _before(runtimeData)
+{
+}
 
-/*
- * Add an provider ID to the read list
- */
-void RuntimeProvider::requestReadOnNextLoop(String const& addID) {
+RUNTIME_DATA_T& RuntimeDataClass::WriteGuard::getRuntimeData()
+{
+    return runtimeData;
+}
 
-    std::lock_guard<std::mutex> lock(_mutexInterface);
-
-    // if the ID is not already on the list, add it
-    auto id = std::find(_readIDList.begin(), _readIDList.end(), addID);
-    if (id == _readIDList.end()) { _readIDList.push_back(addID); }
-    _readNow.store(true);
+RuntimeDataClass::WriteGuard::~WriteGuard()
+{
+    if (memcmp(&_before, &runtimeData, sizeof(RUNTIME_DATA_T)) != 0) {
+        Runtime._dirty = true;
+    }
 }

--- a/src/WebApi_firmware.cpp
+++ b/src/WebApi_firmware.cpp
@@ -10,7 +10,6 @@
 #include <AsyncJson.h>
 #include <Update.h>
 #include "esp_partition.h"
-#include "RuntimeData.h"
 
 void WebApiFirmwareClass::init(AsyncWebServer& server, Scheduler& scheduler)
 {
@@ -49,8 +48,6 @@ void WebApiFirmwareClass::onFirmwareUpdateFinish(AsyncWebServerRequest* request)
     response->addHeader(asyncsrv::T_CORS_ACAO, "*");
     request->send(response);
 
-    // write the runtime data to LittleFS, but do not write if last write operation was less than 10 min ago
-    RuntimeData.write(10);
     RestartHelper.triggerRestart();
 }
 

--- a/src/WebApi_maintenance.cpp
+++ b/src/WebApi_maintenance.cpp
@@ -8,7 +8,6 @@
 #include "WebApi.h"
 #include "WebApi_errors.h"
 #include <AsyncJson.h>
-#include "RuntimeData.h"
 
 void WebApiMaintenanceClass::init(AsyncWebServer& server, Scheduler& scheduler)
 {
@@ -45,8 +44,6 @@ void WebApiMaintenanceClass::onRebootPost(AsyncWebServerRequest* request)
 
         WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
 
-        // write the runtime data to LittleFS, but do not write if last write operation was less than 10 min ago
-        RuntimeData.write(10);
         RestartHelper.triggerRestart();
     } else {
         retMsg["message"] = "Reboot cancled!";

--- a/src/WebApi_sysstatus.cpp
+++ b/src/WebApi_sysstatus.cpp
@@ -84,7 +84,7 @@ void WebApiSysstatusClass::onSystemStatus(AsyncWebServerRequest* request)
     root["resetreason_1"] = reason;
 
     root["cfgsavecount"] = Configuration.get().Cfg.SaveCount;
-    root["runtime_savecount"] = RuntimeData.getWriteCountAndTimeString();
+    root["runtime_savecount"] = Runtime.getWriteCountAndTimeString();
 
     char version[16];
     snprintf(version, sizeof(version), "%d.%d.%d", CONFIG_VERSION >> 24 & 0xff, CONFIG_VERSION >> 16 & 0xff, CONFIG_VERSION >> 8 & 0xff);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,6 +88,12 @@ void setup()
         Configuration.migrateOnBattery();
     }
 
+    // Read runtime data. Must happen before any component's init() runs, so
+    // components can read their persisted state immediately at init() time.
+    ESP_LOGI(TAG, "Reading runtime data...");
+    Runtime.init(scheduler);
+    Runtime.read();
+
     // Set configured log levels
     Logging.applyLogLevels();
     esp_log_level_set(TAG, ESP_LOG_VERBOSE);
@@ -147,14 +153,11 @@ void setup()
     RestartHelper.init(scheduler);
 
     // OpenDTU-OnBattery-specific initializations go between here...
-    Runtime.init(scheduler); // Runtime must be initialized before the components below can register providers to it
     SolarCharger.init(scheduler);
     PowerMeter.init(scheduler);
     PowerLimiter.init(scheduler);
     GridCharger.init(scheduler);
     Battery.init(scheduler);
-
-    Runtime.read(); // Read runtime values from all components that are registered to read on startup
 
     ESP_LOGI(TAG, "Startup complete");
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,16 +147,14 @@ void setup()
     RestartHelper.init(scheduler);
 
     // OpenDTU-OnBattery-specific initializations go between here...
+    Runtime.init(scheduler); // Runtime must be initialized before the components below can register providers to it
     SolarCharger.init(scheduler);
     PowerMeter.init(scheduler);
     PowerLimiter.init(scheduler);
     GridCharger.init(scheduler);
     Battery.init(scheduler);
-    // ... and here (before RuntimeData)
 
-    // Must be done after all other components have been initialized
-    RuntimeData.init(scheduler);
-    RuntimeData.read();
+    Runtime.read(); // Read runtime values from all components that are registered to read on startup
 
     ESP_LOGI(TAG, "Startup complete");
 }


### PR DESCRIPTION
Saves the DPL-Battery-State into the runtime file to preserve the status after a firmware update or restart.
Including additional safety feature. We only adopt the battery status from the runtime file if it is no more than 1 hour old.
Please note: Only updates or restarts triggered via the web user interface can be processed correctly.

**Performing a quick test**
If the inverter is active and the voltage/SoC is between start and stop threshold:
- Perform a restart via the web user interface.

If the inverter is active and the voltage/SoC is above the start threshold:
- Set the upper battery threshold to a value above the current voltage/SoC.
- Perform a restart via the web user interface.

**Result:** The battery maintains its current state, and the inverter must be active again after the restart.

<br>

@AndreasBoehm 
I've implemented the following changes to the Runtime class:

- New interface as suggested by "claude". See PR #2262 
- The runtime source code never changes when you add a subsystem
- Each subsystem owns its own data
- There are two ways to determine when data is read from the file:
- At startup (The normal, simple way, perfect for single tone instances)
- On request (More complex, needed for dynamically instances)
- Better central place to call Runtime.writeAll() on restart or update;
- Old runtime data is not automatically deleted when writing. For example, the measured battery internal resistance is retained even if the Battery Guard is temporarily deactivated.

