### PR TITLE
the old version ignored unconfigured rxen and txen pins and just assu…

### DIFF
--- a/src/powermeter/sdm/serial/Provider.cpp
+++ b/src/powermeter/sdm/serial/Provider.cpp
@@ -44,7 +44,7 @@ bool Provider::init()
 
     _upSdmSerial = std::make_unique<SoftwareSerial>();
 
-    if (pin.powermeter_rxen > GPIO_NUM_NC && pin.powermeter_txen > GPIO_NUM_NC) {
+    if (pin.powermeter_rxen <= GPIO_NUM_NC && pin.powermeter_txen <= GPIO_NUM_NC) {
         _upSdm = std::make_unique<SDM>(*_upSdmSerial, 9600, pin.powermeter_rxen, pin.powermeter_txen,
             SWSERIAL_8N1, pin.powermeter_rx, pin.powermeter_tx);
     }


### PR DESCRIPTION
fix for https://github.com/hoylabs/OpenDTU-OnBattery/discussions/2617

the old version ignored unconfigured rxen and txen pins and just assumed they were legit.
This stopped RS485 without RXEN and TXEN Pins unusable