### PR TITLE
fix: fix silent argument shift in SDM PowerMeter serial constructor

### DIFF
--- a/src/powermeter/sdm/serial/Provider.cpp
+++ b/src/powermeter/sdm/serial/Provider.cpp
@@ -44,13 +44,22 @@ bool Provider::init()
 
     _upSdmSerial = std::make_unique<SoftwareSerial>();
 
+    // NOTE: the pin arguments must match the SDM constructors' parameter types
+    // (int for the dere/re pins, int8_t for rx/tx). since switching the pin
+    // config to gpio_num_t, passing the enum values directly changes overload
+    // resolution: gpio_num_t promotes to int, which lets the 6-argument call
+    // below bind to the 7-parameter (rxen/txen) constructor instead of the
+    // intended 6-parameter (dere) one, silently shifting every argument by one.
+    // cast explicitly to restore the exact-match overload selection.
     if (pin.powermeter_rxen > GPIO_NUM_NC && pin.powermeter_txen > GPIO_NUM_NC) {
-        _upSdm = std::make_unique<SDM>(*_upSdmSerial, 9600, pin.powermeter_rxen, pin.powermeter_txen,
-            SWSERIAL_8N1, pin.powermeter_rx, pin.powermeter_tx);
+        _upSdm = std::make_unique<SDM>(*_upSdmSerial, 9600,
+            static_cast<int>(pin.powermeter_rxen), static_cast<int>(pin.powermeter_txen),
+            SWSERIAL_8N1, static_cast<int8_t>(pin.powermeter_rx), static_cast<int8_t>(pin.powermeter_tx));
     }
     else {
-        _upSdm = std::make_unique<SDM>(*_upSdmSerial, 9600, pin.powermeter_dere,
-            SWSERIAL_8N1, pin.powermeter_rx, pin.powermeter_tx);
+        _upSdm = std::make_unique<SDM>(*_upSdmSerial, 9600,
+            static_cast<int>(pin.powermeter_dere),
+            SWSERIAL_8N1, static_cast<int8_t>(pin.powermeter_rx), static_cast<int8_t>(pin.powermeter_tx));
     }
 
     _upSdm->begin();


### PR DESCRIPTION
## Problem

  A previous commit changed power meter pin config fields from `int8_t` to
  `gpio_num_t`. This broke SDM serial initialization in a non-obvious way:

  `gpio_num_t` promotes to `int`, which changed overload resolution on the SDM
  constructor calls. The 6-argument call that was meant to bind the
  6-parameter (dere) overload instead matched the 7-parameter (rxen/txen)
  overload — silently shifting every subsequent argument one position to the
  right. Result: wrong pins assigned for rx/tx/dere on SDM serial meters.

  ## Fix

  Add explicit `static_cast<int>` / `static_cast<int8_t>` on pin arguments to
  restore exact-match overload selection, independent of the field's underlying
  type.

  ## Impact

  Users with SDM power meters connected via serial (RS485) would have seen
  incorrect pin behaviour — meter not responding or hardware misconfigured —
  since the `gpio_num_t` type change landed.