### PR TITLE
fix: MQTT / WriteGuard issue

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -18,6 +18,7 @@ CONFIG_T config;
 static std::condition_variable sWriterCv;
 static std::mutex sWriterMutex;
 static unsigned sWriterCount = 0;
+static bool sWriterActive = false;
 
 void ConfigurationClass::init(Scheduler& scheduler)
 {
@@ -1327,8 +1328,14 @@ void ConfigurationClass::loop()
         return;
     }
 
+    // close the write guard for new writers, inform all existing writers and wait for them to finish
+    sWriterActive = true;
     sWriterCv.notify_all();
     sWriterCv.wait(lock, [] { return sWriterCount == 0; });
+
+    // open the write guard for new writers and inform all waiting writers that they can continue
+    sWriterActive = false;
+    sWriterCv.notify_all();
 }
 
 CONFIG_T& ConfigurationClass::WriteGuard::getConfig()
@@ -1339,8 +1346,14 @@ CONFIG_T& ConfigurationClass::WriteGuard::getConfig()
 ConfigurationClass::WriteGuard::WriteGuard()
     : _lock(sWriterMutex)
 {
+    // if writers are currently processed, we must wait for them to finish before we can add ourselves to the writer count
+    if (sWriterActive) {
+        sWriterCv.wait(_lock, [] { return !sWriterActive; });
+    }
+
+    // add ourselves to the writer count and wait to be processed
     sWriterCount++;
-    sWriterCv.wait(_lock);
+    sWriterCv.wait(_lock, [] { return sWriterActive; });
 }
 
 ConfigurationClass::WriteGuard::~WriteGuard()


### PR DESCRIPTION
This fix will (maybe) solve one major bug of the MQTT Command issues. 
See #2560, #2250, #1629, #1494 

The fix use conditions on wait() to avoid:
- spurious wakeups
- missed wakeups
- a potential deadlock
- data races

**How do we run into a deadlock?**
Check the communication between the WriteGuard() Constructor/Destructor and the ConfigurationClass::loop().

<img width="400" height="400" alt="grafik" src="https://github.com/user-attachments/assets/c5d3bda0-40f4-493e-89ea-d180e1113a3f" />

(1) Configuration loop will wait until counter == 0;
(2) The second command arrives during write() and can not continue because the mutex is hold by the first command
(3) Notifying the loop, but the loop can not continue because the mutex is still hold by the first command
(4) Now the first command release the mutex

Who will get the mutex next? The second command or the loop?
In case of the second command:

- the counter will be set to 1
- the loop will wait for counter == 0. Will never happen. Wait for ever. --> deadlock
- the second command will wait for notification. Will never happen. Wait for ever. --> deadlock

This would also explain why we have to wait some seconds before we can send the next MQTT command. Because we just run into a Problem if a new command arrives during the old command is processed.<br>
Be aware, the WriteGuard is also called from the WebClient! 

The new pattern works like a "ship lock"  😜

- New ships can enter as long as the upper door is open and the lower door is closed
- New ships can't enter as long as ships in the "ships lock" leave the "ships lock"  through the lower door
- After the "ships lock" is empty and the lower door is closed waiting ships will be informed to enter

I know the fix must be placed in the upstream project, but maybe someone can first verify the changes on a running system with fast MQTT commands? I do not use MQTT.